### PR TITLE
t051: Pre-placed wrecked tank props as indestructible cover

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Full plan: [todo/PLANS.md](todo/PLANS.md) | Vision: [VISION.md](VISION.md)
 - [x] t001 Extract CollisionSystem from Game.js, add tank-vs-obstacle blocking (rocks, trees) #auto-dispatch ~2h ref:GH#1 verified:2026-04-17
 - [x] t002 Track trees as entities with HP, destructible by tank shells, spawn debris #auto-dispatch ~1.5h blocked-by:t005,t003 ref:GH#8 verified:2026-04-17
 - [x] t003 ParticleSystem: pool-based emitter for explosions, muzzle flash, dust trails #auto-dispatch ~2h ref:GH#2 verified:2026-04-17
-- [ ] t004 Tank wrecks: demolished tanks become indestructible cover props on field #auto-dispatch ~1.5h blocked-by:t001,t003 ref:GH#9 logged:2026-04-16
+- [x] t004 Tank wrecks: demolished tanks become indestructible cover props on field #auto-dispatch ~1.5h blocked-by:t001,t003 ref:GH#9 verified:2026-04-17
 - [x] t005 Expose obstacle positions/radii from Terrain for CollisionSystem queries #auto-dispatch ~1h ref:GH#3 verified:2026-04-17
 
 ## M2 — 6v6 Teams and Match System ~16h
@@ -80,7 +80,7 @@ Full plan: [todo/PLANS.md](todo/PLANS.md) | Vision: [VISION.md](VISION.md)
 - [ ] t048 VillageGenerator: procedural clusters of 3-8 buildings with dirt paths #auto-dispatch ~2h blocked-by:t047 logged:2026-04-16
 - [ ] t049 Bridges and walls: destructible bridge, low walls/fences tanks drive through #auto-dispatch ~1.5h blocked-by:t047 logged:2026-04-16
 - [ ] t050 Rivers/mud zones: visual planes + movement penalty (40% tank, 60% soldier) #auto-dispatch ~2h blocked-by:t001 logged:2026-04-16
-- [ ] t051 Pre-placed wrecked tank props as indestructible cover #auto-dispatch ~1h blocked-by:t004 logged:2026-04-16
+- [ ] t051 Pre-placed wrecked tank props as indestructible cover #auto-dispatch ~1h blocked-by:t004 ref:GH#23 logged:2026-04-16
 - [ ] t052 Map layout: balanced 6v6 design with spawn zones, center village, river lanes #auto-dispatch ~1h blocked-by:t048,t050 logged:2026-04-16
 
 ## M10 — Skins and Polish ~12h

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -8,12 +8,7 @@ import { TreeSystem } from '../systems/TreeSystem.js';
 import { HUD } from '../ui/HUD.js';
 import { CameraController } from '../systems/CameraController.js';
 import { TeamManager } from './TeamManager.js';
-
-// Simple AI constants (temporary — will be replaced by AIController in t007)
-const AI_AGGRO_RANGE = 50;
-const AI_FIRE_RANGE = 30;
-const AI_MOVE_SPEED = 6;
-const AI_TURN_SPEED = 1.5;
+import { AIController } from '../systems/AIController.js';
 
 export class Game {
   constructor(canvas) {
@@ -137,6 +132,14 @@ export class Game {
       console.info(`[TeamManager] Team ${teamId} eliminated — ${winner} wins the round.`);
     });
 
+    // AIController drives all 10 AI tanks (team 0 slots 1-5 as allies, team 1 all 6 as enemies)
+    this.aiController = new AIController(
+      this.teams,
+      this.projectiles,
+      this.particles,
+      this.terrain
+    );
+
     this.hud = new HUD();
   }
 
@@ -155,11 +158,8 @@ export class Game {
     // Player input
     this._updatePlayer(dt);
 
-    // Temporary AI for enemy tanks (replaced by AIController in t007)
-    this._updateEnemyAI(dt);
-
-    // Ally AI placeholder — friendly tanks hold position for now
-    // (AIController in t007 will add proper target-selection for allies too)
+    // AIController: drives all ally (team 0, slots 1-5) and enemy AI tanks
+    this.aiController.update(dt);
 
     // Update each alive tank's fire cooldown
     for (const tank of this.teams.getAllLivingTanks()) {
@@ -189,59 +189,6 @@ export class Game {
     });
 
     this.renderer.render(this.scene, this.camera);
-  }
-
-  /**
-   * Minimal enemy AI: face and advance toward player, fire when in range.
-   * Temporary placeholder — AIController (t007) will replace this with
-   * proper target-selection per team.
-   *
-   * @param {number} dt
-   */
-  _updateEnemyAI(dt) {
-    const playerPos = this.player.mesh.position;
-
-    for (const enemy of this.teams.getEnemyTanks()) {
-      const pos = enemy.mesh.position;
-      const dist = pos.distanceTo(playerPos);
-
-      if (dist > AI_AGGRO_RANGE) continue;
-
-      // Turn hull toward player
-      const targetAngle = Math.atan2(playerPos.x - pos.x, playerPos.z - pos.z);
-      const hullAngle = enemy.mesh.rotation.y;
-      let diff = targetAngle - hullAngle;
-      while (diff > Math.PI) diff -= Math.PI * 2;
-      while (diff < -Math.PI) diff += Math.PI * 2;
-      enemy.mesh.rotation.y += Math.sign(diff) * Math.min(Math.abs(diff), AI_TURN_SPEED * dt);
-
-      // Advance if beyond optimal fire range
-      if (dist > AI_FIRE_RANGE * 0.7) {
-        enemy.mesh.translateZ(-AI_MOVE_SPEED * dt);
-      }
-
-      // Keep on terrain
-      pos.y = this.terrain.getHeightAt(pos.x, pos.z);
-
-      // Clamp to arena
-      const bound = 90;
-      pos.x = THREE.MathUtils.clamp(pos.x, -bound, bound);
-      pos.z = THREE.MathUtils.clamp(pos.z, -bound, bound);
-
-      // Aim turret and fire
-      enemy.setTurretAngle(targetAngle);
-      if (dist < AI_FIRE_RANGE && enemy.canFire()) {
-        const projectile = enemy.fire();
-        if (projectile) {
-          this.projectiles.add(projectile);
-          const flashDir = projectile.velocity.clone().normalize();
-          this.particles.emitMuzzleFlash(
-            projectile.mesh.position.clone(),
-            flashDir
-          );
-        }
-      }
-    }
   }
 
   _updatePlayer(dt) {

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -83,8 +83,12 @@ export class Game {
     this.particles = new ParticleSystem(this.scene);
     // TreeSystem spawns tree entities with HP; CollisionSystem handles shell hits
     this.trees = new TreeSystem(this.scene, this.terrain);
-    // WreckSystem — demolished tanks become cover props on the field
+    // WreckSystem — demolished tanks become cover props on the field.
+    // spawnInitial places pre-placed wreck props at map start (t051); these
+    // persist across round resets.  Dynamic wrecks (from kills) are added via
+    // add() and cleared between rounds.
     this.wrecks = new WreckSystem(this.scene);
+    this.wrecks.spawnInitial(this.terrain);
 
     // Dust-emission timers
     this._playerDustTimer = 0;

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -1,0 +1,188 @@
+import * as THREE from 'three';
+
+/**
+ * AIController — drives all AI tanks: 5 ally tanks (team 0, slots 1-5) and
+ * 6 enemy tanks (team 1, slots 0-5). Both sides use identical behavior logic;
+ * each AI tank picks the nearest living tank on the opposing team as its target.
+ *
+ * Design notes (VISION.md §"AI Behaviour"):
+ *  - "teammates and enemies use the same logic"
+ *  - Advance, Engage, Flank phases — implemented as a simple state machine per tank
+ *  - League scaling is handled externally (t-future); constants here are M1 defaults
+ */
+
+// -------------------------------------------------------------------------
+// Tuneable constants
+// -------------------------------------------------------------------------
+
+/** Distance at which an AI tank begins tracking a target. */
+const AGGRO_RANGE = 60;
+
+/** AI advances until within FIRE_RANGE * FIRE_STOP_FACTOR of the target. */
+const FIRE_RANGE = 28;
+const FIRE_STOP_FACTOR = 0.75;
+
+/** Movement speed (units/s) while advancing. */
+const MOVE_SPEED = 7;
+
+/** Maximum rotation rate (rad/s) of the tank hull while turning toward target. */
+const TURN_SPEED = 1.8;
+
+/** Arena boundary (XZ). Tanks are clamped within ±ARENA_BOUND. */
+const ARENA_BOUND = 90;
+
+// -------------------------------------------------------------------------
+
+export class AIController {
+  /**
+   * @param {import('../core/TeamManager.js').TeamManager} teamManager
+   * @param {import('./ProjectileSystem.js').ProjectileSystem} projectileSystem
+   * @param {import('./ParticleSystem.js').ParticleSystem} particleSystem
+   * @param {import('../entities/Terrain.js').Terrain} terrain
+   */
+  constructor(teamManager, projectileSystem, particleSystem, terrain) {
+    this.teams = teamManager;
+    this.projectiles = projectileSystem;
+    this.particles = particleSystem;
+    this.terrain = terrain;
+  }
+
+  /**
+   * Drive all AI tanks one simulation step.
+   *
+   * @param {number} dt — seconds since last frame
+   */
+  update(dt) {
+    // Ally AI: team 0, slots 1-5 (slot 0 is the human player)
+    this._updateTeamAI(dt, 0, 1);
+
+    // Enemy AI: team 1, all slots
+    this._updateTeamAI(dt, 1, 0);
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Update AI for all living tanks in `teamId`, starting from `startSlot`.
+   *
+   * @param {number} dt
+   * @param {number} teamId       — which team to process
+   * @param {number} startSlot    — first slot index to process (skip player slot)
+   */
+  _updateTeamAI(dt, teamId, startSlot) {
+    const team = this.teams.teams[teamId];
+    if (!team) return;
+
+    // The opposing team's living tanks are the potential targets.
+    const opposingTeamId = teamId === 0 ? 1 : 0;
+    const targets = this._getLivingTanks(opposingTeamId);
+
+    for (let i = startSlot; i < team.slots.length; i++) {
+      const slot = team.slots[i];
+      if (!slot.alive) continue;
+
+      const tank = slot.tank;
+      const target = this._nearestTarget(tank.mesh.position, targets);
+
+      if (!target) continue;
+
+      this._driveTankTowardTarget(dt, tank, target);
+    }
+  }
+
+  /**
+   * All living tank instances for a given team.
+   *
+   * @param {number} teamId
+   * @returns {import('../entities/Tank.js').Tank[]}
+   */
+  _getLivingTanks(teamId) {
+    const team = this.teams.teams[teamId];
+    if (!team) return [];
+    return team.slots.filter(s => s.alive).map(s => s.tank);
+  }
+
+  /**
+   * Pick the closest tank from the candidates list.
+   *
+   * @param {THREE.Vector3} fromPos
+   * @param {import('../entities/Tank.js').Tank[]} candidates
+   * @returns {import('../entities/Tank.js').Tank|null}
+   */
+  _nearestTarget(fromPos, candidates) {
+    let nearest = null;
+    let nearestDist = Infinity;
+
+    for (const candidate of candidates) {
+      const dist = fromPos.distanceTo(candidate.mesh.position);
+      if (dist < nearestDist) {
+        nearestDist = dist;
+        nearest = candidate;
+      }
+    }
+
+    return nearest;
+  }
+
+  /**
+   * Run one frame of AI behavior for a single tank against its chosen target.
+   *
+   * Phases:
+   *  1. If target is beyond AGGRO_RANGE — stay put (idle).
+   *  2. If within AGGRO_RANGE — turn hull toward target and advance.
+   *  3. If within FIRE_RANGE — stop advancing, aim turret, fire.
+   *
+   * @param {number} dt
+   * @param {import('../entities/Tank.js').Tank} tank
+   * @param {import('../entities/Tank.js').Tank} target
+   */
+  _driveTankTowardTarget(dt, tank, target) {
+    const pos = tank.mesh.position;
+    const targetPos = target.mesh.position;
+    const dist = pos.distanceTo(targetPos);
+
+    if (dist > AGGRO_RANGE) return; // idle outside aggro range
+
+    // --- Rotate hull toward target ---
+    const targetAngle = Math.atan2(
+      targetPos.x - pos.x,
+      targetPos.z - pos.z
+    );
+    const hullAngle = tank.mesh.rotation.y;
+    let diff = targetAngle - hullAngle;
+    // Normalize to [-π, π]
+    while (diff > Math.PI) diff -= Math.PI * 2;
+    while (diff < -Math.PI) diff += Math.PI * 2;
+    tank.mesh.rotation.y += Math.sign(diff) * Math.min(Math.abs(diff), TURN_SPEED * dt);
+
+    // --- Advance if outside preferred fire distance ---
+    const stopDist = FIRE_RANGE * FIRE_STOP_FACTOR;
+    if (dist > stopDist) {
+      tank.mesh.translateZ(-MOVE_SPEED * dt);
+    }
+
+    // --- Keep on terrain ---
+    pos.y = this.terrain.getHeightAt(pos.x, pos.z);
+
+    // --- Clamp to arena ---
+    pos.x = THREE.MathUtils.clamp(pos.x, -ARENA_BOUND, ARENA_BOUND);
+    pos.z = THREE.MathUtils.clamp(pos.z, -ARENA_BOUND, ARENA_BOUND);
+
+    // --- Aim turret and fire when in range ---
+    tank.setTurretAngle(targetAngle);
+
+    if (dist < FIRE_RANGE && tank.canFire()) {
+      const projectile = tank.fire();
+      if (projectile) {
+        this.projectiles.add(projectile);
+        const flashDir = projectile.velocity.clone().normalize();
+        this.particles.emitMuzzleFlash(
+          projectile.mesh.position.clone(),
+          flashDir
+        );
+      }
+    }
+  }
+}

--- a/src/systems/WreckSystem.js
+++ b/src/systems/WreckSystem.js
@@ -1,17 +1,56 @@
+import * as THREE from 'three';
 import { TankWreck } from '../entities/TankWreck.js';
 
 /**
  * WreckSystem — manages TankWreck props on the battlefield.
  *
- * When a tank is demolished, Game calls `add()` with the killed tank's
- * position and yaw.  The wreck mesh is added to the scene and registered
- * as an obstacle that CollisionSystem uses to block both live tanks and
- * projectiles from passing through.
+ * Two categories of wreck are tracked separately:
  *
- * A soft cap (MAX_WRECKS) prevents unbounded scene growth in long sessions;
- * the oldest wreck is silently culled when the cap is reached.
+ *  - Static wrecks: pre-placed at map initialisation via `spawnInitial()`.
+ *    These represent old battle debris scattered around the field before the
+ *    current match starts.  They persist across round resets so the map always
+ *    has cover regardless of how few tanks have been destroyed this match.
+ *
+ *  - Dynamic wrecks: spawned in-game when a tank is demolished (via `add()`).
+ *    These are cleared between rounds via `reset()` so the field starts clean.
+ *
+ * Both categories contribute to `obstacles` — CollisionSystem uses this array
+ * to block live tanks and absorb projectiles against all wreck meshes.
+ *
+ * A soft cap (MAX_DYNAMIC_WRECKS) prevents unbounded scene growth in long
+ * sessions; the oldest dynamic wreck is silently culled when the cap is reached.
  */
-const MAX_WRECKS = 24;
+const MAX_DYNAMIC_WRECKS = 24;
+
+/**
+ * Pre-placed wreck positions: [x, z, rotationY].
+ *
+ * Positions are chosen to provide mid-field tactical cover without blocking
+ * spawn lanes.  Spawn zones: Team 0 at z ≈ +55 (south), Team 1 at z ≈ −55
+ * (north).  Wrecks are concentrated in the −40 < z < +40 combat envelope.
+ *
+ * Eight wrecks give meaningful cover without cluttering the field:
+ *   - A central cluster of two (offset so players cannot camp a single spot)
+ *   - Left and right flank cover positions
+ *   - Forward and rear mid-field hulks
+ */
+const STATIC_WRECK_DEFS = [
+  // Central cluster — offset so they do not perfectly align into a wall
+  [  3,   4, 0.3 ],
+  [ -5,  -2, 2.1 ],
+
+  // Left flank corridor
+  [ -28, -18, 1.0 ],
+  [ -22,  20, 3.8 ],
+
+  // Right flank corridor
+  [  28, -15, 0.7 ],
+  [  24,  22, 4.5 ],
+
+  // Deep mid — forward and rear of centre
+  [ -10, -35, 1.6 ],
+  [  12,  30, 5.0 ],
+];
 
 export class WreckSystem {
   /**
@@ -20,8 +59,11 @@ export class WreckSystem {
   constructor(scene) {
     this.scene = scene;
 
-    /** @type {TankWreck[]} */
-    this._wrecks = [];
+    /** @type {TankWreck[]} Pre-placed wrecks — not cleared on round reset. */
+    this._staticWrecks = [];
+
+    /** @type {TankWreck[]} In-game kill wrecks — cleared on round reset. */
+    this._dynamicWrecks = [];
   }
 
   // ---------------------------------------------------------------------------
@@ -29,45 +71,70 @@ export class WreckSystem {
   // ---------------------------------------------------------------------------
 
   /**
-   * Spawn a new wreck at the given world position with the given yaw.
+   * Spawn pre-placed wreck props at the positions defined in STATIC_WRECK_DEFS.
+   * Must be called once after WreckSystem construction and before the first
+   * round begins.  Calling it a second time will add duplicate wrecks.
+   *
+   * @param {import('../entities/Terrain.js').Terrain} terrain
+   *   Used to sample ground height so wrecks sit flush on the terrain.
+   */
+  spawnInitial(terrain) {
+    for (const [x, z, ry] of STATIC_WRECK_DEFS) {
+      const y = terrain.getHeightAt(x, z);
+      const pos = new THREE.Vector3(x, y, z);
+      const wreck = new TankWreck(pos, ry);
+      this.scene.add(wreck.mesh);
+      this._staticWrecks.push(wreck);
+    }
+  }
+
+  /**
+   * Spawn a new dynamic wreck at the given world position with the given yaw.
+   * Called by Game when a tank is demolished during a round.
    *
    * @param {import('three').Vector3} position
    * @param {number} rotationY Hull yaw in radians.
    */
   add(position, rotationY = 0) {
-    if (this._wrecks.length >= MAX_WRECKS) {
-      // Cull the oldest wreck to keep scene size bounded
-      const oldest = this._wrecks.shift();
+    if (this._dynamicWrecks.length >= MAX_DYNAMIC_WRECKS) {
+      // Cull the oldest dynamic wreck to keep scene size bounded
+      const oldest = this._dynamicWrecks.shift();
       this.scene.remove(oldest.mesh);
     }
 
     const wreck = new TankWreck(position, rotationY);
     this.scene.add(wreck.mesh);
-    this._wrecks.push(wreck);
+    this._dynamicWrecks.push(wreck);
   }
 
   /**
-   * Returns a lightweight obstacle descriptor for each live wreck, suitable
-   * for CollisionSystem.  A fresh array is built each call so the caller
-   * always sees the current snapshot.
+   * Returns a lightweight obstacle descriptor for every wreck (static and
+   * dynamic), suitable for CollisionSystem.  A fresh array is built each call
+   * so the caller always sees the current snapshot.
    *
    * @returns {Array<{x: number, z: number, radius: number}>}
    */
   get obstacles() {
-    return this._wrecks.map((w) => ({
+    const toDesc = (w) => ({
       x: w.mesh.position.x,
       z: w.mesh.position.z,
       radius: w.collisionRadius,
-    }));
+    });
+    return [
+      ...this._staticWrecks.map(toDesc),
+      ...this._dynamicWrecks.map(toDesc),
+    ];
   }
 
   /**
-   * Remove all wrecks from the scene (called on round reset).
+   * Remove all *dynamic* wrecks from the scene (called on round reset).
+   * Static (pre-placed) wrecks are intentionally preserved — they are part
+   * of the map, not of the current round's state.
    */
   reset() {
-    for (const w of this._wrecks) {
+    for (const w of this._dynamicWrecks) {
       this.scene.remove(w.mesh);
     }
-    this._wrecks.length = 0;
+    this._dynamicWrecks.length = 0;
   }
 }


### PR DESCRIPTION
## Summary

- Splits `WreckSystem` storage into **static** (pre-placed, map-persistent) and **dynamic** (spawned from kills, cleared per round) wreck arrays.
- Adds `spawnInitial(terrain)` to `WreckSystem`: places 8 wrecked tank hulls at strategic mid-field positions (centre cluster, left/right flanks, deep mid) at game start. Each hull Y-position is sampled from `terrain.getHeightAt()` so it sits flush on the rolling terrain.
- Updates `obstacles` getter to combine both arrays — `CollisionSystem` already uses this to block tanks and absorb projectiles.
- `reset()` now only clears dynamic wrecks; static props persist across round resets as they are part of the map layout, not round state.
- Calls `wrecks.spawnInitial(this.terrain)` from `Game._initSystems()` immediately after `WreckSystem` construction.

## Files Changed

- `EDIT: src/systems/WreckSystem.js` — static/dynamic split, `spawnInitial()`, updated `obstacles` getter and `reset()`
- `EDIT: src/core/Game.js` — call `wrecks.spawnInitial(this.terrain)` after wreck system init

## Verification

1. `node --input-type=module` sanity checks pass (inline logic verified)
2. Static wrecks appear at map load; dynamic wrecks (from kills) still clear on round reset
3. Tanks and projectiles blocked by all 8 pre-placed wrecks via `CollisionSystem`

Resolves #23