### PR TITLE
t016: Data definitions: TankDefs, WeaponDefs, UpgradeDefs with all VISION.md stats

### DIFF
--- a/src/data/TankDefs.js
+++ b/src/data/TankDefs.js
@@ -1,0 +1,207 @@
+/**
+ * TankDefs.js — Static definitions for all 8 tank classes.
+ *
+ * Each entry is keyed by a stable ID string used throughout the codebase.
+ * Stats reflect VISION.md tables. All values are base (tier-0, no upgrades).
+ *
+ * leagueRequired: 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond'
+ * price:          USD cost in the shop (0 = free / starter).
+ * hp:             Base max hit points.
+ * armor:          Damage reduction fraction (0 = no reduction, 0.3 = 30% reduction).
+ * speed:          World-units per second, forward movement.
+ * turnRate:       Radians per second, hull rotation.
+ * damage:         Base damage per shell hit (before target armor reduction).
+ * fireRate:       Shots per second.
+ * range:          Maximum effective range in world units.
+ * ability:        Identifier for the tank's special ability (null if none).
+ * abilityCooldown: Seconds between ability uses (0 if no ability).
+ */
+export const TankDefs = {
+  standard: {
+    id: 'standard',
+    name: 'Standard',
+    description: 'Balanced all-rounder. The starter tank — no extreme stats, reliable in any situation.',
+    price: 0,
+    leagueRequired: 'bronze',
+    hp: 100,
+    armor: 0.10,
+    speed: 12,
+    turnRate: 1.2,
+    damage: 25,
+    fireRate: 0.9,      // shots per second
+    range: 80,
+    ability: null,
+    abilityCooldown: 0,
+    colorBody: 0x2d5a27,
+    colorTurret: 0x3a7a33,
+    // Visual scale relative to default mesh (1 = no change)
+    scaleHull: 1.0,
+  },
+
+  scout: {
+    id: 'scout',
+    name: 'Scout',
+    description: 'Light, fast, weak armor. Rapid-fire small cannon. Best at flanking and hit-and-run.',
+    price: 2000,
+    leagueRequired: 'bronze',
+    hp: 60,
+    armor: 0.0,
+    speed: 20,
+    turnRate: 1.8,
+    damage: 14,
+    fireRate: 2.0,      // rapid-fire
+    range: 60,
+    ability: null,
+    abilityCooldown: 0,
+    colorBody: 0x6b8e23,
+    colorTurret: 0x8fbc8f,
+    scaleHull: 0.75,
+  },
+
+  heavy: {
+    id: 'heavy',
+    name: 'Heavy',
+    description: 'Slow, thick armor, big cannon. Highest damage per shot but longest reload.',
+    price: 5000,
+    leagueRequired: 'silver',
+    hp: 200,
+    armor: 0.30,
+    speed: 7,
+    turnRate: 0.7,
+    damage: 60,
+    fireRate: 0.4,      // slow reload
+    range: 90,
+    ability: 'reactiveArmor',
+    abilityCooldown: 20,
+    colorBody: 0x4a3728,
+    colorTurret: 0x5c4a3a,
+    scaleHull: 1.35,
+  },
+
+  artillery: {
+    id: 'artillery',
+    name: 'Artillery',
+    description: 'Very long range, arc shots. Paper-thin armor. Devastating from a distance.',
+    price: 5000,
+    leagueRequired: 'silver',
+    hp: 40,
+    armor: 0.0,
+    speed: 6,
+    turnRate: 0.6,
+    damage: 80,
+    fireRate: 0.25,     // very slow reload
+    range: 200,         // extreme range
+    ability: 'barrage',
+    abilityCooldown: 30,
+    colorBody: 0x7a6a3a,
+    colorTurret: 0x9a8a5a,
+    scaleHull: 1.1,
+  },
+
+  flameTank: {
+    id: 'flameTank',
+    name: 'Flame Tank',
+    description: 'Short-range flamethrower. Strong vs groups. Has Inferno Burst ability.',
+    price: 8000,
+    leagueRequired: 'gold',
+    hp: 120,
+    armor: 0.15,
+    speed: 10,
+    turnRate: 1.0,
+    damage: 18,         // per-tick damage while in flamethrower cone
+    fireRate: 10,       // continuous (ticks per second)
+    range: 20,          // short range only
+    ability: 'infernoBurst',
+    abilityCooldown: 20,
+    colorBody: 0x8b1a00,
+    colorTurret: 0xcc3300,
+    scaleHull: 1.05,
+  },
+
+  shieldTank: {
+    id: 'shieldTank',
+    name: 'Shield Tank',
+    description: 'Medium speed, medium armor. Has Energy Shield ability — blocks all incoming fire for 5s.',
+    price: 15000,
+    leagueRequired: 'platinum',
+    hp: 150,
+    armor: 0.20,
+    speed: 11,
+    turnRate: 1.0,
+    damage: 28,
+    fireRate: 0.8,
+    range: 85,
+    ability: 'energyShield',
+    abilityCooldown: 25,
+    colorBody: 0x1a3a8b,
+    colorTurret: 0x2255cc,
+    scaleHull: 1.15,
+  },
+
+  jumpTank: {
+    id: 'jumpTank',
+    name: 'Jump Tank',
+    description: 'Light-medium armor. Has Rocket Jump — launches into air, lands with area damage.',
+    price: 15000,
+    leagueRequired: 'platinum',
+    hp: 100,
+    armor: 0.12,
+    speed: 14,
+    turnRate: 1.3,
+    damage: 25,
+    fireRate: 0.9,
+    range: 80,
+    ability: 'rocketJump',
+    abilityCooldown: 15,
+    colorBody: 0x2a5a8b,
+    colorTurret: 0x3a7ab0,
+    scaleHull: 0.95,
+  },
+
+  siegeTank: {
+    id: 'siegeTank',
+    name: 'Siege Tank',
+    description: 'Heavy armor, powerful cannon. Has Lockdown Mode — stationary but doubles fire rate and range for 8s.',
+    price: 25000,
+    leagueRequired: 'diamond',
+    hp: 250,
+    armor: 0.35,
+    speed: 5,
+    turnRate: 0.5,
+    damage: 90,
+    fireRate: 0.35,
+    range: 110,
+    ability: 'lockdownMode',
+    abilityCooldown: 20,
+    colorBody: 0x3a2a1a,
+    colorTurret: 0x5a4030,
+    scaleHull: 1.5,
+  },
+};
+
+/**
+ * Ordered array of tank IDs for shop display order.
+ */
+export const TANK_ORDER = [
+  'standard',
+  'scout',
+  'heavy',
+  'artillery',
+  'flameTank',
+  'shieldTank',
+  'jumpTank',
+  'siegeTank',
+];
+
+/**
+ * Return a tank definition by id. Throws if the id is unknown.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getTankDef(id) {
+  const def = TankDefs[id];
+  if (!def) {
+    throw new Error(`Unknown tank id: "${id}"`);
+  }
+  return def;
+}

--- a/src/data/UpgradeDefs.js
+++ b/src/data/UpgradeDefs.js
@@ -1,0 +1,411 @@
+/**
+ * UpgradeDefs.js — Static definitions for all upgrades.
+ *
+ * Two categories:
+ *   TANK_UPGRADE_DEFS  — permanent per-tank-class stat upgrades.
+ *   FOOT_UPGRADE_DEFS  — permanent per-weapon on-foot upgrades.
+ *
+ * Upgrade tiers and league caps (from VISION.md):
+ *   Tier 1 — Bronze minimum  (+10–15% stat boost)
+ *   Tier 2 — Bronze minimum  (+15–20%)
+ *   Tier 3 — Silver minimum  (+20–25%)
+ *   Tier 4 — Gold minimum    (+25–30%)
+ *   Tier 5 — Platinum minimum(+30–35%)
+ *
+ * League tier-cap table (maximum tier purchasable per league):
+ *   Bronze   → tier 2
+ *   Silver   → tier 3
+ *   Gold     → tier 4
+ *   Platinum → tier 5
+ *   Diamond  → tier 5 (no additional cap)
+ *   Champion → tier 5
+ *
+ * Each upgrade entry has:
+ *   id:          Stable string key.
+ *   name:        Display name.
+ *   description: Effect description.
+ *   category:    'tank' | 'foot'
+ *   maxTier:     Highest purchasable tier (1–5).
+ *   costs:       Array of prices indexed by tier (costs[0] = tier 1 price, etc.).
+ *   stat:        Which stat this upgrade affects.
+ *   bonusPerTier: Flat or fractional bonus applied per tier level.
+ *   bonusType:   'additive_percent' = multiply base by (1 + tier * bonus) |
+ *                'additive_flat'    = add (tier * bonus) to base value.
+ *
+ * Stat multiplier helpers are exported separately (see applyUpgrades).
+ */
+
+// ---------------------------------------------------------------------------
+// League tier-cap constants
+// ---------------------------------------------------------------------------
+export const LEAGUE_TIER_CAPS = {
+  bronze:   2,
+  silver:   3,
+  gold:     4,
+  platinum: 5,
+  diamond:  5,
+  champion: 5,
+};
+
+// ---------------------------------------------------------------------------
+// Tank upgrades (apply per-tank-class; upgrading Standard does not affect Heavy)
+// ---------------------------------------------------------------------------
+export const TankUpgradeDefs = {
+  armorPlating: {
+    id: 'armorPlating',
+    name: 'Armor Plating',
+    description: 'Increases maximum HP of this tank class.',
+    category: 'tank',
+    maxTier: 5,
+    costs: [500, 1000, 2000, 4000, 8000],
+    stat: 'hp',
+    bonusPerTier: 0.15,     // +15% HP per tier → tier 5 = +75% HP
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold', 'platinum'],
+  },
+
+  engine: {
+    id: 'engine',
+    name: 'Engine',
+    description: 'Increases speed and turn rate of this tank class.',
+    category: 'tank',
+    maxTier: 5,
+    costs: [500, 1000, 2000, 4000, 8000],
+    stat: 'speed',              // also improves turnRate proportionally
+    bonusPerTier: 0.12,         // +12% speed per tier
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold', 'platinum'],
+  },
+
+  mainGun: {
+    id: 'mainGun',
+    name: 'Main Gun',
+    description: 'Increases shell damage and reduces reload time.',
+    category: 'tank',
+    maxTier: 5,
+    costs: [750, 1500, 3000, 6000, 12000],
+    stat: 'damage',             // also improves fireRate proportionally (–8% reload per tier)
+    bonusPerTier: 0.15,
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold', 'platinum'],
+  },
+
+  ammoCapacity: {
+    id: 'ammoCapacity',
+    name: 'Ammo Capacity',
+    description: 'Increases maximum ammo loaded per resupply.',
+    category: 'tank',
+    maxTier: 3,
+    costs: [300, 600, 1200],
+    stat: 'ammo',
+    bonusPerTier: 10,           // +10 ammo per tier (flat)
+    bonusType: 'additive_flat',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+
+  tracks: {
+    id: 'tracks',
+    name: 'Tracks',
+    description: 'Improves hill climbing and reduces terrain slowdown.',
+    category: 'tank',
+    maxTier: 3,
+    costs: [400, 800, 1600],
+    stat: 'terrainPenalty',
+    bonusPerTier: 0.20,         // –20% terrain speed penalty per tier
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+
+  hullReinforcement: {
+    id: 'hullReinforcement',
+    name: 'Hull Reinforcement',
+    description: 'Increases resistance to explosive (splash) damage.',
+    category: 'tank',
+    maxTier: 3,
+    costs: [600, 1200, 2400],
+    stat: 'explosiveResistance',
+    bonusPerTier: 0.15,         // +15% explosive damage reduction per tier
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// On-foot weapon upgrades (apply per-weapon; upgrading AR does not affect Sniper)
+// ---------------------------------------------------------------------------
+export const FootUpgradeDefs = {
+  firearmdamage: {
+    id: 'firearmdamage',
+    name: 'Firearm Damage',
+    description: 'Increases bullet damage for the equipped gun.',
+    category: 'foot',
+    maxTier: 5,
+    costs: [400, 800, 1600, 3200, 6400],
+    stat: 'damage',
+    bonusPerTier: 0.15,
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold', 'platinum'],
+  },
+
+  fireRate: {
+    id: 'fireRate',
+    name: 'Fire Rate',
+    description: 'Reduces time between shots for the equipped gun.',
+    category: 'foot',
+    maxTier: 5,
+    costs: [400, 800, 1600, 3200, 6400],
+    stat: 'fireRate',
+    bonusPerTier: 0.12,         // +12% fire rate per tier
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold', 'platinum'],
+  },
+
+  clipSize: {
+    id: 'clipSize',
+    name: 'Clip Size',
+    description: 'Increases ammo capacity before reload.',
+    category: 'foot',
+    maxTier: 3,
+    costs: [300, 600, 1200],
+    stat: 'clipSize',
+    bonusPerTier: 5,            // +5 rounds per tier (flat)
+    bonusType: 'additive_flat',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+
+  reloadSpeed: {
+    id: 'reloadSpeed',
+    name: 'Reload Speed',
+    description: 'Reduces reload time for the equipped gun.',
+    category: 'foot',
+    maxTier: 3,
+    costs: [300, 600, 1200],
+    stat: 'reloadTime',
+    bonusPerTier: 0.15,         // –15% reload time per tier
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+
+  meleeDamage: {
+    id: 'meleeDamage',
+    name: 'Melee Damage',
+    description: 'Increases damage per melee hit.',
+    category: 'foot',
+    maxTier: 4,
+    costs: [300, 600, 1200, 2400],
+    stat: 'damage',
+    bonusPerTier: 0.20,
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold'],
+  },
+
+  meleeReach: {
+    id: 'meleeReach',
+    name: 'Melee Reach',
+    description: 'Extends the effective range of melee attacks.',
+    category: 'foot',
+    maxTier: 3,
+    costs: [250, 500, 1000],
+    stat: 'range',
+    bonusPerTier: 0.5,          // +0.5 world units per tier (flat)
+    bonusType: 'additive_flat',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+
+  sprintSpeed: {
+    id: 'sprintSpeed',
+    name: 'Sprint Speed',
+    description: 'Increases on-foot movement speed.',
+    category: 'foot',
+    maxTier: 3,
+    costs: [400, 800, 1600],
+    stat: 'speed',
+    bonusPerTier: 0.12,
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver'],
+  },
+
+  bodyArmor: {
+    id: 'bodyArmor',
+    name: 'Body Armor',
+    description: 'Increases on-foot maximum HP.',
+    category: 'foot',
+    maxTier: 4,
+    costs: [500, 1000, 2000, 4000],
+    stat: 'hp',
+    bonusPerTier: 0.20,
+    bonusType: 'additive_percent',
+    leaguePerTier: ['bronze', 'bronze', 'silver', 'gold'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Ordered lists for shop display
+// ---------------------------------------------------------------------------
+export const TANK_UPGRADE_ORDER = [
+  'armorPlating',
+  'engine',
+  'mainGun',
+  'ammoCapacity',
+  'tracks',
+  'hullReinforcement',
+];
+
+export const FOOT_UPGRADE_ORDER = [
+  'firearmdamage',
+  'fireRate',
+  'clipSize',
+  'reloadSpeed',
+  'meleeDamage',
+  'meleeReach',
+  'sprintSpeed',
+  'bodyArmor',
+];
+
+// ---------------------------------------------------------------------------
+// Stat computation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate the stat multiplier for a given tier of a percent-based upgrade.
+ * Returns the total multiplier (e.g. 1.30 means +30% of base).
+ *
+ * @param {object} upgradeDef  - An entry from TankUpgradeDefs or FootUpgradeDefs.
+ * @param {number} tier        - Current purchased tier (0 = none, 1–maxTier).
+ * @returns {number}
+ */
+export function getUpgradeMultiplier(upgradeDef, tier) {
+  if (upgradeDef.bonusType !== 'additive_percent') {
+    return 1;
+  }
+  return 1 + upgradeDef.bonusPerTier * tier;
+}
+
+/**
+ * Calculate the flat additive bonus for a given tier of a flat upgrade.
+ *
+ * @param {object} upgradeDef
+ * @param {number} tier
+ * @returns {number}
+ */
+export function getUpgradeFlat(upgradeDef, tier) {
+  if (upgradeDef.bonusType !== 'additive_flat') {
+    return 0;
+  }
+  return upgradeDef.bonusPerTier * tier;
+}
+
+/**
+ * Apply all purchased tank upgrades to a base stats object.
+ *
+ * @param {object} baseStats          — plain object with base stat values.
+ * @param {object} purchasedUpgrades  — { upgradeId: tier } map for this tank class.
+ * @returns {object}                  — new stats object with upgrades applied.
+ */
+export function applyTankUpgrades(baseStats, purchasedUpgrades) {
+  const stats = { ...baseStats };
+
+  for (const [id, tier] of Object.entries(purchasedUpgrades)) {
+    if (tier === 0) {
+      continue;
+    }
+    const def = TankUpgradeDefs[id];
+    if (!def) {
+      continue;
+    }
+
+    if (def.bonusType === 'additive_percent') {
+      const multiplier = getUpgradeMultiplier(def, tier);
+      stats[def.stat] = baseStats[def.stat] * multiplier;
+
+      // Engine also improves turnRate at the same rate.
+      if (id === 'engine' && 'turnRate' in stats) {
+        stats.turnRate = baseStats.turnRate * multiplier;
+      }
+
+      // Main Gun also reduces reload time (fireRate improvement).
+      if (id === 'mainGun' && 'fireRate' in stats) {
+        // Each tier reduces reload by 8%, which increases shots per second.
+        const fireRateMultiplier = 1 + 0.08 * tier;
+        stats.fireRate = baseStats.fireRate * fireRateMultiplier;
+      }
+    } else {
+      stats[def.stat] = baseStats[def.stat] + getUpgradeFlat(def, tier);
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Apply all purchased foot upgrades to a base weapon stats object.
+ *
+ * @param {object} baseStats          — plain object with base stat values.
+ * @param {object} purchasedUpgrades  — { upgradeId: tier } map for this weapon.
+ * @returns {object}                  — new stats object with upgrades applied.
+ */
+export function applyFootUpgrades(baseStats, purchasedUpgrades) {
+  const stats = { ...baseStats };
+
+  for (const [id, tier] of Object.entries(purchasedUpgrades)) {
+    if (tier === 0) {
+      continue;
+    }
+    const def = FootUpgradeDefs[id];
+    if (!def) {
+      continue;
+    }
+
+    if (def.bonusType === 'additive_percent') {
+      const multiplier = getUpgradeMultiplier(def, tier);
+      // Reload time reduces (lower is better): invert the multiplier.
+      if (id === 'reloadSpeed') {
+        stats[def.stat] = baseStats[def.stat] / multiplier;
+      } else {
+        stats[def.stat] = baseStats[def.stat] * multiplier;
+      }
+    } else {
+      stats[def.stat] = baseStats[def.stat] + getUpgradeFlat(def, tier);
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Return the maximum purchasable tier for a given upgrade in the current league.
+ *
+ * @param {object} upgradeDef   — An upgrade definition object.
+ * @param {string} currentLeague — e.g. 'bronze', 'silver'.
+ * @returns {number}            — 0 if no tiers are available yet, otherwise 1–maxTier.
+ */
+export function getMaxAvailableTier(upgradeDef, currentLeague) {
+  const leagueCap = LEAGUE_TIER_CAPS[currentLeague] ?? 0;
+  return Math.min(upgradeDef.maxTier, leagueCap);
+}
+
+/**
+ * Lookup a tank upgrade definition by id. Throws if unknown.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getTankUpgradeDef(id) {
+  const def = TankUpgradeDefs[id];
+  if (!def) {
+    throw new Error(`Unknown tank upgrade id: "${id}"`);
+  }
+  return def;
+}
+
+/**
+ * Lookup a foot upgrade definition by id. Throws if unknown.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getFootUpgradeDef(id) {
+  const def = FootUpgradeDefs[id];
+  if (!def) {
+    throw new Error(`Unknown foot upgrade id: "${id}"`);
+  }
+  return def;
+}

--- a/src/data/WeaponDefs.js
+++ b/src/data/WeaponDefs.js
@@ -1,0 +1,353 @@
+/**
+ * WeaponDefs.js — Static definitions for all on-foot weapons.
+ *
+ * Two categories:
+ *   GUN_DEFS   — primary ranged weapons (pistol through plasma cannon)
+ *   MELEE_DEFS — melee weapons (knife through energy blade)
+ *
+ * Stat reference:
+ *   damage:       Damage per hit (guns: per bullet/shell; melee: per swing).
+ *   fireRate:     Shots per second (guns only).
+ *   range:        Effective range in world units. Melee values are close-range (≤ 3 m).
+ *   clipSize:     Rounds before reload is needed.
+ *   reloadTime:   Seconds to complete a reload.
+ *   spread:       Inaccuracy cone half-angle in degrees at default range.
+ *   projectileSpeed: World-units per second (0 = instant/hitscan).
+ *   splashRadius: AoE damage radius in world units (0 = point damage only).
+ *   chargeTime:   Seconds to hold fire for max damage (0 = instant).
+ *   ability:      Special ability identifier (null if none).
+ *   abilityCooldown: Seconds between ability uses.
+ *   isExplosive:  true = triggers splash / arc trajectory.
+ *   isArc:        true = projectile follows ballistic arc (grenade launcher).
+ *   leagueRequired: 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond'
+ *   price:        Shop cost in $. 0 = free starter weapon.
+ */
+
+// ---------------------------------------------------------------------------
+// Guns (primary ranged weapons)
+// ---------------------------------------------------------------------------
+export const GunDefs = {
+  pistol: {
+    id: 'pistol',
+    name: 'Pistol',
+    type: 'gun',
+    description: 'Starter sidearm. Low damage, decent fire rate. Always available.',
+    price: 0,
+    leagueRequired: 'bronze',
+    damage: 12,
+    fireRate: 2.0,
+    range: 40,
+    clipSize: 12,
+    reloadTime: 1.2,
+    spread: 5,
+    projectileSpeed: 80,
+    splashRadius: 0,
+    chargeTime: 0,
+    isExplosive: false,
+    isArc: false,
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  smg: {
+    id: 'smg',
+    name: 'SMG',
+    type: 'gun',
+    description: 'Fast fire rate, low accuracy at range. Effective up close.',
+    price: 1500,
+    leagueRequired: 'bronze',
+    damage: 9,
+    fireRate: 5.0,
+    range: 25,
+    clipSize: 30,
+    reloadTime: 1.6,
+    spread: 10,
+    projectileSpeed: 90,
+    splashRadius: 0,
+    chargeTime: 0,
+    isExplosive: false,
+    isArc: false,
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  assaultRifle: {
+    id: 'assaultRifle',
+    name: 'Assault Rifle',
+    type: 'gun',
+    description: 'Balanced damage and fire rate. The workhorse weapon for Silver+ players.',
+    price: 3000,
+    leagueRequired: 'silver',
+    damage: 18,
+    fireRate: 3.0,
+    range: 60,
+    clipSize: 25,
+    reloadTime: 1.8,
+    spread: 4,
+    projectileSpeed: 100,
+    splashRadius: 0,
+    chargeTime: 0,
+    isExplosive: false,
+    isArc: false,
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  sniperRifle: {
+    id: 'sniperRifle',
+    name: 'Sniper Rifle',
+    type: 'gun',
+    description: 'High damage, slow fire, very long range. Must stand still to use effectively.',
+    price: 4500,
+    leagueRequired: 'silver',
+    damage: 60,
+    fireRate: 0.5,
+    range: 200,
+    clipSize: 5,
+    reloadTime: 2.5,
+    spread: 0.5,
+    projectileSpeed: 300,   // fast, near-instant
+    splashRadius: 0,
+    chargeTime: 0,
+    isExplosive: false,
+    isArc: false,
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  shotgun: {
+    id: 'shotgun',
+    name: 'Shotgun',
+    type: 'gun',
+    description: 'Devastating up close with spread pellets, useless at range.',
+    price: 3500,
+    leagueRequired: 'silver',
+    damage: 15,             // per pellet (fires 8 pellets per shot)
+    fireRate: 1.0,
+    range: 15,
+    clipSize: 8,
+    reloadTime: 2.0,
+    spread: 20,
+    projectileSpeed: 70,
+    splashRadius: 0,
+    chargeTime: 0,
+    isExplosive: false,
+    isArc: false,
+    pelletsPerShot: 8,      // shotgun-specific
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  grenadeLauncher: {
+    id: 'grenadeLauncher',
+    name: 'Grenade Launcher',
+    type: 'gun',
+    description: 'Area damage on impact, arc trajectory, slow reload. Cluster Bomb ability.',
+    price: 6000,
+    leagueRequired: 'gold',
+    damage: 55,
+    fireRate: 0.6,
+    range: 70,
+    clipSize: 6,
+    reloadTime: 3.0,
+    spread: 2,
+    projectileSpeed: 30,    // slow arc
+    splashRadius: 6,
+    chargeTime: 0,
+    isExplosive: true,
+    isArc: true,
+    ability: 'clusterBomb',
+    abilityCooldown: 18,
+  },
+
+  rocketLauncher: {
+    id: 'rocketLauncher',
+    name: 'Rocket Launcher',
+    type: 'gun',
+    description: 'High single-target damage with splash. Lock-On ability tracks nearest enemy.',
+    price: 8000,
+    leagueRequired: 'gold',
+    damage: 90,
+    fireRate: 0.4,
+    range: 100,
+    clipSize: 4,
+    reloadTime: 3.5,
+    spread: 1,
+    projectileSpeed: 50,
+    splashRadius: 8,
+    chargeTime: 0,
+    isExplosive: true,
+    isArc: false,
+    ability: 'lockOn',
+    abilityCooldown: 15,
+  },
+
+  railgun: {
+    id: 'railgun',
+    name: 'Railgun',
+    type: 'gun',
+    description: 'Pierces through multiple enemies in a line. Requires a brief charge. Overcharge ability.',
+    price: 12000,
+    leagueRequired: 'platinum',
+    damage: 80,
+    fireRate: 0.35,
+    range: 180,
+    clipSize: 8,
+    reloadTime: 2.8,
+    spread: 0,
+    projectileSpeed: 500,   // near-instant rail
+    splashRadius: 0,
+    chargeTime: 0.8,        // must hold before firing
+    isExplosive: false,
+    isArc: false,
+    piercing: true,         // railgun-specific: hits all in line
+    ability: 'overcharge',
+    abilityCooldown: 20,
+  },
+
+  plasmaCannon: {
+    id: 'plasmaCannon',
+    name: 'Plasma Cannon',
+    type: 'gun',
+    description: 'Massive damage, slow energy projectile, high splash. Nova Blast ability.',
+    price: 18000,
+    leagueRequired: 'diamond',
+    damage: 150,
+    fireRate: 0.25,
+    range: 120,
+    clipSize: 3,
+    reloadTime: 4.0,
+    spread: 1,
+    projectileSpeed: 40,
+    splashRadius: 12,
+    chargeTime: 0,
+    isExplosive: true,
+    isArc: false,
+    ability: 'novaBlast',
+    abilityCooldown: 25,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Melee weapons
+// ---------------------------------------------------------------------------
+export const MeleeDefs = {
+  combatKnife: {
+    id: 'combatKnife',
+    name: 'Combat Knife',
+    type: 'melee',
+    description: 'Starter melee. Quick, low damage. Always available.',
+    price: 0,
+    leagueRequired: 'bronze',
+    damage: 30,
+    attackRate: 2.5,        // swings per second
+    range: 2.0,             // world units reach
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  machete: {
+    id: 'machete',
+    name: 'Machete',
+    type: 'melee',
+    description: 'Wider swing arc, more damage than the knife.',
+    price: 1000,
+    leagueRequired: 'bronze',
+    damage: 50,
+    attackRate: 1.8,
+    range: 2.5,
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  warHammer: {
+    id: 'warHammer',
+    name: 'War Hammer',
+    type: 'melee',
+    description: 'Slow, heavy damage, small knockback on hit.',
+    price: 3000,
+    leagueRequired: 'silver',
+    damage: 100,
+    attackRate: 1.0,
+    range: 2.2,
+    knockback: 3,           // world-units impulse on hit
+    ability: null,
+    abilityCooldown: 0,
+  },
+
+  energyBlade: {
+    id: 'energyBlade',
+    name: 'Energy Blade',
+    type: 'melee',
+    description: 'Fast, high damage, glowing visual. Dash Strike ability.',
+    price: 10000,
+    leagueRequired: 'gold',
+    damage: 120,
+    attackRate: 3.0,
+    range: 3.0,
+    ability: 'dashStrike',
+    abilityCooldown: 12,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Ordered lists for shop display
+// ---------------------------------------------------------------------------
+export const GUN_ORDER = [
+  'pistol',
+  'smg',
+  'assaultRifle',
+  'sniperRifle',
+  'shotgun',
+  'grenadeLauncher',
+  'rocketLauncher',
+  'railgun',
+  'plasmaCannon',
+];
+
+export const MELEE_ORDER = [
+  'combatKnife',
+  'machete',
+  'warHammer',
+  'energyBlade',
+];
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a gun definition by id. Throws if unknown.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getGunDef(id) {
+  const def = GunDefs[id];
+  if (!def) {
+    throw new Error(`Unknown gun id: "${id}"`);
+  }
+  return def;
+}
+
+/**
+ * Return a melee definition by id. Throws if unknown.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getMeleeDef(id) {
+  const def = MeleeDefs[id];
+  if (!def) {
+    throw new Error(`Unknown melee id: "${id}"`);
+  }
+  return def;
+}
+
+/**
+ * Return any weapon def (gun or melee) by id.
+ * Checks guns first, then melee.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getWeaponDef(id) {
+  return GunDefs[id] ?? MeleeDefs[id] ?? (() => { throw new Error(`Unknown weapon id: "${id}"`); })();
+}


### PR DESCRIPTION
## Summary

Implements `src/data/` module with three static definition files covering all game data specified in VISION.md.

### Files added

- **`src/data/TankDefs.js`** — all 8 tank classes (Standard → Siege Tank) with `hp`, `armor`, `speed`, `turnRate`, `damage`, `fireRate`, `range`, `ability`, `price`, `leagueRequired`, and per-class color values. Exports `getTankDef(id)` and `TANK_ORDER`.
- **`src/data/WeaponDefs.js`** — 9 on-foot guns (Pistol → Plasma Cannon) and 4 melee weapons (Combat Knife → Energy Blade). Each entry has full stat blocks: damage, fireRate, range, clipSize, reloadTime, spread, projectileSpeed, splashRadius, chargeTime, piercing, pelletsPerShot, isExplosive, isArc, ability, abilityCooldown. Exports `getGunDef()`, `getMeleeDef()`, `getWeaponDef()`.
- **`src/data/UpgradeDefs.js`** — 6 tank upgrades (Armor Plating, Engine, Main Gun, Ammo Capacity, Tracks, Hull Reinforcement) and 8 foot upgrades (Firearm Damage, Fire Rate, Clip Size, Reload Speed, Melee Damage, Melee Reach, Sprint Speed, Body Armor). Exports `applyTankUpgrades()`, `applyFootUpgrades()`, `getMaxAvailableTier()`, `LEAGUE_TIER_CAPS`.

### Verification

All stats match VISION.md tables. Node import + assertion suite confirmed:
- 8 tanks present with correct prices/leagues
- 9 guns + 4 melee weapons
- `applyTankUpgrades({ hp:100 }, { armorPlating:2 })` → `hp === 130` ✓
- League tier caps: Bronze→2, Platinum→5 ✓

Resolves #32