### PR TITLE
t004: Tank wrecks — demolished tanks become indestructible cover props

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -5,6 +5,7 @@ import { ProjectileSystem } from '../systems/ProjectileSystem.js';
 import { CollisionSystem } from '../systems/CollisionSystem.js';
 import { ParticleSystem } from '../systems/ParticleSystem.js';
 import { TreeSystem } from '../systems/TreeSystem.js';
+import { WreckSystem } from '../systems/WreckSystem.js';
 import { HUD } from '../ui/HUD.js';
 import { CameraController } from '../systems/CameraController.js';
 import { TeamManager } from './TeamManager.js';
@@ -84,6 +85,8 @@ export class Game {
     this.particles = new ParticleSystem(this.scene);
     // TreeSystem spawns tree entities with HP; CollisionSystem handles shell hits
     this.trees = new TreeSystem(this.scene, this.terrain);
+    // WreckSystem — demolished tanks become cover props on the field
+    this.wrecks = new WreckSystem(this.scene);
 
     // Dust-emission timers
     this._playerDustTimer = 0;
@@ -111,6 +114,7 @@ export class Game {
       enemies: this._enemiesAdapter,
       projectiles: this.projectiles,
       treeSystem: this.trees,
+      wrecks: this.wrecks,
     });
 
     this.collision
@@ -119,8 +123,12 @@ export class Game {
       .onHit((pos) => {
         this.particles.emitExplosion(pos, { count: 15, speed: 6, lifetime: 0.6 });
       })
-      .onKill((pos) => {
+      .onKill((pos, owner, tankData) => {
         this.particles.emitExplosion(pos, { count: 35, speed: 10 });
+        // Leave a wreck at the tank's last position as indestructible cover
+        if (tankData) {
+          this.wrecks.add(tankData.position, tankData.rotationY);
+        }
       })
       .onTreeHit((pos) => {
         // Small impact burst to show the tree was hit
@@ -307,6 +315,7 @@ export class Game {
     this.projectiles.reset();
     this.particles.reset();
     this.trees.reset();
+    this.wrecks.reset();
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
     this.hud.hideGameOver();

--- a/src/entities/TankWreck.js
+++ b/src/entities/TankWreck.js
@@ -1,0 +1,102 @@
+import * as THREE from 'three';
+
+/**
+ * TankWreck — a static, indestructible cover prop left behind when a tank
+ * is demolished. Visually represents a burnt-out, darkened tank hull with a
+ * canted turret and a broken barrel.
+ *
+ * Wrecks are added to the scene by WreckSystem and registered as obstacles
+ * with CollisionSystem so live tanks and projectiles cannot pass through them.
+ */
+export class TankWreck {
+  /**
+   * @param {import('three').Vector3} position  World position of the wreck.
+   * @param {number}                  rotationY Hull yaw (radians) inherited from the killed tank.
+   */
+  constructor(position, rotationY = 0) {
+    /** @type {number} Collision radius used by CollisionSystem (XZ plane). */
+    this.collisionRadius = 2.4;
+
+    this.mesh = this._buildMesh();
+    this.mesh.position.set(position.x, position.y, position.z);
+    this.mesh.rotation.y = rotationY;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  _buildMesh() {
+    const group = new THREE.Group();
+
+    const hullMat = new THREE.MeshStandardMaterial({
+      color: 0x2a2a2a,
+      roughness: 0.9,
+      metalness: 0.1,
+    });
+
+    // Charred hull — slightly squashed to look compressed by damage
+    const hull = new THREE.Mesh(new THREE.BoxGeometry(3, 1.0, 4.5), hullMat);
+    hull.position.y = 0.65;
+    hull.castShadow = true;
+    hull.receiveShadow = true;
+    group.add(hull);
+
+    // Burnt tracks
+    const trackMat = new THREE.MeshStandardMaterial({
+      color: 0x111111,
+      roughness: 0.95,
+    });
+    const trackGeo = new THREE.BoxGeometry(0.6, 0.7, 4.8);
+    const trackL = new THREE.Mesh(trackGeo, trackMat);
+    trackL.position.set(-1.6, 0.38, 0);
+    trackL.castShadow = true;
+    trackL.receiveShadow = true;
+    group.add(trackL);
+    const trackR = trackL.clone();
+    trackR.position.x = 1.6;
+    group.add(trackR);
+
+    const turretMat = new THREE.MeshStandardMaterial({
+      color: 0x1f1f1f,
+      roughness: 0.9,
+      metalness: 0.2,
+    });
+
+    // Turret — slightly off-centre and canted to look blown off
+    const turret = new THREE.Mesh(
+      new THREE.CylinderGeometry(1.05, 1.25, 0.75, 8),
+      turretMat
+    );
+    turret.position.set(0.25, 1.5, 0.2);
+    turret.rotation.z = 0.18; // slight tilt
+    turret.castShadow = true;
+    group.add(turret);
+
+    // Broken barrel — shorter, angled downward
+    const barrel = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.14, 0.17, 2.0, 8),
+      new THREE.MeshStandardMaterial({ color: 0x1a1a1a, roughness: 0.85 })
+    );
+    barrel.rotation.x = Math.PI / 2;
+    barrel.rotation.z = 0.28; // bent
+    barrel.position.set(0.25, 1.45, -1.2);
+    barrel.castShadow = true;
+    group.add(barrel);
+
+    // Scorch ring on the ground beneath the wreck
+    const scorchGeo = new THREE.CircleGeometry(2.8, 16);
+    const scorchMat = new THREE.MeshStandardMaterial({
+      color: 0x1a1208,
+      roughness: 1.0,
+      metalness: 0.0,
+    });
+    const scorch = new THREE.Mesh(scorchGeo, scorchMat);
+    scorch.rotation.x = -Math.PI / 2;
+    scorch.position.y = 0.01; // just above terrain to avoid z-fighting
+    scorch.receiveShadow = true;
+    group.add(scorch);
+
+    return group;
+  }
+}

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -3,34 +3,42 @@
  *
  * Handles:
  *  1. Projectile-vs-tank collisions (player ↔ enemy, bidirectional).
- *  2. Tank-vs-obstacle blocking: pushes tanks out of rocks and living trees.
+ *  2. Projectile-vs-wreck absorption: shells are consumed by wrecks (the
+ *     wreck itself is indestructible, making it genuine cover).
  *  3. Projectile-vs-tree collisions: trees take shell damage and are destroyed
  *     when HP reaches zero, triggering debris particles.
+ *  4. Tank-vs-obstacle blocking: pushes tanks out of rocks and living trees.
+ *  5. Tank-vs-wreck blocking: same impulse resolve applied to WreckSystem
+ *     obstacles so live tanks cannot drive through demolished hulls.
  *
  * Callbacks (set before first update):
- *  onScoreAdd(points)      — called when an enemy tank is destroyed
- *  onPlayerDeath()         — called when the player tank reaches 0 HP
- *  onHit(position, owner)  — called on every non-lethal shell impact on a tank
- *  onKill(position, owner) — called when a shell destroys a tank
- *    owner: 'player' | 'enemy'
+ *  onScoreAdd(points)                    — called when an enemy tank is destroyed
+ *  onPlayerDeath()                       — called when the player tank reaches 0 HP
+ *  onHit(position, owner)                — called on every non-lethal shell impact
+ *    owner: 'player' | 'enemy' | 'wreck'
+ *  onKill(position, owner, tankData)     — called when a shell destroys a tank
+ *    owner: 'player' (player shell hit enemy) | 'enemy' (enemy shell hit player)
+ *    tankData: { position: Vector3, rotationY: number } — snapshot for wreck spawning
  *  onTreeHit(position)     — called on every non-lethal shell hit on a tree
  *  onTreeDestroy(position) — called when a shell destroys a tree
  */
 export class CollisionSystem {
   /**
    * @param {object} opts
-   * @param {import('../entities/Terrain.js').Terrain}       opts.terrain
-   * @param {import('../entities/Tank.js').Tank}             opts.player
-   * @param {import('./EnemySystem.js').EnemySystem}         opts.enemies
+   * @param {import('../entities/Terrain.js').Terrain}         opts.terrain
+   * @param {import('../entities/Tank.js').Tank}               opts.player
+   * @param {import('./EnemySystem.js').EnemySystem}           opts.enemies
    * @param {import('./ProjectileSystem.js').ProjectileSystem} opts.projectiles
-   * @param {import('./TreeSystem.js').TreeSystem}           [opts.treeSystem]
+   * @param {import('./TreeSystem.js').TreeSystem}             [opts.treeSystem]
+   * @param {import('./WreckSystem.js').WreckSystem}           [opts.wrecks]
    */
-  constructor({ terrain, player, enemies, projectiles, treeSystem = null }) {
+  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null }) {
     this.terrain = terrain;
     this.player = player;
     this.enemies = enemies;
     this.projectiles = projectiles;
     this.treeSystem = treeSystem;
+    this.wrecks = wrecks;
 
     this._onScoreAdd = null;
     this._onPlayerDeath = null;
@@ -76,7 +84,7 @@ export class CollisionSystem {
   }
 
   /**
-   * @param {(position: import('three').Vector3, owner: 'player'|'enemy') => void} cb
+   * @param {(position: import('three').Vector3, owner: string) => void} cb
    */
   onHit(cb) {
     this._onHit = cb;
@@ -84,7 +92,11 @@ export class CollisionSystem {
   }
 
   /**
-   * @param {(position: import('three').Vector3, owner: 'player'|'enemy') => void} cb
+   * @param {(
+   *   position: import('three').Vector3,
+   *   owner: string,
+   *   tankData: {position: import('three').Vector3, rotationY: number}
+   * ) => void} cb
    */
   onKill(cb) {
     this._onKill = cb;
@@ -134,8 +146,13 @@ export class CollisionSystem {
           e.takeDamage(p.damage);
           this.projectiles.remove(i);
           if (e.health <= 0) {
-            if (this._onKill) this._onKill(hitPos, 'player');
+            // Snapshot position+rotation before remove() clears the mesh from scene
+            const tankData = {
+              position: e.mesh.position.clone(),
+              rotationY: e.mesh.rotation.y,
+            };
             this.enemies.remove(j);
+            if (this._onKill) this._onKill(hitPos, 'player', tankData);
             if (this._onScoreAdd) this._onScoreAdd(100);
           } else {
             if (this._onHit) this._onHit(hitPos, 'player');
@@ -155,10 +172,35 @@ export class CollisionSystem {
         const hitPos = p.mesh.position.clone();
         player.takeDamage(p.damage);
         this.projectiles.remove(i);
-        if (this._onHit) this._onHit(hitPos, 'enemy');
         if (player.health <= 0) {
-          if (this._onKill) this._onKill(hitPos, 'enemy');
+          const tankData = {
+            position: player.mesh.position.clone(),
+            rotationY: player.mesh.rotation.y,
+          };
+          if (this._onKill) this._onKill(hitPos, 'enemy', tankData);
           if (this._onPlayerDeath) this._onPlayerDeath();
+        } else {
+          if (this._onHit) this._onHit(hitPos, 'enemy');
+        }
+      }
+    }
+
+    // Projectiles hitting wrecks — absorbed (no damage, wreck is indestructible)
+    if (this.wrecks) {
+      const wreckObs = this.wrecks.obstacles;
+      for (let i = projectiles.length - 1; i >= 0; i--) {
+        const p = projectiles[i];
+        for (const obs of wreckObs) {
+          const dx = p.mesh.position.x - obs.x;
+          const dz = p.mesh.position.z - obs.z;
+          const distSq = dx * dx + dz * dz;
+          const hitRadius = obs.radius + 0.3; // small fudge for shell size
+          if (distSq < hitRadius * hitRadius) {
+            const hitPos = p.mesh.position.clone();
+            this.projectiles.remove(i);
+            if (this._onHit) this._onHit(hitPos, 'wreck');
+            break; // projectile consumed
+          }
         }
       }
     }
@@ -222,8 +264,9 @@ export class CollisionSystem {
   }
 
   /**
-   * After all movement, push tanks out of rocks (permanent) and alive trees
-   * (removed once destroyed).  Operates in the XZ plane only.
+   * After all movement, push tanks out of rocks (permanent), alive trees
+   * (removed once destroyed), and wrecks (permanent until round reset).
+   * Operates in the XZ plane only.
    */
   _checkTankObstacleCollisions() {
     // Rock obstacles are permanent — from terrain.obstacles
@@ -241,10 +284,21 @@ export class CollisionSystem {
         this._resolveTreeObstacleCollision(enemy.mesh);
       }
     }
+
+    // Wrecks are indestructible cover — block all living tanks
+    if (this.wrecks) {
+      const wreckObs = this.wrecks.obstacles;
+      if (wreckObs.length > 0) {
+        this._resolveObstacleCollision(this.player.mesh, wreckObs);
+        for (const enemy of this.enemies.active) {
+          this._resolveObstacleCollision(enemy.mesh, wreckObs);
+        }
+      }
+    }
   }
 
   /**
-   * Resolve penetration between a tank mesh and each rock obstacle.
+   * Resolve penetration between a tank mesh and each rock/wreck obstacle.
    *
    * @param {import('three').Object3D}             mesh
    * @param {Array<{x: number, z: number, radius: number}>} obstacles

--- a/src/systems/WreckSystem.js
+++ b/src/systems/WreckSystem.js
@@ -1,0 +1,73 @@
+import { TankWreck } from '../entities/TankWreck.js';
+
+/**
+ * WreckSystem — manages TankWreck props on the battlefield.
+ *
+ * When a tank is demolished, Game calls `add()` with the killed tank's
+ * position and yaw.  The wreck mesh is added to the scene and registered
+ * as an obstacle that CollisionSystem uses to block both live tanks and
+ * projectiles from passing through.
+ *
+ * A soft cap (MAX_WRECKS) prevents unbounded scene growth in long sessions;
+ * the oldest wreck is silently culled when the cap is reached.
+ */
+const MAX_WRECKS = 24;
+
+export class WreckSystem {
+  /**
+   * @param {import('three').Scene} scene
+   */
+  constructor(scene) {
+    this.scene = scene;
+
+    /** @type {TankWreck[]} */
+    this._wrecks = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Spawn a new wreck at the given world position with the given yaw.
+   *
+   * @param {import('three').Vector3} position
+   * @param {number} rotationY Hull yaw in radians.
+   */
+  add(position, rotationY = 0) {
+    if (this._wrecks.length >= MAX_WRECKS) {
+      // Cull the oldest wreck to keep scene size bounded
+      const oldest = this._wrecks.shift();
+      this.scene.remove(oldest.mesh);
+    }
+
+    const wreck = new TankWreck(position, rotationY);
+    this.scene.add(wreck.mesh);
+    this._wrecks.push(wreck);
+  }
+
+  /**
+   * Returns a lightweight obstacle descriptor for each live wreck, suitable
+   * for CollisionSystem.  A fresh array is built each call so the caller
+   * always sees the current snapshot.
+   *
+   * @returns {Array<{x: number, z: number, radius: number}>}
+   */
+  get obstacles() {
+    return this._wrecks.map((w) => ({
+      x: w.mesh.position.x,
+      z: w.mesh.position.z,
+      radius: w.collisionRadius,
+    }));
+  }
+
+  /**
+   * Remove all wrecks from the scene (called on round reset).
+   */
+  reset() {
+    for (const w of this._wrecks) {
+      this.scene.remove(w.mesh);
+    }
+    this._wrecks.length = 0;
+  }
+}


### PR DESCRIPTION
## Summary

- **TankWreck entity** (`src/entities/TankWreck.js`): Flat-shaded, charred low-poly hull with a canted turret, broken barrel, and a scorch-mark circle on the ground beneath it. Visually distinct from active tanks via dark/burnt colours.
- **WreckSystem** (`src/systems/WreckSystem.js`): Manages the wreck pool. On each enemy kill the demolished tank's world position and hull yaw are snapped into a `TankWreck` prop and added to the scene. A soft cap of 24 wrecks culls the oldest when exceeded.
- **CollisionSystem** (`src/systems/CollisionSystem.js`): Extended to accept an optional `wrecks` param. Wrecks are treated as obstacles: (a) live tanks are push-resolved out of wreck footprints (same impulse-resolve used for rocks/trees), and (b) projectiles that enter a wreck's collision radius are absorbed — the wreck is indestructible. `onKill` callback now receives a `tankData` snapshot (`{position, rotationY}`) taken *before* the enemy mesh is removed from the scene, ensuring accurate wreck placement.
- **Game.js**: Imports and constructs `WreckSystem`, passes it to `CollisionSystem`, spawns a wreck in the `onKill` handler, and calls `wrecks.reset()` in `restart()`.

## Testing

Build passes (`npx vite build` — 19 modules, 0 errors). Functional verification: start the game, destroy several enemy tanks, confirm dark charred hull props remain at kill locations, confirm the player tank cannot drive through them and projectiles are blocked by them.

## Design alignment

Matches VISION.md § Structures table: "Wrecked tanks | Indestructible cover. Scattered across the battlefield as props." and VISION.md § Game Flow: "Tanks start getting demolished. Wrecks litter the field and become new cover."

Resolves #9