### PR TITLE
hotfix/t002-missing-tree-files: add missing Tree.js and TreeSystem.js

### DIFF
--- a/src/entities/Tree.js
+++ b/src/entities/Tree.js
@@ -1,0 +1,95 @@
+/**
+ * Tree — a destructible scenery entity.
+ *
+ * Each tree has 3 HP. Player shells deal 1 damage per hit; three hits
+ * fell the tree, removing it from the scene. The obstacle entry is kept
+ * on the TreeSystem's alive array so CollisionSystem can skip dead trees.
+ *
+ * Geometry is shared across all instances to minimise GPU upload cost.
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Shared geometries and materials (module-level singletons)
+// ---------------------------------------------------------------------------
+
+const _trunkGeo = new THREE.CylinderGeometry(0.2, 0.3, 2, 6);
+const _trunkMat = new THREE.MeshStandardMaterial({ color: 0x5c3a1e });
+
+const _canopyGeo = new THREE.ConeGeometry(1.5, 4, 6);
+const _canopyMat = new THREE.MeshStandardMaterial({
+  color: 0x2d5a27,
+  flatShading: true,
+});
+
+// ---------------------------------------------------------------------------
+// Tree
+// ---------------------------------------------------------------------------
+
+export class Tree {
+  /**
+   * @param {THREE.Scene} scene
+   * @param {number}      x       World X position.
+   * @param {number}      z       World Z position.
+   * @param {number}      groundY Terrain height at (x, z).
+   */
+  constructor(scene, x, z, groundY) {
+    this._scene = scene;
+
+    /** World X — used by CollisionSystem for push-back. */
+    this.x = x;
+    /** World Z — used by CollisionSystem for push-back. */
+    this.z = z;
+    /** Collision radius (matches ConeGeometry base radius). */
+    this.radius = 1.5;
+    /** Current hit-points. */
+    this.hp = 3;
+    /** Maximum hit-points (for UI or future use). */
+    this.maxHp = 3;
+    /** False once hp reaches 0 and the mesh has been removed. */
+    this.alive = true;
+
+    // Build the Three.js group
+    this.group = new THREE.Group();
+
+    const trunk = new THREE.Mesh(_trunkGeo, _trunkMat);
+    trunk.position.y = 1;
+    trunk.castShadow = true;
+    this.group.add(trunk);
+
+    const canopy = new THREE.Mesh(_canopyGeo, _canopyMat);
+    canopy.position.y = 4;
+    canopy.castShadow = true;
+    this.group.add(canopy);
+
+    this.group.position.set(x, groundY, z);
+    scene.add(this.group);
+  }
+
+  /**
+   * Apply damage.  Returns true on the hit that reduces HP to 0 (destruction).
+   *
+   * @param {number} amount
+   * @returns {boolean} True if the tree was just destroyed.
+   */
+  takeDamage(amount) {
+    if (!this.alive) return false;
+    this.hp = Math.max(0, this.hp - amount);
+    if (this.hp === 0) {
+      this.alive = false;
+      this._scene.remove(this.group);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Force-remove the mesh without damage logic (used by reset).
+   */
+  destroy() {
+    this.hp = 0;
+    this.alive = false;
+    this._scene.remove(this.group);
+  }
+}

--- a/src/systems/TreeSystem.js
+++ b/src/systems/TreeSystem.js
@@ -1,0 +1,76 @@
+/**
+ * TreeSystem — owns all Tree instances on the map.
+ *
+ * Responsibilities:
+ *  - Spawns 30 trees at random world positions (same density as the prior
+ *    decorative trees in Terrain._addProps).
+ *  - Exposes `this.trees` for projectile hit-testing in CollisionSystem.
+ *  - `reset()` tears down the current tree set and respawns fresh trees,
+ *    suitable for round reset.
+ *
+ * Trees are placed directly in the THREE.Scene (not as children of the
+ * terrain mesh) so their world positions equal their group.position values,
+ * which simplifies collision math.
+ */
+
+import { Tree } from '../entities/Tree.js';
+
+const TREE_COUNT = 30;
+/** Minimum XZ distance from world origin (spawn zone) to prevent trees
+ *  blocking tank spawn. */
+const SPAWN_CLEAR_RADIUS = 15;
+
+export class TreeSystem {
+  /**
+   * @param {THREE.Scene}                              scene
+   * @param {import('../entities/Terrain.js').Terrain} terrain
+   */
+  constructor(scene, terrain) {
+    this._scene = scene;
+    this._terrain = terrain;
+
+    /** @type {Tree[]} All Tree instances (alive + dead). */
+    this.trees = [];
+
+    this._spawnTrees();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  _spawnTrees() {
+    let placed = 0;
+    let attempts = 0;
+    // Attempt up to 5x count to hit the quota despite spawn-clear filtering
+    while (placed < TREE_COUNT && attempts < TREE_COUNT * 5) {
+      attempts++;
+      const x = (Math.random() - 0.5) * 170;
+      const z = (Math.random() - 0.5) * 170;
+      if (Math.abs(x) < SPAWN_CLEAR_RADIUS && Math.abs(z) < SPAWN_CLEAR_RADIUS) {
+        continue;
+      }
+      const groundY = this._terrain.getHeightAt(x, z);
+      this.trees.push(new Tree(this._scene, x, z, groundY));
+      placed++;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Remove all trees from the scene and spawn a fresh set.
+   * Call on round reset.
+   */
+  reset() {
+    for (const tree of this.trees) {
+      if (tree.alive) {
+        tree.destroy();
+      }
+    }
+    this.trees = [];
+    this._spawnTrees();
+  }
+}


### PR DESCRIPTION
## Summary

PR #13 merged the t002 tree-entity implementation but a prior cleanup commit deleted Tree.js and TreeSystem.js (because the stubs referenced a non-existent \`particles.emitWoodDebris()\` method). The correct files were never re-added, leaving the game with a broken import:

```js
import { TreeSystem } from '../systems/TreeSystem.js';  // file missing
```

## Files Added

- **NEW: `src/entities/Tree.js`** — Tree entity with HP=3, shared geometries, `takeDamage(amount)` (returns true on destruction), `destroy()` for reset
- **NEW: `src/systems/TreeSystem.js`** — Spawns 30 trees, exposes `this.trees` for CollisionSystem hit-testing and push-back, `reset()` respawns on round restart

## No Logic Changes

`CollisionSystem.js`, `Game.js`, `Terrain.js`, and `ParticleSystem.js` from PR #13 already implement the full tree-entity logic correctly. This PR only adds the two missing files.

## Verification

- `Game.js` import resolves correctly
- `TreeSystem` constructor accepts `(scene, terrain)` — matches `Game._initSystems()`  
- `Tree` exposes `.x`, `.z`, `.radius`, `.alive`, `.group`, `.takeDamage()` — matches `CollisionSystem._checkProjectileTreeCollisions()` and `_resolveTreeObstacleCollision()`

Ref #8