### PR TITLE
t006: TeamManager — 2 teams of 6, opposite-side spawn, alive/dead tracking

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -1,13 +1,18 @@
 import * as THREE from 'three';
-import { Tank } from '../entities/Tank.js';
 import { Terrain } from '../entities/Terrain.js';
 import { InputSystem } from '../systems/InputSystem.js';
 import { ProjectileSystem } from '../systems/ProjectileSystem.js';
-import { EnemySystem } from '../systems/EnemySystem.js';
 import { CollisionSystem } from '../systems/CollisionSystem.js';
 import { ParticleSystem } from '../systems/ParticleSystem.js';
 import { HUD } from '../ui/HUD.js';
 import { CameraController } from '../systems/CameraController.js';
+import { TeamManager } from './TeamManager.js';
+
+// Simple AI constants (temporary — will be replaced by AIController in t007)
+const AI_AGGRO_RANGE = 50;
+const AI_FIRE_RANGE = 30;
+const AI_MOVE_SPEED = 6;
+const AI_TURN_SPEED = 1.5;
 
 export class Game {
   constructor(canvas) {
@@ -65,39 +70,45 @@ export class Game {
     this.terrain = new Terrain();
     this.scene.add(this.terrain.mesh);
 
-    // Player tank
-    this.player = new Tank({ isPlayer: true });
-    this.player.mesh.position.set(0, 0, 0);
-    this.scene.add(this.player.mesh);
+    // TeamManager creates all 12 tanks and places them on the field.
+    // this.player is a convenience alias to teams[0].slots[0].tank.
+    this.teams = new TeamManager(this.scene, this.terrain);
+    this.player = this.teams.player;
   }
 
   _initSystems() {
     this.input = new InputSystem(this.canvas);
     this.cameraController = new CameraController(this.camera, this.player);
     this.projectiles = new ProjectileSystem(this.scene);
-    this.enemies = new EnemySystem(this.scene, this.player);
     this.particles = new ParticleSystem(this.scene);
 
-    // Dust-emission timers (seconds until next dust puff)
+    // Dust-emission timers
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
 
-    // Route enemy fire into the shared projectile pool + muzzle flash
-    this.enemies.onFire((projectile) => {
-      this.projectiles.add(projectile);
-      const flashDir = projectile.velocity.clone().normalize();
-      this.particles.emitMuzzleFlash(
-        projectile.mesh.position.clone(),
-        flashDir
-      );
-    });
+    /**
+     * CollisionSystem compatibility adapter.
+     * CollisionSystem expects enemies.active (Tank[]) and enemies.remove(j).
+     * We delegate to TeamManager so kills are tracked correctly.
+     */
+    const teams = this.teams;
+    this._enemiesAdapter = {
+      get active() { return teams.getEnemyTanks(); },
+      remove: (j) => {
+        const living = teams.getEnemyTanks();
+        if (living[j]) {
+          teams.killTank(living[j]);
+        }
+      },
+    };
 
     this.collision = new CollisionSystem({
       terrain: this.terrain,
       player: this.player,
-      enemies: this.enemies,
+      enemies: this._enemiesAdapter,
       projectiles: this.projectiles,
     });
+
     this.collision
       .onScoreAdd(pts => { this.score += pts; })
       .onPlayerDeath(() => this._gameOver())
@@ -107,6 +118,12 @@ export class Game {
       .onKill((pos) => {
         this.particles.emitExplosion(pos, { count: 35, speed: 10 });
       });
+
+    // Notify on team elimination (will be consumed by MatchManager in t008)
+    this.teams.onTeamEliminated((teamId) => {
+      const winner = teamId === 1 ? 'Player Team' : 'Enemy Team';
+      console.info(`[TeamManager] Team ${teamId} eliminated — ${winner} wins the round.`);
+    });
 
     this.hud = new HUD();
   }
@@ -123,24 +140,32 @@ export class Game {
 
     const dt = Math.min(this.clock.getDelta(), 0.05);
 
-    // Update player from input
+    // Player input
     this._updatePlayer(dt);
 
-    // Update systems
+    // Temporary AI for enemy tanks (replaced by AIController in t007)
+    this._updateEnemyAI(dt);
+
+    // Ally AI placeholder — friendly tanks hold position for now
+    // (AIController in t007 will add proper target-selection for allies too)
+
+    // Update each alive tank's fire cooldown
+    for (const tank of this.teams.getAllLivingTanks()) {
+      tank.update(dt);
+    }
+
+    // Systems
     this.projectiles.update(dt);
-    this.enemies.update(dt);
     this.particles.update(dt);
     this.cameraController.update(dt);
-
-    // Collision detection (projectiles + tank-vs-obstacle blocking)
     this.collision.update();
 
-    // Dust trails for active enemies (timer-gated)
+    // Dust trails for living enemy tanks
     this._enemyDustTimer -= dt;
     if (this._enemyDustTimer <= 0) {
       this._enemyDustTimer = 0.15;
-      for (const enemy of this.enemies.active) {
-        this.particles.emitDust(enemy.mesh.position);
+      for (const tank of this.teams.getEnemyTanks()) {
+        this.particles.emitDust(tank.mesh.position);
       }
     }
 
@@ -154,10 +179,62 @@ export class Game {
     this.renderer.render(this.scene, this.camera);
   }
 
+  /**
+   * Minimal enemy AI: face and advance toward player, fire when in range.
+   * Temporary placeholder — AIController (t007) will replace this with
+   * proper target-selection per team.
+   *
+   * @param {number} dt
+   */
+  _updateEnemyAI(dt) {
+    const playerPos = this.player.mesh.position;
+
+    for (const enemy of this.teams.getEnemyTanks()) {
+      const pos = enemy.mesh.position;
+      const dist = pos.distanceTo(playerPos);
+
+      if (dist > AI_AGGRO_RANGE) continue;
+
+      // Turn hull toward player
+      const targetAngle = Math.atan2(playerPos.x - pos.x, playerPos.z - pos.z);
+      const hullAngle = enemy.mesh.rotation.y;
+      let diff = targetAngle - hullAngle;
+      while (diff > Math.PI) diff -= Math.PI * 2;
+      while (diff < -Math.PI) diff += Math.PI * 2;
+      enemy.mesh.rotation.y += Math.sign(diff) * Math.min(Math.abs(diff), AI_TURN_SPEED * dt);
+
+      // Advance if beyond optimal fire range
+      if (dist > AI_FIRE_RANGE * 0.7) {
+        enemy.mesh.translateZ(-AI_MOVE_SPEED * dt);
+      }
+
+      // Keep on terrain
+      pos.y = this.terrain.getHeightAt(pos.x, pos.z);
+
+      // Clamp to arena
+      const bound = 90;
+      pos.x = THREE.MathUtils.clamp(pos.x, -bound, bound);
+      pos.z = THREE.MathUtils.clamp(pos.z, -bound, bound);
+
+      // Aim turret and fire
+      enemy.setTurretAngle(targetAngle);
+      if (dist < AI_FIRE_RANGE && enemy.canFire()) {
+        const projectile = enemy.fire();
+        if (projectile) {
+          this.projectiles.add(projectile);
+          const flashDir = projectile.velocity.clone().normalize();
+          this.particles.emitMuzzleFlash(
+            projectile.mesh.position.clone(),
+            flashDir
+          );
+        }
+      }
+    }
+  }
+
   _updatePlayer(dt) {
     const input = this.input.getState();
 
-    // Movement
     const moveSpeed = 12;
     const turnSpeed = 2.5;
 
@@ -174,17 +251,14 @@ export class Game {
       this.player.mesh.rotation.y -= turnSpeed * dt;
     }
 
-    // Turret aim (touch/mouse)
     if (input.turretAngle !== null) {
       this.player.setTurretAngle(input.turretAngle);
     }
 
-    // Fire
     if (input.fire && this.player.canFire()) {
       const projectile = this.player.fire();
       if (projectile) {
         this.projectiles.add(projectile);
-        // Muzzle flash at projectile spawn point
         const flashDir = projectile.velocity.clone().normalize();
         this.particles.emitMuzzleFlash(
           projectile.mesh.position.clone(),
@@ -202,7 +276,7 @@ export class Game {
     pos.x = THREE.MathUtils.clamp(pos.x, -bound, bound);
     pos.z = THREE.MathUtils.clamp(pos.z, -bound, bound);
 
-    // Dust trail while moving (timer-gated)
+    // Dust trail while moving
     this._playerDustTimer -= dt;
     if (this._playerDustTimer <= 0 && (input.forward || input.backward)) {
       this._playerDustTimer = 0.15;
@@ -217,10 +291,7 @@ export class Game {
 
   restart() {
     this.score = 0;
-    this.player.reset();
-    this.player.mesh.position.set(0, 0, 0);
-    this.player.mesh.rotation.set(0, 0, 0);
-    this.enemies.reset();
+    this.teams.reset();
     this.projectiles.reset();
     this.particles.reset();
     this._playerDustTimer = 0;

--- a/src/core/TeamManager.js
+++ b/src/core/TeamManager.js
@@ -1,0 +1,254 @@
+import * as THREE from 'three';
+import { Tank } from '../entities/Tank.js';
+
+/**
+ * TeamManager — creates and tracks two teams of 6 tanks for a 6v6 match.
+ *
+ * Team layout:
+ *   Team 0 (player team, green): spawns on the south side (z = +SPAWN_Z).
+ *     tanks[0] = the human-controlled player tank.
+ *     tanks[1-5] = AI ally tanks.
+ *   Team 1 (enemy team, red): spawns on the north side (z = -SPAWN_Z).
+ *     tanks[0-5] = AI enemy tanks.
+ *
+ * Alive/dead tracking:
+ *   Each slot is an object { tank, alive }.
+ *   Call killTank(tank) when a tank is destroyed; it sets alive=false and
+ *   removes the mesh from the scene.
+ *   isTeamEliminated(teamId) returns true when all 6 slots are dead.
+ *
+ * Integration with EnemySystem / CollisionSystem:
+ *   Use getEnemyTanks() to get the live enemy Tank instances so existing
+ *   systems that iterate over an `active` array still work. EnemySystem
+ *   should be replaced by AIController (t007) once TeamManager is in use.
+ */
+
+const TEAM_SIZE = 6;
+
+// Spawn parameters
+const SPAWN_Z = 55;          // north/south offset from centre
+const SPAWN_SPREAD_X = 30;   // total X spread across spawn line
+const SPAWN_ROW_DEPTH = 8;   // gap between two row groups (not used for single row)
+
+// Team color palettes
+const TEAM_COLORS = [
+  { body: 0x2d5a27, turret: 0x3a7a33 }, // Team 0 — green (player side)
+  { body: 0x8b2500, turret: 0xb03000 }, // Team 1 — red (enemy side)
+];
+
+export class TeamManager {
+  /**
+   * @param {THREE.Scene} scene
+   * @param {import('../entities/Terrain.js').Terrain} terrain
+   */
+  constructor(scene, terrain) {
+    this.scene = scene;
+    this.terrain = terrain;
+
+    /**
+     * @type {Array<{id: number, name: string, slots: Array<{tank: Tank, alive: boolean}>}>}
+     */
+    this.teams = [];
+
+    this._onTeamEliminatedCb = null;
+
+    this._buildTeams();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The human-controlled player Tank instance (always teams[0].slots[0].tank).
+   * @returns {Tank}
+   */
+  get player() {
+    return this.teams[0].slots[0].tank;
+  }
+
+  /**
+   * All living Tank instances on team 0 (player side, excluding the player).
+   * @returns {Tank[]}
+   */
+  getAllyTanks() {
+    return this.teams[0].slots
+      .filter((slot, i) => i > 0 && slot.alive)
+      .map(slot => slot.tank);
+  }
+
+  /**
+   * All living Tank instances on team 1 (enemy side).
+   * Compatible with EnemySystem's `.active` interface for CollisionSystem.
+   * @returns {Tank[]}
+   */
+  getEnemyTanks() {
+    return this.teams[1].slots
+      .filter(slot => slot.alive)
+      .map(slot => slot.tank);
+  }
+
+  /**
+   * Returns living tanks for both teams as a flat array.
+   * @returns {Tank[]}
+   */
+  getAllLivingTanks() {
+    return this.teams.flatMap(team =>
+      team.slots.filter(slot => slot.alive).map(slot => slot.tank)
+    );
+  }
+
+  /**
+   * Mark a tank as dead, remove its mesh from the scene.
+   * Triggers the onTeamEliminated callback if the team is now wiped.
+   *
+   * @param {Tank} tank
+   */
+  killTank(tank) {
+    for (const team of this.teams) {
+      for (const slot of team.slots) {
+        if (slot.tank === tank && slot.alive) {
+          slot.alive = false;
+          this.scene.remove(tank.mesh);
+          if (this.isTeamEliminated(team.id) && this._onTeamEliminatedCb) {
+            this._onTeamEliminatedCb(team.id);
+          }
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns true if every tank on the given team is dead.
+   * @param {number} teamId — 0 or 1
+   * @returns {boolean}
+   */
+  isTeamEliminated(teamId) {
+    const team = this.teams[teamId];
+    if (!team) return false;
+    return team.slots.every(slot => !slot.alive);
+  }
+
+  /**
+   * Count living tanks per team.
+   * @returns {{team0: number, team1: number}}
+   */
+  getAliveCounts() {
+    return {
+      team0: this.teams[0].slots.filter(s => s.alive).length,
+      team1: this.teams[1].slots.filter(s => s.alive).length,
+    };
+  }
+
+  /**
+   * Register a callback called when a team is fully eliminated.
+   * @param {(teamId: number) => void} cb
+   */
+  onTeamEliminated(cb) {
+    this._onTeamEliminatedCb = cb;
+    return this;
+  }
+
+  /**
+   * Reset both teams to full health, restore meshes to scene, reposition.
+   * Called by MatchManager/round reset (t009).
+   */
+  reset() {
+    for (const team of this.teams) {
+      const isPlayerTeam = team.id === 0;
+      for (let i = 0; i < team.slots.length; i++) {
+        const slot = team.slots[i];
+        slot.alive = true;
+        slot.tank.reset();
+
+        // Restore mesh if it was removed from the scene
+        if (!slot.tank.mesh.parent) {
+          this.scene.add(slot.tank.mesh);
+        }
+
+        // Reposition
+        const spawnPos = this._spawnPosition(i, isPlayerTeam ? 0 : 1);
+        slot.tank.mesh.position.copy(spawnPos);
+        slot.tank.mesh.rotation.y = isPlayerTeam ? 0 : Math.PI;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  _buildTeams() {
+    // Team 0 — player side
+    const playerTeam = {
+      id: 0,
+      name: 'Player Team',
+      slots: [],
+    };
+
+    for (let i = 0; i < TEAM_SIZE; i++) {
+      const isPlayer = i === 0;
+      const tank = new Tank({
+        isPlayer,
+        color: TEAM_COLORS[0].body,
+        turretColor: TEAM_COLORS[0].turret,
+        teamId: 0,
+      });
+
+      const pos = this._spawnPosition(i, 0);
+      tank.mesh.position.copy(pos);
+      tank.mesh.rotation.y = 0; // facing north
+
+      this.scene.add(tank.mesh);
+      playerTeam.slots.push({ tank, alive: true });
+    }
+
+    // Team 1 — enemy side
+    const enemyTeam = {
+      id: 1,
+      name: 'Enemy Team',
+      slots: [],
+    };
+
+    for (let i = 0; i < TEAM_SIZE; i++) {
+      const tank = new Tank({
+        isPlayer: false,
+        color: TEAM_COLORS[1].body,
+        turretColor: TEAM_COLORS[1].turret,
+        teamId: 1,
+      });
+
+      const pos = this._spawnPosition(i, 1);
+      tank.mesh.position.copy(pos);
+      tank.mesh.rotation.y = Math.PI; // facing south
+
+      this.scene.add(tank.mesh);
+      enemyTeam.slots.push({ tank, alive: true });
+    }
+
+    this.teams.push(playerTeam, enemyTeam);
+  }
+
+  /**
+   * Calculate spawn position for a given slot index and team side.
+   *
+   * Team 0 spawns along z = +SPAWN_Z (south).
+   * Team 1 spawns along z = -SPAWN_Z (north).
+   * Tanks are evenly spaced across the X axis within SPAWN_SPREAD_X.
+   *
+   * @param {number} index — 0..5
+   * @param {number} teamId — 0 or 1
+   * @returns {THREE.Vector3}
+   */
+  _spawnPosition(index, teamId) {
+    // Spread tanks evenly: positions at -SPREAD/2, ..., +SPREAD/2
+    const step = SPAWN_SPREAD_X / (TEAM_SIZE - 1);
+    const x = -SPAWN_SPREAD_X / 2 + index * step;
+    const z = teamId === 0 ? SPAWN_Z : -SPAWN_Z;
+
+    const y = this.terrain ? this.terrain.getHeightAt(x, z) : 0;
+    return new THREE.Vector3(x, y, z);
+  }
+}

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -7,19 +7,27 @@ const TANK_COLORS = {
 };
 
 export class Tank {
-  constructor({ isPlayer = false, color = null } = {}) {
+  /**
+   * @param {object} [opts]
+   * @param {boolean} [opts.isPlayer=false]
+   * @param {number|null} [opts.color=null]       — override hull color (hex int)
+   * @param {number|null} [opts.turretColor=null] — override turret color (hex int)
+   * @param {number} [opts.teamId=1]              — 0 = player team, 1 = enemy team
+   */
+  constructor({ isPlayer = false, color = null, turretColor = null, teamId = 1 } = {}) {
     this.isPlayer = isPlayer;
+    this.teamId = teamId;
     this.health = 100;
     this.maxHealth = 100;
     this.ammo = 30;
     this.fireCooldown = 0;
     this.fireRate = 0.3; // seconds between shots
 
-    const palette = isPlayer ? TANK_COLORS.player : TANK_COLORS.enemy;
-    if (color) {
-      palette.body = color;
-      palette.turret = color;
-    }
+    const base = isPlayer ? TANK_COLORS.player : TANK_COLORS.enemy;
+    const palette = {
+      body: color !== null ? color : base.body,
+      turret: turretColor !== null ? turretColor : (color !== null ? color : base.turret),
+    };
 
     this.mesh = this._buildMesh(palette);
     this.turret = this.mesh.getObjectByName('turret');


### PR DESCRIPTION
## Summary

- Adds `src/core/TeamManager.js`: owns both 6-tank teams for a 6v6 match.
- Updates `src/entities/Tank.js`: accepts `turretColor` and `teamId` constructor options.
- Rewrites `src/core/Game.js`: replaces ad-hoc player + EnemySystem with TeamManager.

## What was done

**TeamManager** (`src/core/TeamManager.js`):
- Team 0 (green) spawns at z=+55 (south); `teams[0].slots[0].tank` is the human player.
- Team 1 (red) spawns at z=−55 (north), facing south.
- 6 tanks per team, evenly spread 30u across the X axis.
- `killTank(tank)` removes the mesh and marks the slot dead.
- `onTeamEliminated(cb)` fires when all 6 on a team are dead (consumed by MatchManager in t008).
- `getEnemyTanks()` / `getAllyTanks()` / `getAllLivingTanks()` — live-tank queries used by CollisionSystem and the AI loop.
- `getAliveCounts()` returns `{team0, team1}` live counts for HUD/Scoreboard (t013).
- `reset()` repositions and restores all 12 tanks for round replay (t009).

**Tank.js**: `turretColor` and `teamId` options added; existing callers unaffected.

**Game.js**:
- EnemySystem removed; TeamManager creates all 12 tanks at init.
- CollisionSystem wired via a thin `enemiesAdapter` (`{ get active, remove }`) delegating to TeamManager, so enemy kills are properly tracked.
- Temporary `_updateEnemyAI()` preserves move/aim/fire behaviour until AIController (t007) replaces it.

## Verification

Build: `npx vite build` — 17 modules, no errors.  
API surface: all 10 public methods present in TeamManager.  
Integration: all Game.js integration points verified by static check.

Resolves #10