### PR TITLE
t003: add pool-based ParticleSystem for explosions, muzzle flash, dust trails

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -5,6 +5,7 @@ import { InputSystem } from '../systems/InputSystem.js';
 import { ProjectileSystem } from '../systems/ProjectileSystem.js';
 import { EnemySystem } from '../systems/EnemySystem.js';
 import { CollisionSystem } from '../systems/CollisionSystem.js';
+import { ParticleSystem } from '../systems/ParticleSystem.js';
 import { HUD } from '../ui/HUD.js';
 import { CameraController } from '../systems/CameraController.js';
 
@@ -75,9 +76,21 @@ export class Game {
     this.cameraController = new CameraController(this.camera, this.player);
     this.projectiles = new ProjectileSystem(this.scene);
     this.enemies = new EnemySystem(this.scene, this.player);
+    this.particles = new ParticleSystem(this.scene);
 
-    // Route enemy fire into the shared projectile pool
-    this.enemies.onFire(p => this.projectiles.add(p));
+    // Dust-emission timers (seconds until next dust puff)
+    this._playerDustTimer = 0;
+    this._enemyDustTimer = 0;
+
+    // Route enemy fire into the shared projectile pool + muzzle flash
+    this.enemies.onFire((projectile) => {
+      this.projectiles.add(projectile);
+      const flashDir = projectile.velocity.clone().normalize();
+      this.particles.emitMuzzleFlash(
+        projectile.mesh.position.clone(),
+        flashDir
+      );
+    });
 
     this.collision = new CollisionSystem({
       terrain: this.terrain,
@@ -87,7 +100,13 @@ export class Game {
     });
     this.collision
       .onScoreAdd(pts => { this.score += pts; })
-      .onPlayerDeath(() => this._gameOver());
+      .onPlayerDeath(() => this._gameOver())
+      .onHit((pos) => {
+        this.particles.emitExplosion(pos, { count: 15, speed: 6, lifetime: 0.6 });
+      })
+      .onKill((pos) => {
+        this.particles.emitExplosion(pos, { count: 35, speed: 10 });
+      });
 
     this.hud = new HUD();
   }
@@ -110,10 +129,20 @@ export class Game {
     // Update systems
     this.projectiles.update(dt);
     this.enemies.update(dt);
+    this.particles.update(dt);
     this.cameraController.update(dt);
 
     // Collision detection (projectiles + tank-vs-obstacle blocking)
     this.collision.update();
+
+    // Dust trails for active enemies (timer-gated)
+    this._enemyDustTimer -= dt;
+    if (this._enemyDustTimer <= 0) {
+      this._enemyDustTimer = 0.15;
+      for (const enemy of this.enemies.active) {
+        this.particles.emitDust(enemy.mesh.position);
+      }
+    }
 
     // HUD
     this.hud.update({
@@ -155,6 +184,12 @@ export class Game {
       const projectile = this.player.fire();
       if (projectile) {
         this.projectiles.add(projectile);
+        // Muzzle flash at projectile spawn point
+        const flashDir = projectile.velocity.clone().normalize();
+        this.particles.emitMuzzleFlash(
+          projectile.mesh.position.clone(),
+          flashDir
+        );
       }
     }
 
@@ -166,6 +201,13 @@ export class Game {
     const bound = 90;
     pos.x = THREE.MathUtils.clamp(pos.x, -bound, bound);
     pos.z = THREE.MathUtils.clamp(pos.z, -bound, bound);
+
+    // Dust trail while moving (timer-gated)
+    this._playerDustTimer -= dt;
+    if (this._playerDustTimer <= 0 && (input.forward || input.backward)) {
+      this._playerDustTimer = 0.15;
+      this.particles.emitDust(this.player.mesh.position);
+    }
   }
 
   _gameOver() {
@@ -180,6 +222,9 @@ export class Game {
     this.player.mesh.rotation.set(0, 0, 0);
     this.enemies.reset();
     this.projectiles.reset();
+    this.particles.reset();
+    this._playerDustTimer = 0;
+    this._enemyDustTimer = 0;
     this.hud.hideGameOver();
     this.start();
   }

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -7,8 +7,11 @@
  *     in Terrain.obstacles so they cannot pass through scenery.
  *
  * Callbacks (set before first update):
- *  onScoreAdd(points)  — called when an enemy tank is destroyed
- *  onPlayerDeath()     — called when the player tank reaches 0 HP
+ *  onScoreAdd(points)      — called when an enemy tank is destroyed
+ *  onPlayerDeath()         — called when the player tank reaches 0 HP
+ *  onHit(position, owner)  — called on every non-lethal shell impact
+ *  onKill(position, owner) — called when a shell destroys a tank
+ *    owner: 'player' (player shell hit enemy) | 'enemy' (enemy shell hit player)
  */
 export class CollisionSystem {
   /**
@@ -26,6 +29,8 @@ export class CollisionSystem {
 
     this._onScoreAdd = null;
     this._onPlayerDeath = null;
+    this._onHit = null;
+    this._onKill = null;
 
     /**
      * Approximate half-width of a tank hull for obstacle push-back.
@@ -44,6 +49,22 @@ export class CollisionSystem {
   /** @param {() => void} cb */
   onPlayerDeath(cb) {
     this._onPlayerDeath = cb;
+    return this;
+  }
+
+  /**
+   * @param {(position: import('three').Vector3, owner: 'player'|'enemy') => void} cb
+   */
+  onHit(cb) {
+    this._onHit = cb;
+    return this;
+  }
+
+  /**
+   * @param {(position: import('three').Vector3, owner: 'player'|'enemy') => void} cb
+   */
+  onKill(cb) {
+    this._onKill = cb;
     return this;
   }
 
@@ -70,13 +91,15 @@ export class CollisionSystem {
         const e = enemies[j];
         const dist = p.mesh.position.distanceTo(e.mesh.position);
         if (dist < 2.5) {
+          const hitPos = p.mesh.position.clone();
           e.takeDamage(p.damage);
           this.projectiles.remove(i);
           if (e.health <= 0) {
+            if (this._onKill) this._onKill(hitPos, 'player');
             this.enemies.remove(j);
-            if (this._onScoreAdd) {
-              this._onScoreAdd(100);
-            }
+            if (this._onScoreAdd) this._onScoreAdd(100);
+          } else {
+            if (this._onHit) this._onHit(hitPos, 'player');
           }
           break; // projectile consumed; skip remaining enemies
         }
@@ -90,10 +113,13 @@ export class CollisionSystem {
 
       const dist = p.mesh.position.distanceTo(player.mesh.position);
       if (dist < 2.5) {
+        const hitPos = p.mesh.position.clone();
         player.takeDamage(p.damage);
         this.projectiles.remove(i);
-        if (player.health <= 0 && this._onPlayerDeath) {
-          this._onPlayerDeath();
+        if (this._onHit) this._onHit(hitPos, 'enemy');
+        if (player.health <= 0) {
+          if (this._onKill) this._onKill(hitPos, 'enemy');
+          if (this._onPlayerDeath) this._onPlayerDeath();
         }
       }
     }

--- a/src/systems/ParticleSystem.js
+++ b/src/systems/ParticleSystem.js
@@ -1,0 +1,304 @@
+/**
+ * ParticleSystem — pool-based particle emitter for Three.js.
+ *
+ * All particles share a single BoxGeometry. Each particle owns its own
+ * MeshBasicMaterial so color and opacity can vary per particle without
+ * lighting overhead. The pool avoids allocations at runtime: particles
+ * are acquired from a free-list and returned on death.
+ *
+ * Supported effects:
+ *   emitExplosion(position, opts)   — burst of fire/smoke on tank/shell impact
+ *   emitMuzzleFlash(position, dir)  — brief flash cone at barrel tip on fire
+ *   emitDust(position)              — rising dirt puff behind moving tracks
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const POOL_SIZE = 300;
+
+// Shared geometry — all particles are scaled cubes.
+const _GEO = new THREE.BoxGeometry(0.25, 0.25, 0.25);
+
+// ---------------------------------------------------------------------------
+// ParticleSystem
+// ---------------------------------------------------------------------------
+
+export class ParticleSystem {
+  /**
+   * @param {THREE.Scene} scene
+   */
+  constructor(scene) {
+    this.scene = scene;
+
+    /** @type {Array<ParticleData>} complete pool */
+    this._pool = [];
+    /** @type {number[]} indices of free (inactive) particles */
+    this._free = [];
+    /** @type {number[]} indices of active (alive) particles */
+    this._active = [];
+
+    this._buildPool();
+  }
+
+  // -------------------------------------------------------------------------
+  // Pool management
+  // -------------------------------------------------------------------------
+
+  _buildPool() {
+    for (let i = 0; i < POOL_SIZE; i++) {
+      const mat = new THREE.MeshBasicMaterial({
+        transparent: true,
+        depthWrite: false,
+      });
+      const mesh = new THREE.Mesh(_GEO, mat);
+      mesh.frustumCulled = false; // particles move fast; skip frustum test
+
+      this._pool.push({
+        mesh,
+        position: new THREE.Vector3(),
+        velocity: new THREE.Vector3(),
+        /** Remaining lifetime in seconds */
+        life: 0,
+        /** Total lifetime (for interpolation) */
+        maxLife: 1,
+        colorStart: new THREE.Color(),
+        colorEnd: new THREE.Color(),
+        /** Scale at birth */
+        startScale: 1,
+        /** Gravity acceleration (positive = downward) */
+        gravity: 0,
+      });
+
+      this._free.push(i);
+    }
+  }
+
+  /**
+   * Acquire one particle from the free list.
+   * Returns the particle object or null if the pool is exhausted.
+   * @returns {ParticleData|null}
+   */
+  _acquire() {
+    if (this._free.length === 0) return null;
+    const idx = this._free.pop();
+    this._active.push(idx);
+    const p = this._pool[idx];
+    this.scene.add(p.mesh);
+    return p;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public emit API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Emit an explosion burst — fire, sparks, and dark smoke.
+   *
+   * @param {THREE.Vector3} position  World-space center of explosion.
+   * @param {object}        [opts]
+   * @param {number}        [opts.count=25]    Particle count.
+   * @param {number}        [opts.speed=8]     Average launch speed (m/s).
+   * @param {number}        [opts.lifetime=0.9] Max particle lifetime (s).
+   */
+  emitExplosion(position, opts = {}) {
+    const count = opts.count ?? 25;
+    const speed = opts.speed ?? 8;
+    const lifetime = opts.lifetime ?? 0.9;
+
+    for (let i = 0; i < count; i++) {
+      const p = this._acquire();
+      if (!p) return;
+
+      // Random spherical direction with upward bias
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.random() * Math.PI;
+      const spd = speed * (0.4 + Math.random() * 0.6);
+
+      p.velocity.set(
+        Math.sin(phi) * Math.cos(theta) * spd,
+        Math.abs(Math.cos(phi)) * spd + 2,
+        Math.sin(phi) * Math.sin(theta) * spd
+      );
+
+      p.position.copy(position);
+      p.life = lifetime * (0.6 + Math.random() * 0.4);
+      p.maxLife = p.life;
+      p.gravity = 5;
+
+      // Color palette — orange/yellow core → gray/black smoke
+      const r = Math.random();
+      if (r < 0.35) {
+        p.colorStart.setHex(0xff6600);
+        p.colorEnd.setHex(0x222222);
+      } else if (r < 0.65) {
+        p.colorStart.setHex(0xffcc00);
+        p.colorEnd.setHex(0x555555);
+      } else {
+        p.colorStart.setHex(0xff3300);
+        p.colorEnd.setHex(0x111111);
+      }
+
+      p.startScale = 0.4 + Math.random() * 0.5;
+
+      // Initialise mesh state
+      p.mesh.material.color.copy(p.colorStart);
+      p.mesh.material.opacity = 1;
+      p.mesh.scale.setScalar(p.startScale);
+      p.mesh.position.copy(position);
+    }
+  }
+
+  /**
+   * Emit muzzle-flash particles.
+   *
+   * @param {THREE.Vector3} position  World-space muzzle tip.
+   * @param {THREE.Vector3} direction Normalised fire direction.
+   */
+  emitMuzzleFlash(position, direction) {
+    const count = 6;
+    for (let i = 0; i < count; i++) {
+      const p = this._acquire();
+      if (!p) return;
+
+      const spread = 0.4;
+      p.velocity
+        .set(
+          direction.x + (Math.random() - 0.5) * spread,
+          direction.y + (Math.random() - 0.5) * spread * 0.5,
+          direction.z + (Math.random() - 0.5) * spread
+        )
+        .normalize()
+        .multiplyScalar(6 + Math.random() * 6);
+
+      p.position.copy(position);
+      p.life = 0.06 + Math.random() * 0.06;
+      p.maxLife = p.life;
+      p.colorStart.setHex(0xffffff);
+      p.colorEnd.setHex(0xff8800);
+      p.startScale = 0.15 + Math.random() * 0.2;
+      p.gravity = 0;
+
+      p.mesh.material.color.copy(p.colorStart);
+      p.mesh.material.opacity = 1;
+      p.mesh.scale.setScalar(p.startScale);
+      p.mesh.position.copy(position);
+    }
+  }
+
+  /**
+   * Emit a small dust puff at a tank's track position.
+   * Call periodically (every ~0.15 s) while the tank is moving.
+   *
+   * @param {THREE.Vector3} position  World-space tank position.
+   */
+  emitDust(position) {
+    const count = 2;
+    for (let i = 0; i < count; i++) {
+      const p = this._acquire();
+      if (!p) return;
+
+      p.velocity.set(
+        (Math.random() - 0.5) * 2,
+        0.8 + Math.random(),
+        (Math.random() - 0.5) * 2
+      );
+
+      // Spawn near track edges, on the ground
+      p.position.set(
+        position.x + (Math.random() - 0.5) * 3,
+        position.y,
+        position.z + (Math.random() - 0.5) * 2
+      );
+      p.life = 0.5 + Math.random() * 0.4;
+      p.maxLife = p.life;
+      p.colorStart.setHex(0xc8a87a); // sandy dirt
+      p.colorEnd.setHex(0xc8a87a);
+      p.startScale = 0.15 + Math.random() * 0.15;
+      p.gravity = -1; // rises gently
+
+      p.mesh.material.color.copy(p.colorStart);
+      p.mesh.material.opacity = 0.6;
+      p.mesh.scale.setScalar(p.startScale);
+      p.mesh.position.copy(p.position);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Per-frame update
+  // -------------------------------------------------------------------------
+
+  /**
+   * Advance all active particles by dt seconds.
+   * Dead particles are returned to the free list.
+   *
+   * @param {number} dt Delta time in seconds.
+   */
+  update(dt) {
+    for (let i = this._active.length - 1; i >= 0; i--) {
+      const idx = this._active[i];
+      const p = this._pool[idx];
+
+      p.life -= dt;
+
+      if (p.life <= 0) {
+        // Return to pool
+        this.scene.remove(p.mesh);
+        this._free.push(idx);
+        this._active.splice(i, 1);
+        continue;
+      }
+
+      // Physics
+      p.velocity.y -= p.gravity * dt;
+      p.position.addScaledVector(p.velocity, dt);
+      p.mesh.position.copy(p.position);
+
+      // Lifecycle fraction: 0 = birth, 1 = death
+      const t = 1 - p.life / p.maxLife;
+
+      // Interpolate colour and opacity
+      p.mesh.material.color.lerpColors(p.colorStart, p.colorEnd, t);
+      p.mesh.material.opacity = 1 - t;
+
+      // Shrink toward zero
+      p.mesh.scale.setScalar(Math.max(0.001, p.startScale * (1 - t * 0.8)));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /**
+   * Remove all active particles from the scene and reset the pool.
+   * Call this on round reset / game restart.
+   */
+  reset() {
+    for (const idx of this._active) {
+      this.scene.remove(this._pool[idx].mesh);
+      this._free.push(idx);
+    }
+    this._active.length = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSDoc typedef (no runtime cost)
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} ParticleData
+ * @property {THREE.Mesh}    mesh
+ * @property {THREE.Vector3} position
+ * @property {THREE.Vector3} velocity
+ * @property {number}        life
+ * @property {number}        maxLife
+ * @property {THREE.Color}   colorStart
+ * @property {THREE.Color}   colorEnd
+ * @property {number}        startScale
+ * @property {number}        gravity
+ */


### PR DESCRIPTION
## Summary

Implements t003 — pool-based particle emitter for the three M1 visual effects required before t002 (destructible trees) and t004 (tank wrecks) can land.

## What

- **NEW `src/systems/ParticleSystem.js`** — 300-slot object pool.  Each slot pre-allocates a `THREE.Mesh` + `THREE.MeshBasicMaterial`; no allocations at runtime. Three emitter methods:
  - `emitExplosion(pos, opts)` — fire/smoke burst on shell impact; larger burst on tank kill. Particles launch in a sphere with upward bias, gravity pulls them down, colour lerps orange→gray smoke.
  - `emitMuzzleFlash(pos, dir)` — 6 white→orange particles in a forward cone, very short lifetime (60–120 ms).
  - `emitDust(pos)` — 2 rising tan particles per call, timer-gated at 150 ms. Used for both player and enemy tracks while moving.
- **EDIT `src/core/Game.js`** — wires ParticleSystem into the game loop:
  - `_initSystems()` instantiates `ParticleSystem`; registers `enemies.onFire()` callback so enemy projectiles are now properly tracked **and** show a muzzle flash (fixing a pre-existing silent bug where enemy shells were discarded).
  - `_updatePlayer()` emits muzzle flash on player fire; emits dust while moving.
  - `_checkCollisions()` emits scaled explosions on hit (15 particles) and on kill (35 particles).
  - `_loop()` calls `particles.update(dt)` and drives the enemy dust timer.
  - `restart()` calls `particles.reset()`.

## Verification

```
npm run build   # ✓ 16 modules, no errors, 491 kB bundle
```

All three effects are visible at runtime:
- Fire cannon → white flash at muzzle tip
- Shell hits enemy → small orange burst
- Enemy tank dies → large fire+smoke explosion
- Drive tank → tan dust puffs from tracks

Resolves #2