### PR TITLE
t011: Performance rewards calculator from StatsTracker output

### DIFF
--- a/src/systems/PerformanceRewards.js
+++ b/src/systems/PerformanceRewards.js
@@ -1,0 +1,309 @@
+/**
+ * PerformanceRewards — calculates post-match money rewards from StatsTracker output.
+ *
+ * Reward table (from VISION.md § "Performance-Based Rewards"):
+ *
+ *  | Action                        | Money Earned                              |
+ *  |-------------------------------|-------------------------------------------|
+ *  | Damage dealt                  | +$1 per 5 HP dealt to enemy tanks         |
+ *  | Tank kill (last hit)          | +$100–$300 (varies by enemy tank class)   |
+ *  | Assist (≥30% damage, not kill)| +$50–$150 (varies by enemy tank class)    |
+ *  | On-foot kill (enemy soldier)  | +$40                                      |
+ *  | Survived the round            | +$150 bonus per round                     |
+ *  | Win a round                   | +$500 bonus per round won                 |
+ *  | Win the match                 | +$1,000 bonus                             |
+ *  | MVP (most damage in match)    | +$400 bonus                               |
+ *  | Flawless round (zero dmg taken| +$300 bonus per flawless round            |
+ *  | Lose the match                | keep damage/kill earnings, no win/MVP     |
+ *
+ * Usage:
+ *  const rewards = PerformanceRewards.calculate({
+ *    matchStats,      // from StatsTracker.getMatchStats()
+ *    roundWins,       // boolean[] — true for each round the player's team won
+ *    matchWon,        // boolean — did the player's team win the match?
+ *    isMVP,           // boolean — did this player deal most damage?
+ *    killReward,      // optional number — $ per kill (default 200)
+ *    assistReward,    // optional number — $ per assist (default 100)
+ *  });
+ *  // rewards.total   — total money earned
+ *  // rewards.lines   — human-readable breakdown for the rewards screen
+ *
+ * Notes:
+ *  - Kill and assist rewards default to the midpoint of the VISION.md ranges
+ *    ($200 and $100 respectively).  When TankDefs (t016) are implemented, pass
+ *    the per-kill reward array for class-accurate values.
+ *  - isMVP must be determined by the caller (MatchManager) by comparing each
+ *    player's total damageDealt across all rounds.
+ *  - roundWins length must match matchStats.rounds length (rounds played).
+ *  - Flawless detection uses RoundStats.damageReceived, which requires
+ *    StatsTracker.recordPlayerDamageTaken() to be called on every player hit.
+ */
+export class PerformanceRewards {
+  // ---------------------------------------------------------------------------
+  // Reward constants (from VISION.md reward table)
+  // ---------------------------------------------------------------------------
+
+  /** $1 per 5 HP dealt — expressed as $ per 1 HP for multiplication. */
+  static DAMAGE_RATE = 1 / 5;
+
+  /** Default kill reward (mid-range of $100–$300). */
+  static KILL_DEFAULT = 200;
+
+  /** Minimum kill reward (cheapest tank class). */
+  static KILL_MIN = 100;
+
+  /** Maximum kill reward (most expensive tank class). */
+  static KILL_MAX = 300;
+
+  /** Default assist reward (mid-range of $50–$150). */
+  static ASSIST_DEFAULT = 100;
+
+  /** Minimum assist reward. */
+  static ASSIST_MIN = 50;
+
+  /** Maximum assist reward. */
+  static ASSIST_MAX = 150;
+
+  /** Bonus per on-foot (soldier) kill. */
+  static ON_FOOT_KILL_REWARD = 40;
+
+  /** Bonus per round survived. */
+  static SURVIVED_BONUS = 150;
+
+  /** Bonus per round won by the player's team. */
+  static WIN_ROUND_BONUS = 500;
+
+  /** Bonus for winning the overall match. */
+  static WIN_MATCH_BONUS = 1000;
+
+  /** Bonus for being MVP (most damage in match). */
+  static MVP_BONUS = 400;
+
+  /** Bonus per round where the player's tank took zero damage. */
+  static FLAWLESS_BONUS = 300;
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Calculate total money rewards for a completed match.
+   *
+   * @param {object}  params
+   * @param {{ rounds: import('./StatsTracker.js').RoundStats[],
+   *           totals: import('./StatsTracker.js').MatchTotals }} params.matchStats
+   *   — output of StatsTracker.getMatchStats()
+   * @param {boolean[]} params.roundWins
+   *   — true for each round the player's team won (index matches rounds array)
+   * @param {boolean}  params.matchWon
+   *   — true if the player's team won the match
+   * @param {boolean}  params.isMVP
+   *   — true if this player dealt the most total damage across all players
+   * @param {number}   [params.killReward=200]
+   *   — $ per kill; use per-class value from TankDefs when available
+   * @param {number}   [params.assistReward=100]
+   *   — $ per assist; use per-class value from TankDefs when available
+   * @param {number}   [params.onFootKills=0]
+   *   — number of enemy soldiers killed while on foot
+   * @returns {RewardBreakdown}
+   */
+  static calculate({
+    matchStats,
+    roundWins,
+    matchWon,
+    isMVP,
+    killReward = PerformanceRewards.KILL_DEFAULT,
+    assistReward = PerformanceRewards.ASSIST_DEFAULT,
+    onFootKills = 0,
+  }) {
+    const { rounds, totals } = matchStats;
+
+    // --- per-HP damage reward ---
+    const damageEarned = Math.floor(totals.damageDealt * PerformanceRewards.DAMAGE_RATE);
+
+    // --- kill and assist rewards ---
+    const killEarned = totals.kills * killReward;
+    const assistEarned = totals.assists * assistReward;
+
+    // --- on-foot kill reward ---
+    const onFootEarned = onFootKills * PerformanceRewards.ON_FOOT_KILL_REWARD;
+
+    // --- per-round bonuses ---
+    let survivalEarned = 0;
+    let flawlessEarned = 0;
+    let roundWinEarned = 0;
+
+    for (let i = 0; i < rounds.length; i++) {
+      const round = rounds[i];
+
+      if (round.survived) {
+        survivalEarned += PerformanceRewards.SURVIVED_BONUS;
+      }
+
+      if (round.damageReceived === 0 && round.survived) {
+        // Flawless: tank alive at round end AND took zero damage
+        flawlessEarned += PerformanceRewards.FLAWLESS_BONUS;
+      }
+
+      if (roundWins[i]) {
+        roundWinEarned += PerformanceRewards.WIN_ROUND_BONUS;
+      }
+    }
+
+    // --- match-level bonuses (only on win) ---
+    const matchWinEarned = matchWon ? PerformanceRewards.WIN_MATCH_BONUS : 0;
+    const mvpEarned = isMVP && matchWon ? PerformanceRewards.MVP_BONUS : 0;
+
+    // --- total ---
+    const total =
+      damageEarned +
+      killEarned +
+      assistEarned +
+      onFootEarned +
+      survivalEarned +
+      flawlessEarned +
+      roundWinEarned +
+      matchWinEarned +
+      mvpEarned;
+
+    // --- human-readable breakdown lines ---
+    const lines = PerformanceRewards._buildLines({
+      damageDealt: totals.damageDealt,
+      damageEarned,
+      kills: totals.kills,
+      killReward,
+      killEarned,
+      assists: totals.assists,
+      assistReward,
+      assistEarned,
+      onFootKills,
+      onFootEarned,
+      survivalEarned,
+      flawlessEarned,
+      roundWinEarned,
+      matchWon,
+      matchWinEarned,
+      isMVP,
+      mvpEarned,
+    });
+
+    return {
+      total,
+      breakdown: {
+        damage: damageEarned,
+        kills: killEarned,
+        assists: assistEarned,
+        onFootKills: onFootEarned,
+        survivalBonuses: survivalEarned,
+        flawlessBonuses: flawlessEarned,
+        roundWinBonuses: roundWinEarned,
+        matchWinBonus: matchWinEarned,
+        mvpBonus: mvpEarned,
+      },
+      lines,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build an array of { label, amount } objects for the rewards screen UI.
+   * Only lines where amount > 0 are included.
+   *
+   * @param {object} p — destructured calculation intermediates
+   * @returns {RewardLine[]}
+   */
+  static _buildLines(p) {
+    const lines = [];
+
+    if (p.damageEarned > 0) {
+      lines.push({
+        label: `Damage dealt (${p.damageDealt} HP)`,
+        amount: p.damageEarned,
+      });
+    }
+
+    if (p.killEarned > 0) {
+      lines.push({
+        label: `Kills ×${p.kills} ($${p.killReward} each)`,
+        amount: p.killEarned,
+      });
+    }
+
+    if (p.assistEarned > 0) {
+      lines.push({
+        label: `Assists ×${p.assists} ($${p.assistReward} each)`,
+        amount: p.assistEarned,
+      });
+    }
+
+    if (p.onFootEarned > 0) {
+      lines.push({
+        label: `On-foot kills ×${p.onFootKills}`,
+        amount: p.onFootEarned,
+      });
+    }
+
+    if (p.survivalEarned > 0) {
+      lines.push({
+        label: 'Survived round bonus',
+        amount: p.survivalEarned,
+      });
+    }
+
+    if (p.flawlessEarned > 0) {
+      lines.push({
+        label: 'Flawless round bonus',
+        amount: p.flawlessEarned,
+      });
+    }
+
+    if (p.roundWinEarned > 0) {
+      lines.push({
+        label: 'Round win bonus',
+        amount: p.roundWinEarned,
+      });
+    }
+
+    if (p.matchWinEarned > 0) {
+      lines.push({
+        label: 'Match win bonus',
+        amount: p.matchWinEarned,
+      });
+    }
+
+    if (p.mvpEarned > 0) {
+      lines.push({
+        label: 'MVP bonus',
+        amount: p.mvpEarned,
+      });
+    }
+
+    return lines;
+  }
+}
+
+/**
+ * @typedef {{
+ *   total:     number,
+ *   breakdown: {
+ *     damage:          number,
+ *     kills:           number,
+ *     assists:         number,
+ *     onFootKills:     number,
+ *     survivalBonuses: number,
+ *     flawlessBonuses: number,
+ *     roundWinBonuses: number,
+ *     matchWinBonus:   number,
+ *     mvpBonus:        number,
+ *   },
+ *   lines: RewardLine[],
+ * }} RewardBreakdown
+ *
+ * @typedef {{
+ *   label:  string,
+ *   amount: number,
+ * }} RewardLine
+ */

--- a/src/systems/StatsTracker.js
+++ b/src/systems/StatsTracker.js
@@ -2,16 +2,18 @@
  * StatsTracker — per-round and match-aggregate performance tracking.
  *
  * Tracks (per round, for the player):
- *  - damageDealt  : total HP damage dealt to enemy tanks
- *  - kills        : enemy tanks destroyed by the player (last-hit)
- *  - assists      : enemy tanks the player damaged ≥30% of maxHP, killed by someone else
- *  - survived     : whether the player's tank was alive when the round ended
- *  - survivalTime : seconds the player's tank was alive in the round
+ *  - damageDealt    : total HP damage dealt to enemy tanks
+ *  - damageReceived : total HP damage the player's tank absorbed (for flawless detection)
+ *  - kills          : enemy tanks destroyed by the player (last-hit)
+ *  - assists        : enemy tanks the player damaged ≥30% of maxHP, killed by someone else
+ *  - survived       : whether the player's tank was alive when the round ended
+ *  - survivalTime   : seconds the player's tank was alive in the round
  *
  * Usage:
  *  const stats = new StatsTracker();
  *  stats.startRound();                             // call before each round begins
  *  stats.recordPlayerDamage(tank, amount);         // on every player-hit
+ *  stats.recordPlayerDamageTaken(amount);          // on every hit the player's tank receives
  *  stats.recordTankKilled(tank, isPlayerKill);     // on every enemy tank death
  *  stats.update(dt);                               // in game loop for survival time
  *  const result = stats.endRound(playerAlive);     // at round end
@@ -128,6 +130,17 @@ export class StatsTracker {
   }
 
   /**
+   * Record damage the player's own tank received this round.
+   * Used to determine whether a round was flawless (zero damage taken).
+   * Call every time a projectile or ability hits the player's tank.
+   *
+   * @param {number} amount — HP damage absorbed by the player's tank
+   */
+  recordPlayerDamageTaken(amount) {
+    this._current.damageReceived += amount;
+  }
+
+  /**
    * Notify StatsTracker that the player's own tank has been destroyed.
    * Stops survival-time accumulation for the round.
    */
@@ -188,12 +201,13 @@ export class StatsTracker {
     const totals = allRounds.reduce(
       (acc, r) => ({
         damageDealt: acc.damageDealt + r.damageDealt,
+        damageReceived: acc.damageReceived + r.damageReceived,
         kills: acc.kills + r.kills,
         assists: acc.assists + r.assists,
         roundsSurvived: acc.roundsSurvived + (r.survived ? 1 : 0),
         totalSurvivalTime: acc.totalSurvivalTime + r.survivalTime,
       }),
-      { damageDealt: 0, kills: 0, assists: 0, roundsSurvived: 0, totalSurvivalTime: 0 }
+      { damageDealt: 0, damageReceived: 0, kills: 0, assists: 0, roundsSurvived: 0, totalSurvivalTime: 0 }
     );
 
     return { rounds: allRounds, totals };
@@ -219,6 +233,7 @@ export class StatsTracker {
   _emptyRound() {
     return {
       damageDealt: 0,
+      damageReceived: 0,
       kills: 0,
       assists: 0,
       survived: false,
@@ -229,15 +244,17 @@ export class StatsTracker {
 
 /**
  * @typedef {{
- *   damageDealt:  number,
- *   kills:        number,
- *   assists:      number,
- *   survived:     boolean,
- *   survivalTime: number
+ *   damageDealt:    number,
+ *   damageReceived: number,
+ *   kills:          number,
+ *   assists:        number,
+ *   survived:       boolean,
+ *   survivalTime:   number
  * }} RoundStats
  *
  * @typedef {{
  *   damageDealt:       number,
+ *   damageReceived:    number,
  *   kills:             number,
  *   assists:           number,
  *   roundsSurvived:    number,


### PR DESCRIPTION
## Summary

Implements the performance rewards calculator specified in VISION.md § "Performance-Based Rewards" (t011).

### Changes

**New: `src/systems/PerformanceRewards.js`**

Static class with `PerformanceRewards.calculate()` that takes StatsTracker match output plus match-level context and returns a full `RewardBreakdown`:

| Reward | Amount |
|--------|--------|
| Damage dealt | +\$1 per 5 HP |
| Tank kill (last hit) | +\$200 default (\$100–\$300 range, scales with TankDefs in t016) |
| Assist (≥30% damage) | +\$100 default (\$50–\$150 range) |
| On-foot soldier kill | +\$40 |
| Survived the round | +\$150 per round |
| Flawless round (zero damage taken) | +\$300 per round |
| Round win | +\$500 per round won |
| Match win | +\$1,000 |
| MVP (most damage, match-win only) | +\$400 |

Returns `{ total, breakdown, lines }` where `lines` is ready-to-render text for the rewards screen UI.

**Modified: `src/systems/StatsTracker.js`**

Added `damageReceived` tracking needed for flawless round detection:
- New `recordPlayerDamageTaken(amount)` method
- `damageReceived` field in `RoundStats` and `MatchTotals` (zero in existing callsites — no breaking change)

## Testing

The API is exercised by EconomySystem (t014) when it calculates and credits rewards at match end. Flawless detection requires that `recordPlayerDamageTaken()` be wired up in the collision/damage path (same call site as `recordPlayerDamage`).

Resolves #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a post-match reward system that calculates earnings from multiple performance metrics including damage dealt, kills, assists, round survival bonuses, and match outcomes. The system recognizes MVP performance and applies bonus multipliers for match victories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->