### PR TITLE
t009: Round reset — turret angle, trees, player death propagation

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -179,6 +179,8 @@ export class Game {
         this.projectiles.reset();
         this.particles.reset();
         this.wrecks.reset();
+        // Respawn the destructible tree set so the field is full again next round.
+        this.trees.reset();
         this._playerDustTimer = 0;
         this._enemyDustTimer = 0;
       })
@@ -334,13 +336,17 @@ export class Game {
 
   /**
    * Called by CollisionSystem when the player's tank HP reaches 0.
-   * The tank is already marked dead in TeamManager (via enemies.remove adapter),
-   * which may trigger onTeamEliminated → MatchManager handles round/match end.
+   * Marks the player's slot dead in TeamManager so `isTeamEliminated(0)` can
+   * fire, removing the mesh from the scene and triggering the MatchManager
+   * round-end / match-end flow if all allies are also gone.
    */
   _onPlayerTankDestroyed() {
     // Notify StatsTracker to stop the survival timer for this round.
     this.stats.recordPlayerDeath();
-    // MatchOverlay handles ROUND_END / MATCH_END display.
+    // Mark player dead in TeamManager: removes mesh, checks team elimination.
+    // Without this call the player's slot stays alive=true and the team can
+    // never be eliminated, stalling the round indefinitely.
+    this.teams.killTank(this.player);
     console.info('[Game] Player tank destroyed.');
   }
 

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -179,5 +179,11 @@ export class Tank {
     this.fireCooldown = 0;
     this.kills = 0;
     this.damageDealt = 0;
+    // Reset turret to face forward (local rotation.y = 0).
+    // Loadout properties (tank class, weapons, upgrades — added in future tasks)
+    // are intentionally NOT reset here — they persist across rounds per VISION.md.
+    if (this.turret) {
+      this.turret.rotation.y = 0;
+    }
   }
 }

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -210,6 +210,10 @@ export class CollisionSystem {
     for (let i = projectiles.length - 1; i >= 0; i--) {
       const p = projectiles[i];
       if (p.isPlayerOwned) continue;
+      // Skip if the player is already dead (health=0 after killTank was called).
+      // Without this guard, projectiles in-flight when the player dies would
+      // re-trigger _onPlayerDeath on every subsequent frame they collide.
+      if (player.health <= 0) continue;
 
       const dist = p.mesh.position.distanceTo(player.mesh.position);
       if (dist < 2.5) {


### PR DESCRIPTION
## Summary

Implements t009: round reset — all 12 tanks respawn at full HP/ammo, field cleared of projectiles/wrecks/trees, loadout preserved.

The round-reset infrastructure landed in t008 (MatchManager, TeamManager.reset, onRoundReset callback). This PR fills the three gaps that would cause rounds to stall or render incorrectly:

### Changes

**`src/entities/Tank.reset()`**
- Reset `turret.rotation.y = 0` so tanks face forward after each round rather than carrying over their last aiming angle.
- Added explicit comment: future loadout properties (tank class, weapons, upgrades) must NOT be reset here — they persist across rounds per VISION.md §Round Rules.

**`src/core/Game.js — onRoundReset`**
- Added `this.trees.reset()`. Trees are destructible mid-round; without this call, rounds 2 and 3 start with fewer trees (or none), giving surviving players permanent terrain advantage. `TreeSystem.reset()` already existed and handles teardown + respawn.

**`src/core/Game.js — _onPlayerTankDestroyed()`**
- Added `this.teams.killTank(this.player)`. Previously the player's `slot.alive` stayed `true` after death, so `isTeamEliminated(0)` could never return `true`. If the enemy team didn't wipe all AI allies, the round stalled with no winner. `killTank` removes the mesh, marks the slot dead, and fires `onTeamEliminated` if warranted.
- Corrected stale JSDoc that claimed "the tank is already marked dead via enemies.remove adapter" — the player is not in the enemies adapter.

**`src/systems/CollisionSystem.js`**
- Added `if (player.health <= 0) continue` guard before processing enemy projectile hits on the player. Without this, in-flight projectiles from the frame the player died would re-trigger `_onPlayerDeath` on subsequent frames, causing duplicate kill-feed entries, wreck spawns, and stat records.

### Verification

```
npm run build   # ✓ 27 modules, 0 errors, 0 TS warnings
```

Round-reset correctness confirmed by code trace:
1. `MatchManager._prepareNextRound()` → calls `onRoundResetCb` (clears projectiles/particles/wrecks/trees) then `teams.reset()` (respawns 12 tanks at spawn positions)
2. `teams.reset()` calls `tank.reset()` per slot → HP=100, ammo=30, fireCooldown=0, turret.rotation.y=0
3. Player death: `killTank(player)` → slot.alive=false, mesh removed, team-elimination check fires → MatchManager handles round/match end

Resolves #28