### PR TITLE
t005: Expose obstacle positions/radii from Terrain for CollisionSystem

### DIFF
--- a/src/entities/Terrain.js
+++ b/src/entities/Terrain.js
@@ -1,9 +1,21 @@
 import * as THREE from 'three';
 
+/**
+ * Obstacle record for CollisionSystem queries.
+ * @typedef {Object} ObstacleRecord
+ * @property {number} x - World X position.
+ * @property {number} z - World Z position.
+ * @property {number} radius - Approximate collision radius (metres).
+ * @property {'rock'|'tree'} type - Obstacle category.
+ */
+
 export class Terrain {
   constructor() {
     this.size = 200;
     this.segments = 80;
+
+    /** @type {ObstacleRecord[]} */
+    this.obstacles = [];
 
     const geo = new THREE.PlaneGeometry(
       this.size,
@@ -74,6 +86,8 @@ export class Terrain {
       rock.castShadow = true;
       rock.receiveShadow = true;
       this.mesh.add(rock);
+      // DodecahedronGeometry has unit radius; XZ scale == collision radius
+      this.obstacles.push({ x, z, radius: scale, type: 'rock' });
     }
 
     // Simple trees (cylinder trunk + cone canopy)
@@ -105,6 +119,17 @@ export class Terrain {
 
       tree.position.set(x, this._heightFn(x, z), z);
       this.mesh.add(tree);
+      // Canopy ConeGeometry base radius is 1.5; use that as the collision footprint
+      this.obstacles.push({ x, z, radius: 1.5, type: 'tree' });
     }
+  }
+
+  /**
+   * Return all obstacle records for CollisionSystem queries.
+   * Each record has {x, z, radius, type}.
+   * @returns {ObstacleRecord[]}
+   */
+  getObstacles() {
+    return this.obstacles;
   }
 }


### PR DESCRIPTION
## Summary

- Added `this.obstacles` array (`ObstacleRecord[]`) populated by `_addProps()` as rocks and trees are placed
- Rocks: `radius = scale` (DodecahedronGeometry has unit radius; XZ scale equals the collision sphere radius)
- Trees: `radius = 1.5` (matches the ConeGeometry base radius of the canopy)
- Added `getObstacles()` public method returning the full obstacle list for CollisionSystem queries
- Added JSDoc `@typedef ObstacleRecord` `{x, z, radius, type: 'rock'|'tree'}` at file top

## Verification

- `npm run build` passes cleanly (vite v6.4.2, ✓ 15 modules transformed)
- `terrain.getObstacles()` returns up to ~70 records (40 rocks + up to 30 trees, minus any skipped near spawn)
- CollisionSystem (t001) and tree-destruction system (t002) can call `terrain.getObstacles()` without traversing the Three.js scene graph

## Unblocks

- t001 (CollisionSystem tank-vs-obstacle blocking) — needs obstacle list from Terrain
- t002 (destructible trees) — depends on t005

Resolves #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terrain now records and tracks collision obstacles for all decorative objects during level generation. Rocks are recorded with dynamic collision radii based on their scale, while trees use fixed footprint measurements. Obstacle data is now available to collision detection and environmental interaction systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->