### PR TITLE
t013: Scoreboard UI — hold Tab shows all 12 tanks with HP/kills/damage/status

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,6 +372,159 @@
     @media (pointer: fine) {
       #touch-controls { display: none; }
     }
+
+    /* === Scoreboard overlay (t013) === */
+    .sb-overlay {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.72);
+      z-index: 50;
+      pointer-events: none;
+    }
+
+    .sb-hidden {
+      display: none;
+    }
+
+    .sb-panel {
+      background: rgba(10, 14, 20, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 10px;
+      padding: 20px 28px;
+      min-width: 680px;
+      max-width: 92vw;
+    }
+
+    .sb-title {
+      text-align: center;
+      color: #fff;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 3px;
+      text-transform: uppercase;
+      margin-bottom: 16px;
+      opacity: 0.9;
+    }
+
+    .sb-columns {
+      display: flex;
+      gap: 0;
+      align-items: flex-start;
+    }
+
+    .sb-team-block {
+      flex: 1;
+    }
+
+    .sb-divider {
+      width: 1px;
+      background: rgba(255, 255, 255, 0.12);
+      align-self: stretch;
+      margin: 0 18px;
+    }
+
+    .sb-team-header {
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      margin-bottom: 8px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .sb-green { color: #4caf50; }
+    .sb-red   { color: #f44336; }
+
+    .sb-col-labels,
+    .sb-row {
+      display: grid;
+      grid-template-columns: 72px 1fr 48px 64px 56px;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+
+    .sb-col-labels {
+      color: rgba(255, 255, 255, 0.4);
+      font-size: 10px;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin-bottom: 4px;
+    }
+
+    .sb-row {
+      color: #fff;
+      padding: 5px 0;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .sb-row-dead {
+      opacity: 0.4;
+    }
+
+    /* HP bar */
+    .sb-col-hp {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .sb-hp-bar-outer {
+      flex: 1;
+      height: 8px;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+
+    .sb-hp-bar-inner {
+      display: block;
+      height: 100%;
+      border-radius: 4px;
+      transition: width 0.1s, background 0.1s;
+    }
+
+    .sb-hp-num {
+      width: 26px;
+      text-align: right;
+      font-size: 11px;
+      color: rgba(255, 255, 255, 0.7);
+    }
+
+    /* Status badge */
+    .sb-status-alive {
+      color: #4caf50;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 1px;
+    }
+
+    .sb-status-dead {
+      color: #f44336;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 1px;
+    }
+
+    .sb-hint {
+      text-align: center;
+      color: rgba(255, 255, 255, 0.3);
+      font-size: 10px;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin-top: 14px;
+    }
+
+    @media (max-width: 720px) {
+      .sb-panel { min-width: 0; padding: 14px 12px; }
+      .sb-col-labels,
+      .sb-row { grid-template-columns: 56px 1fr 36px 52px 44px; font-size: 11px; gap: 4px; }
+      .sb-divider { margin: 0 10px; }
+    }
   </style>
 </head>
 <body>
@@ -410,7 +563,7 @@
   <div id="kill-feed"></div>
 
   <!-- Desktop hint -->
-  <div id="desktop-hint">WASD to move &middot; Mouse to aim &middot; Click to fire</div>
+  <div id="desktop-hint">WASD to move &middot; Mouse to aim &middot; Click to fire &middot; Tab = Scoreboard</div>
 
   <!-- PRE_ROUND: countdown before each round -->
   <div id="pre-round-overlay" class="match-overlay">

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -9,6 +9,7 @@ import { WreckSystem } from '../systems/WreckSystem.js';
 import { HUD } from '../ui/HUD.js';
 import { KillFeed } from '../ui/KillFeed.js';
 import { MatchOverlay } from '../ui/MatchOverlay.js';
+import { Scoreboard } from '../ui/Scoreboard.js';
 import { CameraController } from '../systems/CameraController.js';
 import { TeamManager } from './TeamManager.js';
 import { AIController } from '../systems/AIController.js';
@@ -168,6 +169,7 @@ export class Game {
 
     this.hud = new HUD();
     this.killFeed = new KillFeed();
+    this.scoreboard = new Scoreboard(this.teams);
 
     // MatchOverlay binds to DOM overlays in index.html.
     this.matchOverlay = new MatchOverlay(this);
@@ -190,10 +192,13 @@ export class Game {
     // Must run every frame regardless of combat state.
     this.match.update(dt);
 
+    // Snapshot input once per frame — getState() resets one-shot flags (fire).
+    const input = this.input.getState();
+
     // Gate all combat logic on an active round.
     if (this.match.isActive()) {
       // Player input
-      this._updatePlayer(dt);
+      this._updatePlayer(input, dt);
 
       // AIController: drives all ally (team 0, slots 1-5) and enemy AI tanks
       this.aiController.update(dt);
@@ -228,12 +233,17 @@ export class Game {
       ammo: this.player.ammo,
     });
 
+    // Scoreboard: show when Tab is held
+    this.scoreboard.update(input.tabHeld);
+
     this.renderer.render(this.scene, this.camera);
   }
 
-  _updatePlayer(dt) {
-    const input = this.input.getState();
-
+  /**
+   * @param {ReturnType<import('../systems/InputSystem.js').InputSystem['getState']>} input — pre-fetched this frame
+   * @param {number} dt
+   */
+  _updatePlayer(input, dt) {
     const moveSpeed = 12;
     const turnSpeed = 2.5;
 

--- a/src/entities/Projectile.js
+++ b/src/entities/Projectile.js
@@ -13,8 +13,18 @@ const ENEMY_MAT = new THREE.MeshStandardMaterial({
 });
 
 export class Projectile {
-  constructor({ position, direction, isPlayerOwned, speed = 50, damage = 25 }) {
+  /**
+   * @param {object} opts
+   * @param {import('three').Vector3} opts.position
+   * @param {import('three').Vector3} opts.direction
+   * @param {boolean} opts.isPlayerOwned
+   * @param {number} [opts.speed=50]
+   * @param {number} [opts.damage=25]
+   * @param {import('./Tank.js').Tank|null} [opts.ownerTank=null] — tank that fired this shell (for kill/damage attribution)
+   */
+  constructor({ position, direction, isPlayerOwned, speed = 50, damage = 25, ownerTank = null }) {
     this.isPlayerOwned = isPlayerOwned;
+    this.ownerTank = ownerTank;
     this.speed = speed;
     this.damage = damage;
     this.lifetime = 3; // seconds

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -26,6 +26,10 @@ export class Tank {
     this.fireCooldown = 0;
     this.fireRate = 0.3; // seconds between shots
 
+    // Per-round combat stats — displayed on the scoreboard (t013)
+    this.kills = 0;
+    this.damageDealt = 0;
+
     const base = isPlayer ? TANK_COLORS.player : TANK_COLORS.enemy;
     const palette = {
       body: color !== null ? color : base.body,
@@ -136,6 +140,7 @@ export class Tank {
       position: worldPos,
       direction: worldDir,
       isPlayerOwned: this.isPlayer,
+      ownerTank: this,
       speed: 50,
       damage: 25,
     });
@@ -143,6 +148,23 @@ export class Tank {
 
   takeDamage(amount) {
     this.health = Math.max(0, this.health - amount);
+  }
+
+  /**
+   * Record damage dealt by this tank against an opponent.
+   * Called by CollisionSystem when one of this tank's shells hits a target.
+   * @param {number} amount — actual HP removed (clamped to target's remaining HP)
+   */
+  recordDamage(amount) {
+    this.damageDealt += amount;
+  }
+
+  /**
+   * Record a kill credited to this tank.
+   * Called by CollisionSystem when this tank's shell destroys an opponent.
+   */
+  recordKill() {
+    this.kills++;
   }
 
   update(dt) {
@@ -155,5 +177,7 @@ export class Tank {
     this.health = this.maxHealth;
     this.ammo = 30;
     this.fireCooldown = 0;
+    this.kills = 0;
+    this.damageDealt = 0;
   }
 }

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -156,9 +156,13 @@ export class CollisionSystem {
         const dist = p.mesh.position.distanceTo(e.mesh.position);
         if (dist < 2.5) {
           const hitPos = p.mesh.position.clone();
+          // Record damage dealt before applying it (health may clamp to 0)
+          const actualDamage = Math.min(p.damage, e.health);
+          if (p.ownerTank) p.ownerTank.recordDamage(actualDamage);
           e.takeDamage(p.damage);
           this.projectiles.remove(i);
           if (e.health <= 0) {
+            if (p.ownerTank) p.ownerTank.recordKill();
             // Snapshot position+rotation before remove() clears the mesh from scene
             const tankData = {
               position: e.mesh.position.clone(),
@@ -184,9 +188,13 @@ export class CollisionSystem {
       const dist = p.mesh.position.distanceTo(player.mesh.position);
       if (dist < 2.5) {
         const hitPos = p.mesh.position.clone();
+        // Record damage dealt before applying it (health may clamp to 0)
+        const actualDamage = Math.min(p.damage, player.health);
+        if (p.ownerTank) p.ownerTank.recordDamage(actualDamage);
         player.takeDamage(p.damage);
         this.projectiles.remove(i);
         if (player.health <= 0) {
+          if (p.ownerTank) p.ownerTank.recordKill();
           const tankData = {
             position: player.mesh.position.clone(),
             rotationY: player.mesh.rotation.y,

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -30,6 +30,8 @@ export class InputSystem {
     window.addEventListener('keydown', (e) => {
       this._keys[e.code] = true;
       if (e.code === 'Space') this._fireRequested = true;
+      // Prevent Tab from shifting browser focus while held for the scoreboard
+      if (e.code === 'Tab') e.preventDefault();
     });
     window.addEventListener('keyup', (e) => {
       this._keys[e.code] = false;
@@ -141,6 +143,8 @@ export class InputSystem {
         (joyActive && jdx > deadzone),
       fire: this._fireRequested,
       turretAngle: this._turretAngle,
+      /** true while Tab is held — shows/hides the scoreboard overlay */
+      tabHeld: !!this._keys['Tab'],
     };
 
     // Reset one-shot inputs

--- a/src/ui/Scoreboard.js
+++ b/src/ui/Scoreboard.js
@@ -1,0 +1,175 @@
+/**
+ * Scoreboard — hold Tab to view all 12 tanks with HP, kills, damage, and status.
+ *
+ * Usage:
+ *   const scoreboard = new Scoreboard(teamManager);
+ *   // In the game loop, after reading input:
+ *   scoreboard.update(input.tabHeld);
+ *
+ * The component injects its own DOM element into document.body and manages
+ * visibility itself. No HTML template needed — built entirely in JS to keep
+ * the overlay self-contained and easy to tree-shake later.
+ */
+export class Scoreboard {
+  /**
+   * @param {import('../core/TeamManager.js').TeamManager} teamManager
+   */
+  constructor(teamManager) {
+    this._teams = teamManager;
+    this._visible = false;
+    this._el = null;
+    this._teamContainers = [];
+    this._build();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Call every frame with the current Tab-held state.
+   * Renders fresh data whenever the overlay is visible.
+   * @param {boolean} tabHeld
+   */
+  update(tabHeld) {
+    if (tabHeld && !this._visible) {
+      this._visible = true;
+      this._el.classList.remove('sb-hidden');
+    } else if (!tabHeld && this._visible) {
+      this._visible = false;
+      this._el.classList.add('sb-hidden');
+    }
+
+    if (this._visible) {
+      this._render();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: DOM construction
+  // ---------------------------------------------------------------------------
+
+  _build() {
+    const el = document.createElement('div');
+    el.id = 'scoreboard-overlay';
+    el.className = 'sb-overlay sb-hidden';
+    el.innerHTML = this._scaffoldHTML();
+    document.body.appendChild(el);
+
+    this._el = el;
+    this._teamContainers = [
+      el.querySelector('#sb-team-0'),
+      el.querySelector('#sb-team-1'),
+    ];
+  }
+
+  _scaffoldHTML() {
+    return `
+      <div class="sb-panel">
+        <div class="sb-title">SCOREBOARD</div>
+        <div class="sb-columns">
+          <div class="sb-team-block">
+            <div class="sb-team-header sb-green">YOUR TEAM</div>
+            <div class="sb-col-labels">
+              <span class="sb-col-name">Tank</span>
+              <span class="sb-col-hp">HP</span>
+              <span class="sb-col-kills">Kills</span>
+              <span class="sb-col-dmg">Damage</span>
+              <span class="sb-col-status">Status</span>
+            </div>
+            <div id="sb-team-0" class="sb-rows"></div>
+          </div>
+          <div class="sb-divider"></div>
+          <div class="sb-team-block">
+            <div class="sb-team-header sb-red">ENEMY TEAM</div>
+            <div class="sb-col-labels">
+              <span class="sb-col-name">Tank</span>
+              <span class="sb-col-hp">HP</span>
+              <span class="sb-col-kills">Kills</span>
+              <span class="sb-col-dmg">Damage</span>
+              <span class="sb-col-status">Status</span>
+            </div>
+            <div id="sb-team-1" class="sb-rows"></div>
+          </div>
+        </div>
+        <div class="sb-hint">Release Tab to close</div>
+      </div>
+    `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: rendering
+  // ---------------------------------------------------------------------------
+
+  _render() {
+    this._renderTeam(0);
+    this._renderTeam(1);
+  }
+
+  /**
+   * Rebuild the row HTML for one team.
+   * @param {number} teamId — 0 (player team) or 1 (enemy team)
+   */
+  _renderTeam(teamId) {
+    const container = this._teamContainers[teamId];
+    if (!container) return;
+
+    const slots = this._teams.teams[teamId].slots;
+    let html = '';
+
+    for (let i = 0; i < slots.length; i++) {
+      const slot = slots[i];
+      const tank = slot.tank;
+      const alive = slot.alive;
+
+      const label = this._tankLabel(teamId, i);
+      const hpPct = alive ? Math.max(0, (tank.health / tank.maxHealth) * 100) : 0;
+      const hpColor = this._hpColor(hpPct);
+      const hpText = alive ? Math.ceil(tank.health) : '0';
+      const rowClass = alive ? 'sb-row' : 'sb-row sb-row-dead';
+      const statusClass = alive ? 'sb-status-alive' : 'sb-status-dead';
+      const statusText = alive ? 'ALIVE' : 'DESTR';
+
+      html += `
+        <div class="${rowClass}">
+          <span class="sb-col-name">${label}</span>
+          <span class="sb-col-hp">
+            <span class="sb-hp-bar-outer">
+              <span class="sb-hp-bar-inner" style="width:${hpPct.toFixed(1)}%;background:${hpColor}"></span>
+            </span>
+            <span class="sb-hp-num">${hpText}</span>
+          </span>
+          <span class="sb-col-kills">${tank.kills}</span>
+          <span class="sb-col-dmg">${tank.damageDealt}</span>
+          <span class="sb-col-status ${statusClass}">${statusText}</span>
+        </div>
+      `;
+    }
+
+    container.innerHTML = html;
+  }
+
+  /**
+   * Human-readable label for a tank slot.
+   * @param {number} teamId
+   * @param {number} slotIndex
+   * @returns {string}
+   */
+  _tankLabel(teamId, slotIndex) {
+    if (teamId === 0) {
+      return slotIndex === 0 ? 'You' : `Ally ${slotIndex}`;
+    }
+    return `Enemy ${slotIndex + 1}`;
+  }
+
+  /**
+   * CSS color string for an HP bar based on percentage.
+   * @param {number} pct — 0..100
+   * @returns {string}
+   */
+  _hpColor(pct) {
+    if (pct > 50) return '#4caf50';
+    if (pct > 25) return '#ff9800';
+    return '#f44336';
+  }
+}


### PR DESCRIPTION
## Summary

Implements the in-match scoreboard (t013, GH#19): hold **Tab** to view all 12 tanks in a two-column overlay (your team | enemy team), each row showing HP bar, kills, damage dealt, and alive/dead status.

## Changes

| File | What changed |
|------|-------------|
| `src/ui/Scoreboard.js` | New component — DOM overlay, renders on `update(tabHeld)` |
| `src/entities/Tank.js` | Added `kills`, `damageDealt` stats + `recordDamage()`, `recordKill()` methods; reset in `tank.reset()` |
| `src/entities/Projectile.js` | Added `ownerTank` field for kill/damage attribution |
| `src/systems/CollisionSystem.js` | Calls `ownerTank.recordDamage(actualDamage)` and `ownerTank.recordKill()` on shell impacts |
| `src/systems/InputSystem.js` | Adds `tabHeld` to `getState()`; `preventDefault()` on Tab to block browser focus-shift |
| `src/core/Game.js` | Imports `Scoreboard`, snapshots input once per frame (eliminates double-call of `getState()`), passes `input.tabHeld` to `scoreboard.update()` |
| `index.html` | Scoreboard CSS (two-column grid, HP bars, status badges); desktop hint updated |

## Design

- Two-column layout: **YOUR TEAM** (green header) / **ENEMY TEAM** (red header)
- Each row: tank label | HP bar + number | kills | damage | ALIVE / DESTR badge
- Dead rows dim to 40% opacity; HP bars collapse to zero
- Stats are per-round (reset when `tank.reset()` is called by MatchManager)
- Mobile: `@media (max-width: 720px)` narrows column widths for smaller screens

## Verification

```
npm run dev
# In-browser: hold Tab — overlay appears with 12 rows (6 green + 6 red)
# Shoot enemies — player's damage/kill counts update on the scoreboard
# Release Tab — overlay hides
```

Resolves #19