### PR TITLE
t008: MatchManager — best-of-3 state machine

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,130 @@
       letter-spacing: 1px;
     }
 
-    /* === Game Over === */
+    /* === Match overlays (PRE_ROUND, ROUND_END, MATCH_END) === */
+    .match-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.72);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 100;
+      pointer-events: none;
+    }
+
+    .match-overlay.hidden {
+      display: none;
+    }
+
+    /* Enable pointer events only on the match-end overlay (has a button) */
+    #match-end-overlay {
+      pointer-events: auto;
+    }
+
+    .match-overlay-inner {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 14px;
+      text-align: center;
+    }
+
+    .round-badge {
+      color: #fff;
+      font-size: 36px;
+      font-weight: 900;
+      text-transform: uppercase;
+      letter-spacing: 3px;
+      text-shadow: 2px 2px 8px rgba(0,0,0,0.8);
+    }
+
+    .round-score-display {
+      color: rgba(255,255,255,0.85);
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: 6px;
+    }
+
+    .round-countdown {
+      color: rgba(255,255,255,0.6);
+      font-size: 16px;
+      letter-spacing: 1px;
+    }
+
+    .match-result-title {
+      font-size: 56px;
+      font-weight: 900;
+      text-transform: uppercase;
+      letter-spacing: 4px;
+    }
+
+    #match-restart-btn {
+      margin-top: 8px;
+      padding: 14px 40px;
+      font-size: 18px;
+      font-weight: 700;
+      color: #fff;
+      background: #4caf50;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    #match-restart-btn:active {
+      background: #388e3c;
+      transform: scale(0.96);
+    }
+
+    /* === Round indicator (HUD top centre) === */
+    #round-indicator {
+      position: fixed;
+      top: 12px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 4px;
+      pointer-events: none;
+      z-index: 11;
+    }
+
+    #round-label {
+      color: rgba(255,255,255,0.75);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      text-shadow: 1px 1px 3px rgba(0,0,0,0.8);
+    }
+
+    .round-pips {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .pip {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      border: 2px solid rgba(255,255,255,0.5);
+      background: transparent;
+    }
+
+    .pip-team0.won { background: #4caf50; border-color: #4caf50; }
+    .pip-team1.won { background: #f44336; border-color: #f44336; }
+
+    .pip-sep {
+      color: rgba(255,255,255,0.5);
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    /* === Legacy Game Over (hidden — MatchOverlay handles all end states) === */
     #game-over {
       position: fixed;
       inset: 0;
@@ -226,10 +349,43 @@
     <div class="fire-button">FIRE</div>
   </div>
 
+  <!-- Round indicator (HUD top centre — shows round number and win pips) -->
+  <div id="round-indicator">
+    <div id="round-label">Round 1</div>
+    <div id="round-pips" class="round-pips"></div>
+  </div>
+
   <!-- Desktop hint -->
   <div id="desktop-hint">WASD to move &middot; Mouse to aim &middot; Click to fire</div>
 
-  <!-- Game Over -->
+  <!-- PRE_ROUND: countdown before each round -->
+  <div id="pre-round-overlay" class="match-overlay">
+    <div class="match-overlay-inner">
+      <div class="round-badge">Round <span id="pre-round-number">1</span></div>
+      <div class="round-score-display" id="pre-round-score">0 &mdash; 0</div>
+      <div class="round-countdown">Starting in <span id="pre-round-timer">3</span>&hellip;</div>
+    </div>
+  </div>
+
+  <!-- ROUND_END: result + countdown to next round -->
+  <div id="round-end-overlay" class="match-overlay hidden">
+    <div class="match-overlay-inner">
+      <div class="round-badge" id="round-end-title">GREEN TEAM WINS ROUND 1</div>
+      <div class="round-score-display" id="round-end-score">1 &mdash; 0</div>
+      <div class="round-countdown">Next round in <span id="round-end-timer">5</span>&hellip;</div>
+    </div>
+  </div>
+
+  <!-- MATCH_END: final result + play again -->
+  <div id="match-end-overlay" class="match-overlay hidden">
+    <div class="match-overlay-inner">
+      <div class="match-result-title" id="match-result-title">VICTORY!</div>
+      <div class="round-score-display" id="match-end-score">2 &mdash; 0</div>
+      <button id="match-restart-btn">Play Again</button>
+    </div>
+  </div>
+
+  <!-- Legacy Game Over (kept for HUD.js compatibility, hidden during normal play) -->
   <div id="game-over" class="hidden">
     <h1>DESTROYED</h1>
     <div class="score-line">Score: <span id="final-score">0</span></div>

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -6,8 +6,10 @@ import { CollisionSystem } from '../systems/CollisionSystem.js';
 import { ParticleSystem } from '../systems/ParticleSystem.js';
 import { TreeSystem } from '../systems/TreeSystem.js';
 import { HUD } from '../ui/HUD.js';
+import { MatchOverlay } from '../ui/MatchOverlay.js';
 import { CameraController } from '../systems/CameraController.js';
 import { TeamManager } from './TeamManager.js';
+import { MatchManager } from './MatchManager.js';
 
 // Simple AI constants (temporary — will be replaced by AIController in t007)
 const AI_AGGRO_RANGE = 50;
@@ -115,7 +117,7 @@ export class Game {
 
     this.collision
       .onScoreAdd(pts => { this.score += pts; })
-      .onPlayerDeath(() => this._gameOver())
+      .onPlayerDeath(() => this._onPlayerTankDestroyed())
       .onHit((pos) => {
         this.particles.emitExplosion(pos, { count: 15, speed: 6, lifetime: 0.6 });
       })
@@ -131,13 +133,28 @@ export class Game {
         this.particles.emitTreeDebris(pos);
       });
 
-    // Notify on team elimination (will be consumed by MatchManager in t008)
-    this.teams.onTeamEliminated((teamId) => {
-      const winner = teamId === 1 ? 'Player Team' : 'Enemy Team';
-      console.info(`[TeamManager] Team ${teamId} eliminated — ${winner} wins the round.`);
-    });
+    // MatchManager drives the best-of-3 state machine.
+    // It registers its own onTeamEliminated hook with TeamManager internally.
+    this.match = new MatchManager(this.teams);
+    this.match
+      .onRoundReset(() => {
+        // Clear mid-round objects between rounds.
+        this.projectiles.reset();
+        this.particles.reset();
+        this._playerDustTimer = 0;
+        this._enemyDustTimer = 0;
+      })
+      .onMatchEnd((winnerId) => {
+        const playerWon = winnerId === 0;
+        console.info(`[Game] Match over — ${playerWon ? 'Player' : 'Enemy'} team wins!`);
+        // MatchOverlay handles showing the overlay; no extra action needed here.
+      });
 
     this.hud = new HUD();
+
+    // MatchOverlay binds to DOM overlays in index.html.
+    this.matchOverlay = new MatchOverlay(this);
+    this.match.onUIUpdate(ui => this.matchOverlay.update(ui));
   }
 
   start() {
@@ -152,34 +169,43 @@ export class Game {
 
     const dt = Math.min(this.clock.getDelta(), 0.05);
 
-    // Player input
-    this._updatePlayer(dt);
+    // MatchManager drives PRE_ROUND countdowns and ROUND_END timers.
+    // Must run every frame regardless of combat state.
+    this.match.update(dt);
 
-    // Temporary AI for enemy tanks (replaced by AIController in t007)
-    this._updateEnemyAI(dt);
+    // Gate all combat logic on an active round.
+    if (this.match.isActive()) {
+      // Player input
+      this._updatePlayer(dt);
 
-    // Ally AI placeholder — friendly tanks hold position for now
-    // (AIController in t007 will add proper target-selection for allies too)
+      // Temporary AI for enemy tanks (replaced by AIController in t007)
+      this._updateEnemyAI(dt);
 
-    // Update each alive tank's fire cooldown
-    for (const tank of this.teams.getAllLivingTanks()) {
-      tank.update(dt);
-    }
+      // Ally AI placeholder — friendly tanks hold position for now
+      // (AIController in t007 will add proper target-selection for allies too)
 
-    // Systems
-    this.projectiles.update(dt);
-    this.particles.update(dt);
-    this.cameraController.update(dt);
-    this.collision.update();
+      // Update each alive tank's fire cooldown
+      for (const tank of this.teams.getAllLivingTanks()) {
+        tank.update(dt);
+      }
 
-    // Dust trails for living enemy tanks
-    this._enemyDustTimer -= dt;
-    if (this._enemyDustTimer <= 0) {
-      this._enemyDustTimer = 0.15;
-      for (const tank of this.teams.getEnemyTanks()) {
-        this.particles.emitDust(tank.mesh.position);
+      // Collision and projectile systems
+      this.projectiles.update(dt);
+      this.collision.update();
+
+      // Dust trails for living enemy tanks
+      this._enemyDustTimer -= dt;
+      if (this._enemyDustTimer <= 0) {
+        this._enemyDustTimer = 0.15;
+        for (const tank of this.teams.getEnemyTanks()) {
+          this.particles.emitDust(tank.mesh.position);
+        }
       }
     }
+
+    // Particles and camera update every frame (explosions fade out during overlays).
+    this.particles.update(dt);
+    this.cameraController.update(dt);
 
     // HUD
     this.hud.update({
@@ -296,21 +322,38 @@ export class Game {
     }
   }
 
-  _gameOver() {
-    this.isRunning = false;
-    this.hud.showGameOver(this.score);
+  /**
+   * Called by CollisionSystem when the player's tank HP reaches 0.
+   * The player is still "in" the round — the tank is marked dead via TeamManager
+   * (CollisionSystem calls teams.killTank internally), which may trigger
+   * onTeamEliminated → MatchManager handles round/match end.
+   * Here we just ensure the camera detaches gracefully.
+   */
+  _onPlayerTankDestroyed() {
+    // Camera continues to follow the mesh position (now a wreck).
+    // MatchOverlay handles the ROUND_END / MATCH_END display.
+    console.info('[Game] Player tank destroyed.');
   }
 
+  /**
+   * Full match restart — resets the state machine and all subsystems.
+   * Called by the "Play Again" button in MatchOverlay.
+   */
   restart() {
     this.score = 0;
+    // Reset match state machine first (no team events should fire during reset)
+    this.match.reset();
+    // Reset field entities
     this.teams.reset();
     this.projectiles.reset();
     this.particles.reset();
     this.trees.reset();
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
-    this.hud.hideGameOver();
-    this.start();
+    // Ensure game loop is running
+    if (!this.isRunning) {
+      this.start();
+    }
   }
 
   _onResize() {

--- a/src/core/MatchManager.js
+++ b/src/core/MatchManager.js
@@ -1,0 +1,308 @@
+/**
+ * MatchManager — best-of-3 round state machine.
+ *
+ * State transitions:
+ *
+ *   PRE_ROUND (3 s countdown)
+ *       │  timer expires
+ *       ▼
+ *     ACTIVE  ←─────────────────────────────┐
+ *       │  one team eliminated              │
+ *       ▼                                   │
+ *   ROUND_END (5 s result screen)           │
+ *       │  timer expires                    │
+ *       ├─ a team has 2 wins ──→  MATCH_END │
+ *       └─ match continues ──────────────────┘
+ *
+ * Integration (Game.js):
+ *
+ *   this.match = new MatchManager(this.teams);
+ *   this.match
+ *     .onRoundReset(() => { projectiles.reset(); particles.reset(); })
+ *     .onMatchEnd((winnerId) => { ... });
+ *   // in game loop:
+ *   this.match.update(dt);
+ *   if (!this.match.isActive()) return; // skip combat during overlays
+ */
+
+export const MatchState = Object.freeze({
+  PRE_ROUND:  'PRE_ROUND',
+  ACTIVE:     'ACTIVE',
+  ROUND_END:  'ROUND_END',
+  MATCH_END:  'MATCH_END',
+});
+
+/** Seconds shown on the "ROUND X STARTING IN …" overlay. */
+const PRE_ROUND_DURATION = 3;
+/** Seconds shown on the "ROUND OVER" result screen before advancing. */
+const ROUND_END_DURATION = 5;
+/** Best-of-this-many rounds: first to ceil(MAX_ROUNDS / 2) wins. */
+const MAX_ROUNDS = 3;
+const WINS_NEEDED = Math.ceil(MAX_ROUNDS / 2); // 2
+
+export class MatchManager {
+  /**
+   * @param {import('./TeamManager.js').TeamManager} teams
+   */
+  constructor(teams) {
+    this.teams = teams;
+
+    /** @type {string} */
+    this.state = MatchState.PRE_ROUND;
+    /** Seconds remaining in the current timed phase. */
+    this.stateTimer = PRE_ROUND_DURATION;
+    /** 1-indexed round counter (max MAX_ROUNDS). */
+    this.roundNumber = 1;
+    /** [team0Wins, team1Wins] */
+    this.roundWins = [0, 0];
+    /** Which team won the most recent round (-1 = none yet). */
+    this.lastRoundWinnerId = -1;
+    /** Which team won the overall match (-1 = undecided). */
+    this.matchWinnerId = -1;
+
+    /** @private @type {(() => void) | null} */
+    this._onRoundStartCb = null;
+    /** @private @type {(() => void) | null} */
+    this._onRoundResetCb = null;
+    /** @private @type {((winnerId: number) => void) | null} */
+    this._onMatchEndCb = null;
+    /** @private @type {((ui: MatchUIState) => void) | null} */
+    this._onUIUpdateCb = null;
+
+    // Wire into TeamManager — fired when ALL tanks on a team are dead.
+    this.teams.onTeamEliminated((teamId) => this._handleTeamEliminated(teamId));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * True only while a round is actively in progress.
+   * Game.js uses this to gate player input and AI updates.
+   * @returns {boolean}
+   */
+  isActive() {
+    return this.state === MatchState.ACTIVE;
+  }
+
+  /** @returns {string} One of the MatchState constants. */
+  getState() {
+    return this.state;
+  }
+
+  /**
+   * Drive the state machine forward. Call once per frame from the game loop.
+   * @param {number} dt - Delta time in seconds.
+   */
+  update(dt) {
+    switch (this.state) {
+      case MatchState.PRE_ROUND:
+        this._tickPreRound(dt);
+        break;
+      case MatchState.ROUND_END:
+        this._tickRoundEnd(dt);
+        break;
+      case MatchState.ACTIVE:
+      case MatchState.MATCH_END:
+        // No timer-driven transitions in these states.
+        break;
+    }
+
+    this._emitUI();
+  }
+
+  /**
+   * Register a callback fired when a new round's combat begins (PRE_ROUND → ACTIVE).
+   * Also triggered for the very first round when the timer expires.
+   * @param {() => void} cb
+   * @returns {this}
+   */
+  onRoundStart(cb) {
+    this._onRoundStartCb = cb;
+    return this;
+  }
+
+  /**
+   * Register a callback fired when a completed round is being reset for the next one.
+   * Use this to clear projectiles, particles, wrecks, etc.
+   * Fires before the PRE_ROUND countdown starts for rounds 2 and 3.
+   * @param {() => void} cb
+   * @returns {this}
+   */
+  onRoundReset(cb) {
+    this._onRoundResetCb = cb;
+    return this;
+  }
+
+  /**
+   * Register a callback fired when the match reaches MATCH_END.
+   * @param {(winnerId: number) => void} cb - winnerId: 0 = player team, 1 = enemy team.
+   * @returns {this}
+   */
+  onMatchEnd(cb) {
+    this._onMatchEndCb = cb;
+    return this;
+  }
+
+  /**
+   * Register a UI update callback — called every frame with the current overlay state.
+   * Use MatchOverlay.js to bind this to DOM overlays.
+   * @param {(ui: MatchUIState) => void} cb
+   * @returns {this}
+   */
+  onUIUpdate(cb) {
+    this._onUIUpdateCb = cb;
+    return this;
+  }
+
+  /**
+   * Reset the match to the initial state (all rounds, win counts cleared).
+   * Called by Game.restart().
+   */
+  reset() {
+    this.state = MatchState.PRE_ROUND;
+    this.stateTimer = PRE_ROUND_DURATION;
+    this.roundNumber = 1;
+    this.roundWins = [0, 0];
+    this.lastRoundWinnerId = -1;
+    this.matchWinnerId = -1;
+    // teams.reset() is the caller's responsibility (already done in Game.restart)
+  }
+
+  // ---------------------------------------------------------------------------
+  // State transitions
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _tickPreRound(dt) {
+    this.stateTimer -= dt;
+    if (this.stateTimer <= 0) {
+      this._enterActive();
+    }
+  }
+
+  /** @private */
+  _tickRoundEnd(dt) {
+    this.stateTimer -= dt;
+    if (this.stateTimer <= 0) {
+      this._prepareNextRound();
+    }
+  }
+
+  /**
+   * Called by the TeamManager `onTeamEliminated` hook.
+   * @private
+   * @param {number} teamId - The team that was wiped out.
+   */
+  _handleTeamEliminated(teamId) {
+    if (this.state !== MatchState.ACTIVE) {
+      // Guard: ignore spurious callbacks during non-combat phases.
+      return;
+    }
+
+    // The eliminated team *lost* — the other team wins this round.
+    const winnerId = teamId === 0 ? 1 : 0;
+    this.lastRoundWinnerId = winnerId;
+    this.roundWins[winnerId]++;
+
+    console.info(
+      `[MatchManager] Round ${this.roundNumber} complete — team ${winnerId} wins the round. ` +
+      `Match score: ${this.roundWins[0]}-${this.roundWins[1]} ` +
+      `(need ${WINS_NEEDED} to win match)`
+    );
+
+    if (this.roundWins[winnerId] >= WINS_NEEDED) {
+      this._enterMatchEnd(winnerId);
+    } else {
+      this._enterRoundEnd();
+    }
+  }
+
+  /** @private PRE_ROUND → ACTIVE */
+  _enterActive() {
+    this.state = MatchState.ACTIVE;
+    this.stateTimer = 0;
+    if (this._onRoundStartCb) {
+      this._onRoundStartCb();
+    }
+    console.info(`[MatchManager] Round ${this.roundNumber} — ACTIVE`);
+  }
+
+  /** @private ACTIVE → ROUND_END */
+  _enterRoundEnd() {
+    this.state = MatchState.ROUND_END;
+    this.stateTimer = ROUND_END_DURATION;
+    console.info(`[MatchManager] Round ${this.roundNumber} — ROUND_END`);
+  }
+
+  /** @private ACTIVE → MATCH_END */
+  _enterMatchEnd(winnerId) {
+    this.state = MatchState.MATCH_END;
+    this.matchWinnerId = winnerId;
+    this.stateTimer = 0;
+    console.info(
+      `[MatchManager] MATCH_END — team ${winnerId} wins the match ` +
+      `(${this.roundWins[0]}-${this.roundWins[1]})`
+    );
+    if (this._onMatchEndCb) {
+      this._onMatchEndCb(winnerId);
+    }
+  }
+
+  /**
+   * Advance to the next round: reset the field, enter PRE_ROUND.
+   * @private ROUND_END → PRE_ROUND
+   */
+  _prepareNextRound() {
+    this.roundNumber++;
+
+    // Notify Game.js to clear projectiles, particles, etc.
+    if (this._onRoundResetCb) {
+      this._onRoundResetCb();
+    }
+
+    // Put all tanks back at full HP with starting positions.
+    this.teams.reset();
+
+    this.state = MatchState.PRE_ROUND;
+    this.stateTimer = PRE_ROUND_DURATION;
+    console.info(`[MatchManager] Preparing round ${this.roundNumber} — PRE_ROUND`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // UI emission
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Push current overlay data to the registered UI callback each frame.
+   * @private
+   */
+  _emitUI() {
+    if (!this._onUIUpdateCb) {
+      return;
+    }
+
+    /** @type {MatchUIState} */
+    const ui = {
+      state:         this.state,
+      round:         this.roundNumber,
+      roundWins:     [...this.roundWins],
+      timer:         Math.ceil(this.stateTimer),
+      roundWinnerId: this.lastRoundWinnerId,
+      matchWinnerId: this.matchWinnerId,
+    };
+
+    this._onUIUpdateCb(ui);
+  }
+}
+
+/**
+ * @typedef {Object} MatchUIState
+ * @property {string}   state         - Current MatchState value.
+ * @property {number}   round         - Current round number (1–3).
+ * @property {number[]} roundWins     - [team0Wins, team1Wins].
+ * @property {number}   timer         - Ceiling of stateTimer (0 during ACTIVE/MATCH_END).
+ * @property {number}   roundWinnerId - Which team won the last round (-1 = none).
+ * @property {number}   matchWinnerId - Which team won the match (-1 = undecided).
+ */

--- a/src/ui/MatchOverlay.js
+++ b/src/ui/MatchOverlay.js
@@ -1,0 +1,187 @@
+import { MatchState } from '../core/MatchManager.js';
+
+/**
+ * MatchOverlay — manages the three DOM overlays driven by MatchManager.
+ *
+ * Overlays (must exist in index.html):
+ *   #pre-round-overlay   — PRE_ROUND countdown
+ *   #round-end-overlay   — ROUND_END result + next-round countdown
+ *   #match-end-overlay   — MATCH_END winner screen
+ *
+ * Bind to MatchManager via:
+ *   const overlay = new MatchOverlay(game);
+ *   game.match.onUIUpdate(ui => overlay.update(ui));
+ *
+ * The round pip row in the HUD top-centre is also updated here.
+ */
+
+const TEAM_NAMES = ['GREEN TEAM', 'RED TEAM'];
+
+export class MatchOverlay {
+  /**
+   * @param {import('../core/Game.js').Game} game - Used for the restart handler.
+   */
+  constructor(game) {
+    this.game = game;
+
+    // PRE_ROUND overlay
+    this._preRoundEl     = document.getElementById('pre-round-overlay');
+    this._preRoundNum    = document.getElementById('pre-round-number');
+    this._preRoundScore  = document.getElementById('pre-round-score');
+    this._preRoundTimer  = document.getElementById('pre-round-timer');
+
+    // ROUND_END overlay
+    this._roundEndEl     = document.getElementById('round-end-overlay');
+    this._roundEndTitle  = document.getElementById('round-end-title');
+    this._roundEndScore  = document.getElementById('round-end-score');
+    this._roundEndTimer  = document.getElementById('round-end-timer');
+
+    // MATCH_END overlay
+    this._matchEndEl     = document.getElementById('match-end-overlay');
+    this._matchResultEl  = document.getElementById('match-result-title');
+    this._matchScoreEl   = document.getElementById('match-end-score');
+
+    // Round indicator (HUD top-centre)
+    this._roundPipsEl    = document.getElementById('round-pips');
+    this._roundLabelEl   = document.getElementById('round-label');
+
+    // Wire restart button
+    const restartBtn = document.getElementById('match-restart-btn');
+    if (restartBtn) {
+      restartBtn.addEventListener('click', () => this.game.restart());
+    }
+
+    this._lastState = null;
+  }
+
+  /**
+   * Called every frame by MatchManager.onUIUpdate().
+   * @param {import('../core/MatchManager.js').MatchUIState} ui
+   */
+  update(ui) {
+    // Only update DOM when state or key values change (avoid thrashing).
+    if (ui.state !== this._lastState) {
+      this._applyState(ui);
+      this._lastState = ui.state;
+    }
+
+    // Timer text updates every second regardless.
+    this._updateTimers(ui);
+
+    // Round indicator always reflects current round + per-team wins.
+    this._updateRoundIndicator(ui);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _applyState(ui) {
+    this._hideAll();
+
+    switch (ui.state) {
+      case MatchState.PRE_ROUND:
+        this._showPreRound(ui);
+        break;
+      case MatchState.ROUND_END:
+        this._showRoundEnd(ui);
+        break;
+      case MatchState.MATCH_END:
+        this._showMatchEnd(ui);
+        break;
+      case MatchState.ACTIVE:
+      default:
+        // No overlay during combat.
+        break;
+    }
+  }
+
+  /** @private */
+  _hideAll() {
+    this._setVisible(this._preRoundEl, false);
+    this._setVisible(this._roundEndEl, false);
+    this._setVisible(this._matchEndEl, false);
+  }
+
+  /** @private */
+  _showPreRound(ui) {
+    if (this._preRoundNum)   this._preRoundNum.textContent  = String(ui.round);
+    if (this._preRoundScore) this._preRoundScore.textContent = `${ui.roundWins[0]} \u2014 ${ui.roundWins[1]}`;
+    this._setVisible(this._preRoundEl, true);
+  }
+
+  /** @private */
+  _showRoundEnd(ui) {
+    if (this._roundEndTitle) {
+      const winnerName = ui.roundWinnerId >= 0 ? TEAM_NAMES[ui.roundWinnerId] : 'DRAW';
+      this._roundEndTitle.textContent = `${winnerName} WINS ROUND ${ui.round}`;
+    }
+    if (this._roundEndScore) {
+      this._roundEndScore.textContent = `${ui.roundWins[0]} \u2014 ${ui.roundWins[1]}`;
+    }
+    this._setVisible(this._roundEndEl, true);
+  }
+
+  /** @private */
+  _showMatchEnd(ui) {
+    if (this._matchResultEl) {
+      // Team 0 = player side; team 1 = enemy side.
+      const playerWon = ui.matchWinnerId === 0;
+      this._matchResultEl.textContent = playerWon ? 'VICTORY!' : 'DEFEAT';
+      this._matchResultEl.style.color = playerWon ? '#4caf50' : '#f44336';
+    }
+    if (this._matchScoreEl) {
+      this._matchScoreEl.textContent = `${ui.roundWins[0]} \u2014 ${ui.roundWins[1]}`;
+    }
+    this._setVisible(this._matchEndEl, true);
+  }
+
+  /** @private Update countdown text every frame (ceil changes ~once per second). */
+  _updateTimers(ui) {
+    if (this._preRoundTimer && ui.state === MatchState.PRE_ROUND) {
+      this._preRoundTimer.textContent = String(Math.max(1, ui.timer));
+    }
+    if (this._roundEndTimer && ui.state === MatchState.ROUND_END) {
+      this._roundEndTimer.textContent = String(Math.max(1, ui.timer));
+    }
+  }
+
+  /** @private Pip row: green dots = player wins, red dots = enemy wins. */
+  _updateRoundIndicator(ui) {
+    if (this._roundLabelEl) {
+      this._roundLabelEl.textContent = `Round ${ui.round}`;
+    }
+    if (!this._roundPipsEl) {
+      return;
+    }
+    this._roundPipsEl.innerHTML = '';
+    // Two sets of pips (one per team), separated by a dash.
+    for (let i = 0; i < 2; i++) {
+      const pip = document.createElement('span');
+      pip.className = `pip pip-team${i} ${ui.roundWins[0] > i ? 'won' : ''}`;
+      this._roundPipsEl.appendChild(pip);
+    }
+    const sep = document.createElement('span');
+    sep.className = 'pip-sep';
+    sep.textContent = '\u2014';
+    this._roundPipsEl.appendChild(sep);
+    for (let i = 0; i < 2; i++) {
+      const pip = document.createElement('span');
+      pip.className = `pip pip-team1 ${ui.roundWins[1] > i ? 'won' : ''}`;
+      this._roundPipsEl.appendChild(pip);
+    }
+  }
+
+  /** @private */
+  _setVisible(el, visible) {
+    if (!el) {
+      return;
+    }
+    if (visible) {
+      el.classList.remove('hidden');
+    } else {
+      el.classList.add('hidden');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the MatchManager state machine required by t008, integrating it into Game.js and adding the DOM overlay UI.

## State Machine

```
PRE_ROUND (3 s countdown)
    │ timer expires
    ▼
  ACTIVE  ←──────────────────────────────────┐
    │ one team eliminated                    │
    ▼                                        │
ROUND_END (5 s result screen)                │
    │ timer expires                          │
    ├─ a team has 2 wins ──→ MATCH_END       │
    └─ match continues ──────────────────────┘
```

## Files Changed

- **NEW: `src/core/MatchManager.js`** — State machine, round win tracking, callbacks (`onRoundStart`, `onRoundReset`, `onMatchEnd`, `onUIUpdate`). Registers its own `onTeamEliminated` hook with TeamManager.
- **NEW: `src/ui/MatchOverlay.js`** — Three DOM overlays (PRE_ROUND countdown, ROUND_END result + next-round timer, MATCH_END victory/defeat + play-again button) + round pip indicator in HUD top-centre.
- **EDIT: `src/core/Game.js`** — Import and instantiate MatchManager; gate all combat logic on `match.isActive()`; clear projectiles/particles between rounds via `onRoundReset`; updated `restart()` to call `match.reset()`.
- **EDIT: `index.html`** — Add `#pre-round-overlay`, `#round-end-overlay`, `#match-end-overlay` and `#round-indicator` elements + CSS.

## Verification

```
npm run build   # passes — 21 modules, no errors
```

State transitions are logged to the browser console:
- `[MatchManager] Round 1 — ACTIVE`
- `[MatchManager] Round 1 complete — team 1 wins the round. Match score: 0-1 (need 2 to win match)`
- `[MatchManager] MATCH_END — team 0 wins the match (2-1)`

Resolves #15