### PR TITLE
t012: KillFeed UI — top-right destruction messages, auto-fade, stack limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,57 @@
       transform: scale(0.96);
     }
 
+    /* === Kill Feed === */
+    #kill-feed {
+      position: fixed;
+      top: 70px;
+      right: 16px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 4px;
+      pointer-events: none;
+      z-index: 10;
+      max-width: 280px;
+    }
+
+    .kf-entry {
+      background: rgba(0, 0, 0, 0.55);
+      border-left: 2px solid rgba(255, 255, 255, 0.25);
+      padding: 4px 10px;
+      border-radius: 3px;
+      font-size: 13px;
+      font-weight: 600;
+      text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.9);
+      opacity: 1;
+      transition: opacity 0.5s ease;
+      white-space: nowrap;
+    }
+
+    .kf-entry.kf-fading {
+      opacity: 0;
+    }
+
+    /* Player / ally names — green */
+    .kf-player {
+      color: #4cff80;
+    }
+
+    /* Enemy names — red */
+    .kf-enemy {
+      color: #ff5050;
+    }
+
+    /* Fallback — white */
+    .kf-neutral {
+      color: #ffffff;
+    }
+
+    .kf-verb {
+      color: rgba(255, 255, 255, 0.65);
+      font-weight: 400;
+    }
+
     /* Desktop instructions */
     #desktop-hint {
       position: fixed;
@@ -225,6 +276,9 @@
     </div>
     <div class="fire-button">FIRE</div>
   </div>
+
+  <!-- Kill Feed -->
+  <div id="kill-feed"></div>
 
   <!-- Desktop hint -->
   <div id="desktop-hint">WASD to move &middot; Mouse to aim &middot; Click to fire</div>

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -7,6 +7,7 @@ import { ParticleSystem } from '../systems/ParticleSystem.js';
 import { TreeSystem } from '../systems/TreeSystem.js';
 import { WreckSystem } from '../systems/WreckSystem.js';
 import { HUD } from '../ui/HUD.js';
+import { KillFeed } from '../ui/KillFeed.js';
 import { CameraController } from '../systems/CameraController.js';
 import { TeamManager } from './TeamManager.js';
 import { AIController } from '../systems/AIController.js';
@@ -132,6 +133,9 @@ export class Game {
       .onTreeDestroy((pos) => {
         // Full debris burst when tree is felled
         this.particles.emitTreeDebris(pos);
+      })
+      .onKillFeed((killer, victim) => {
+        this.killFeed.addMessage(killer, victim);
       });
 
     // Notify on team elimination (will be consumed by MatchManager in t008)
@@ -149,6 +153,7 @@ export class Game {
     );
 
     this.hud = new HUD();
+    this.killFeed = new KillFeed();
   }
 
   start() {
@@ -266,6 +271,7 @@ export class Game {
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
     this.hud.hideGameOver();
+    this.killFeed.clear();
     this.start();
   }
 

--- a/src/core/TeamManager.js
+++ b/src/core/TeamManager.js
@@ -195,6 +195,7 @@ export class TeamManager {
         color: TEAM_COLORS[0].body,
         turretColor: TEAM_COLORS[0].turret,
         teamId: 0,
+        name: isPlayer ? 'Player' : `Ally ${i}`,
       });
 
       const pos = this._spawnPosition(i, 0);
@@ -218,6 +219,7 @@ export class TeamManager {
         color: TEAM_COLORS[1].body,
         turretColor: TEAM_COLORS[1].turret,
         teamId: 1,
+        name: `Enemy #${i + 1}`,
       });
 
       const pos = this._spawnPosition(i, 1);

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -13,10 +13,13 @@ export class Tank {
    * @param {number|null} [opts.color=null]       — override hull color (hex int)
    * @param {number|null} [opts.turretColor=null] — override turret color (hex int)
    * @param {number} [opts.teamId=1]              — 0 = player team, 1 = enemy team
+   * @param {string} [opts.name='']               — display name shown in kill feed
    */
-  constructor({ isPlayer = false, color = null, turretColor = null, teamId = 1 } = {}) {
+  constructor({ isPlayer = false, color = null, turretColor = null, teamId = 1, name = '' } = {}) {
     this.isPlayer = isPlayer;
     this.teamId = teamId;
+    /** @type {string} Display name for kill feed messages (e.g. 'Player', 'Enemy #2'). */
+    this.name = name || (isPlayer ? 'Player' : 'Enemy');
     this.health = 100;
     this.maxHealth = 100;
     this.ammo = 30;

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -21,6 +21,9 @@
  *    tankData: { position: Vector3, rotationY: number } — snapshot for wreck spawning
  *  onTreeHit(position)     — called on every non-lethal shell hit on a tree
  *  onTreeDestroy(position) — called when a shell destroys a tree
+ *  onKillFeed(killer, victim) — called on every tank kill for the kill feed UI
+ *    killer: display name of the entity that scored the kill ('Player', 'Enemy #2', …)
+ *    victim: display name of the destroyed tank
  */
 export class CollisionSystem {
   /**
@@ -46,6 +49,7 @@ export class CollisionSystem {
     this._onKill = null;
     this._onTreeHit = null;
     this._onTreeDestroy = null;
+    this._onKillFeed = null;
 
     /**
      * Approximate half-width of a tank hull for obstacle push-back.
@@ -115,6 +119,15 @@ export class CollisionSystem {
     return this;
   }
 
+  /**
+   * Called once per tank kill with display names for the kill feed.
+   * @param {(killer: string, victim: string) => void} cb
+   */
+  onKillFeed(cb) {
+    this._onKillFeed = cb;
+    return this;
+  }
+
   // ---------------------------------------------------------------------------
   // Per-frame entry point
   // ---------------------------------------------------------------------------
@@ -151,6 +164,7 @@ export class CollisionSystem {
               position: e.mesh.position.clone(),
               rotationY: e.mesh.rotation.y,
             };
+            if (this._onKillFeed) this._onKillFeed(this.player.name || 'Player', e.name || 'Enemy');
             this.enemies.remove(j);
             if (this._onKill) this._onKill(hitPos, 'player', tankData);
             if (this._onScoreAdd) this._onScoreAdd(100);
@@ -177,6 +191,7 @@ export class CollisionSystem {
             position: player.mesh.position.clone(),
             rotationY: player.mesh.rotation.y,
           };
+          if (this._onKillFeed) this._onKillFeed('Enemy', player.name || 'Player');
           if (this._onKill) this._onKill(hitPos, 'enemy', tankData);
           if (this._onPlayerDeath) this._onPlayerDeath();
         } else {

--- a/src/ui/KillFeed.js
+++ b/src/ui/KillFeed.js
@@ -1,0 +1,106 @@
+/**
+ * KillFeed — top-right corner overlay showing destruction messages.
+ *
+ * Usage:
+ *   const kf = new KillFeed();
+ *   kf.addMessage('Player', 'Enemy #3');  // → "Player destroyed Enemy #3"
+ *
+ * Features:
+ *   - Auto-fades each entry after FADE_DELAY ms.
+ *   - Caps the visible stack at MAX_MESSAGES; oldest entry removed first.
+ *   - Color-coded: player names in green, enemy names in red.
+ *   - clear() removes all entries (call on round reset).
+ *
+ * Requires a <div id="kill-feed"> in the HTML document.
+ */
+
+const MAX_MESSAGES = 5;
+const FADE_DELAY = 3000;    // ms visible before fade begins
+const FADE_DURATION = 500;  // ms for the CSS opacity transition
+
+export class KillFeed {
+  constructor() {
+    this.el = document.getElementById('kill-feed');
+    /** @type {number[]} setTimeout IDs so clear() can cancel pending fades. */
+    this._timers = [];
+  }
+
+  /**
+   * Add a destruction message to the feed.
+   *
+   * @param {string} killer — display name of the entity that scored the kill
+   *   (e.g. 'Player', 'Enemy #2', 'Ally 3')
+   * @param {string} victim — display name of the destroyed entity
+   */
+  addMessage(killer, victim) {
+    if (!this.el) return;
+
+    // Enforce stack cap — remove oldest entry if already at limit
+    const entries = this.el.querySelectorAll('.kf-entry');
+    if (entries.length >= MAX_MESSAGES) {
+      entries[0].remove();
+    }
+
+    // Build entry element
+    const entry = document.createElement('div');
+    entry.className = 'kf-entry';
+
+    const killerSpan = document.createElement('span');
+    killerSpan.className = _nameClass(killer);
+    killerSpan.textContent = killer;
+
+    const verbSpan = document.createElement('span');
+    verbSpan.className = 'kf-verb';
+    verbSpan.textContent = ' destroyed ';
+
+    const victimSpan = document.createElement('span');
+    victimSpan.className = _nameClass(victim);
+    victimSpan.textContent = victim;
+
+    entry.appendChild(killerSpan);
+    entry.appendChild(verbSpan);
+    entry.appendChild(victimSpan);
+    this.el.appendChild(entry);
+
+    // Schedule fade-out then removal
+    const faderId = setTimeout(() => {
+      entry.classList.add('kf-fading');
+      setTimeout(() => entry.remove(), FADE_DURATION);
+    }, FADE_DELAY);
+
+    this._timers.push(faderId);
+  }
+
+  /**
+   * Remove all messages and cancel pending fade timers.
+   * Call on round reset.
+   */
+  clear() {
+    for (const id of this._timers) {
+      clearTimeout(id);
+    }
+    this._timers = [];
+    if (this.el) this.el.innerHTML = '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a display name to the appropriate CSS class for colour-coding.
+ *
+ * 'Player'       → green  (kf-player)
+ * 'Ally …'       → green  (kf-player)
+ * 'Enemy …'      → red    (kf-enemy)
+ * anything else  → white  (kf-neutral)
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function _nameClass(name) {
+  if (name === 'Player' || name.startsWith('Ally')) return 'kf-player';
+  if (name.startsWith('Enemy')) return 'kf-enemy';
+  return 'kf-neutral';
+}


### PR DESCRIPTION
## Summary

- **`src/ui/KillFeed.js`** — new class: DOM overlay in top-right corner, stacks up to 5 messages, each auto-fades after 3s via CSS `opacity` transition, clear() on round reset
- **`index.html`** — kill feed CSS (positioned below HUD score, green for player/ally names, red for enemy names) and `<div id="kill-feed">` container
- **`src/entities/Tank.js`** — added `name` option to constructor; defaults to `'Player'` or `'Enemy'`
- **`src/core/TeamManager.js`** — sets tank names: `'Player'`, `'Ally 1'`…`'Ally 5'`, `'Enemy #1'`…`'Enemy #6'`
- **`src/systems/CollisionSystem.js`** — added `onKillFeed(killer, victim)` callback (fluent setter pattern matching existing callbacks); fires on every tank kill with display names
- **`src/core/Game.js`** — imports KillFeed, instantiates after HUD, chains `.onKillFeed()` onto collision setup, calls `killFeed.clear()` on restart

## Verification

- `npm run build` passes (20 modules, 0 errors)
- Kill messages appear top-right when a tank is destroyed
- Messages color-code killer/victim (green=player/ally, red=enemy)
- Messages auto-disappear after 3 seconds
- No more than 5 messages visible at once (oldest dropped)
- Feed clears on game restart

Resolves #18