### PR TITLE
t020: LeagueSystem — LP tracking, promote/demote logic on match result

### DIFF
--- a/src/data/LeagueDefs.js
+++ b/src/data/LeagueDefs.js
@@ -235,3 +235,23 @@ export function getLeagueForLP(lp) {
   }
   return 'bronze';
 }
+
+/**
+ * Minimum LP floor per league.
+ *
+ * Prevents a losing streak from dropping the player more than one league tier
+ * per LP calculation. The floor equals the lpRequired of the league below,
+ * so the player can demote to the previous tier but LP cannot skip past it.
+ *
+ * Bronze floor is 0 (no league below).
+ *
+ * @param {string} leagueId
+ * @returns {number}
+ */
+export function lpFloorForLeague(leagueId) {
+  const idx = LEAGUE_ORDER.indexOf(leagueId);
+  if (idx <= 0) {
+    return 0;
+  }
+  return LeagueDefs[LEAGUE_ORDER[idx - 1]].lpRequired;
+}

--- a/src/systems/LeagueSystem.js
+++ b/src/systems/LeagueSystem.js
@@ -1,0 +1,289 @@
+/**
+ * LeagueSystem — LP tracking, promotion/demotion logic on match result.
+ *
+ * Manages the player's accumulated League Points (LP) and league tier, applying
+ * LP gains/losses after every match and handling tier promotions and demotions
+ * according to VISION.md §League System.
+ *
+ * LP Gains/Losses (VISION.md):
+ *   Win match (2-0 sweep)   : +40 LP
+ *   Win match (2-1 close)   : +25 LP
+ *   Lose match (1-2 close)  : -10 LP
+ *   Lose match (0-2 sweep)  : -20 LP
+ *
+ * Promotion:  LP reaches the current league's `lpToPromote` threshold.
+ * Demotion:   LP falls below the current league's `lpRequired` threshold
+ *             (can only demote one tier at a time due to the LP floor).
+ *
+ * Usage:
+ *   const league = new LeagueSystem({ leagueId: 'bronze', lp: 0 });
+ *
+ *   // After each match:
+ *   const result = league.applyMatchResult({ playerWins: 2, enemyWins: 0 });
+ *   // result: { lpDelta, newLp, oldLeagueId, newLeagueId, promoted, demoted }
+ *
+ *   // Read state:
+ *   league.leagueId       // current league ID string
+ *   league.lp             // current LP total
+ *   league.def            // full LeagueDefs entry for the current league
+ *   league.lpToNextLeague // LP gap to next promotion (Infinity at champion)
+ *   league.isMaxLeague    // true at champion tier
+ *   league.canUnlock(id)  // whether a tank/weapon/tier is accessible
+ */
+
+import { LeagueDefs, LEAGUE_ORDER, lpFloorForLeague, getLeagueForLP } from '../data/LeagueDefs.js';
+
+/**
+ * Encodes the four match outcomes into LP deltas.
+ * Key format: `${playerWins}-${enemyWins}` (best-of-3, first to 2 wins).
+ *
+ * @private
+ */
+const LP_DELTA_TABLE = {
+  '2-0': +40,   // win 2-0 sweep
+  '2-1': +25,   // win 2-1 close
+  '1-2': -10,   // lose 1-2 close
+  '0-2': -20,   // lose 0-2 sweep
+};
+
+export class LeagueSystem {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.leagueId='bronze']  Starting league ID.
+   * @param {number} [opts.lp=0]               Starting LP total.
+   * @param {object} [opts.lpDeltas]           Override LP delta table (for testing / balancing).
+   */
+  constructor(opts = {}) {
+    const { leagueId = 'bronze', lp = 0, lpDeltas = {} } = opts;
+
+    if (!LeagueDefs[leagueId]) {
+      throw new Error(`[LeagueSystem] Unknown leagueId: "${leagueId}"`);
+    }
+
+    /** @type {string} */
+    this._leagueId = leagueId;
+
+    /** @type {number} Raw accumulated LP. Never drops below 0. */
+    this._lp = Math.max(0, Math.floor(lp));
+
+    /**
+     * LP delta overrides — used for tuning / A-B testing without touching
+     * the canonical VISION.md table.
+     * @private
+     */
+    this._lpDeltas = { ...LP_DELTA_TABLE, ...lpDeltas };
+
+    /** Ordered history of match results applied this session. */
+    this._matchHistory = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Accessors
+  // ---------------------------------------------------------------------------
+
+  /** Current league ID. @type {string} */
+  get leagueId() {
+    return this._leagueId;
+  }
+
+  /** Current LP total. @type {number} */
+  get lp() {
+    return this._lp;
+  }
+
+  /** Full LeagueDefs entry for the current league. @type {object} */
+  get def() {
+    return LeagueDefs[this._leagueId];
+  }
+
+  /** LP required to promote to the next league (Infinity at champion). @type {number} */
+  get lpToNextLeague() {
+    const promotionThreshold = this.def.lpToPromote;
+    if (!isFinite(promotionThreshold)) {
+      return Infinity;
+    }
+    return Math.max(0, promotionThreshold - this._lp);
+  }
+
+  /** True when the player is at Champion (no further promotion possible). @type {boolean} */
+  get isMaxLeague() {
+    return this._leagueId === LEAGUE_ORDER[LEAGUE_ORDER.length - 1];
+  }
+
+  /**
+   * LP progress within the current league tier, as a fraction 0–1.
+   * Useful for rendering a progress bar.
+   *
+   * Returns 1.0 at champion tier.
+   *
+   * @type {number}
+   */
+  get tierProgress() {
+    const { lpRequired, lpToPromote } = this.def;
+    if (!isFinite(lpToPromote)) {
+      return 1.0;
+    }
+    const range = lpToPromote - lpRequired;
+    if (range <= 0) {
+      return 1.0;
+    }
+    return Math.min(1.0, (this._lp - lpRequired) / range);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Match result application
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply LP changes from a completed match and resolve promotion/demotion.
+   *
+   * Best-of-3: `playerWins` and `enemyWins` must sum to 3 or be a valid early-
+   * exit result (2-0 or 0-2). Valid combos: 2-0, 2-1, 1-2, 0-2.
+   *
+   * @param {object} params
+   * @param {number} params.playerWins  Rounds won by the player's team (0–2).
+   * @param {number} params.enemyWins   Rounds won by the enemy team (0–2).
+   * @returns {MatchLpResult}
+   */
+  applyMatchResult({ playerWins, enemyWins }) {
+    const key = `${playerWins}-${enemyWins}`;
+    const lpDelta = this._lpDeltas[key];
+
+    if (lpDelta === undefined) {
+      throw new Error(
+        `[LeagueSystem] Invalid match result "${key}". ` +
+        `Valid results: ${Object.keys(LP_DELTA_TABLE).join(', ')}`
+      );
+    }
+
+    const oldLeagueId = this._leagueId;
+    const oldLp = this._lp;
+
+    // Apply LP delta, clamped to LP floor for the current league.
+    const floor = lpFloorForLeague(this._leagueId);
+    const rawNewLp = this._lp + lpDelta;
+    this._lp = Math.max(floor, rawNewLp);
+
+    // Resolve new league from updated LP total.
+    const resolvedLeagueId = getLeagueForLP(this._lp);
+
+    const promoted = LEAGUE_ORDER.indexOf(resolvedLeagueId) > LEAGUE_ORDER.indexOf(oldLeagueId);
+    const demoted  = LEAGUE_ORDER.indexOf(resolvedLeagueId) < LEAGUE_ORDER.indexOf(oldLeagueId);
+
+    this._leagueId = resolvedLeagueId;
+
+    const result = {
+      lpDelta,
+      oldLp,
+      newLp: this._lp,
+      oldLeagueId,
+      newLeagueId: this._leagueId,
+      promoted,
+      demoted,
+    };
+
+    this._matchHistory.push({
+      ...result,
+      playerWins,
+      enemyWins,
+      appliedAt: Date.now(),
+    });
+
+    console.info(
+      `[LeagueSystem] Match ${playerWins}-${enemyWins}: ` +
+      `LP ${oldLp} → ${this._lp} (${lpDelta >= 0 ? '+' : ''}${lpDelta}). ` +
+      `League: ${oldLeagueId}${promoted ? ' → ' + this._leagueId + ' (PROMOTED)' : ''}` +
+      `${demoted ? ' → ' + this._leagueId + ' (DEMOTED)' : ''}`
+    );
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unlock checks
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns true if the player's current league meets or exceeds the requirement.
+   *
+   * @param {string} requiredLeagueId  The minimum league needed ('bronze', 'silver', …).
+   * @returns {boolean}
+   */
+  meetsLeagueRequirement(requiredLeagueId) {
+    const playerRank   = LEAGUE_ORDER.indexOf(this._leagueId);
+    const requiredRank = LEAGUE_ORDER.indexOf(requiredLeagueId);
+    if (requiredRank === -1) {
+      throw new Error(`[LeagueSystem] Unknown requiredLeagueId: "${requiredLeagueId}"`);
+    }
+    return playerRank >= requiredRank;
+  }
+
+  /**
+   * Returns the maximum upgrade tier the player can purchase at their current league.
+   *
+   * @returns {number}  1–5.
+   */
+  get upgradeTierCap() {
+    return this.def.upgradeTierCap;
+  }
+
+  /**
+   * Returns true if the player can purchase upgrade tier `tier` at their current league.
+   *
+   * @param {number} tier  1-based upgrade tier to check.
+   * @returns {boolean}
+   */
+  canAffordUpgradeTier(tier) {
+    return tier <= this.upgradeTierCap;
+  }
+
+  // ---------------------------------------------------------------------------
+  // State sync (for SaveSystem integration)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Restore league state loaded from SaveSystem.
+   * Call once after constructing the system from a saved profile.
+   *
+   * @param {string} leagueId
+   * @param {number} lp
+   */
+  loadFromSave(leagueId, lp) {
+    if (!LeagueDefs[leagueId]) {
+      console.warn(
+        `[LeagueSystem] loadFromSave: unknown leagueId "${leagueId}" — defaulting to bronze.`
+      );
+      leagueId = 'bronze';
+    }
+    this._leagueId = leagueId;
+    this._lp = Math.max(0, Math.floor(lp));
+  }
+
+  // ---------------------------------------------------------------------------
+  // History / debug
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Snapshot of match results applied this session (most recent last).
+   * @returns {Array<MatchLpResult & { playerWins: number, enemyWins: number, appliedAt: number }>}
+   */
+  getMatchHistory() {
+    return this._matchHistory.map(r => ({ ...r }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSDoc types
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {{
+ *   lpDelta:      number,
+ *   oldLp:        number,
+ *   newLp:        number,
+ *   oldLeagueId:  string,
+ *   newLeagueId:  string,
+ *   promoted:     boolean,
+ *   demoted:      boolean,
+ * }} MatchLpResult
+ */

--- a/tests/LeagueDefs.test.js
+++ b/tests/LeagueDefs.test.js
@@ -1,0 +1,154 @@
+/**
+ * LeagueDefs.test.js — unit tests for LeagueDefs data and helper functions.
+ *
+ * Run: node --test tests/LeagueDefs.test.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LeagueDefs,
+  LEAGUE_ORDER,
+  getLeagueDef,
+  getLeagueForLP,
+  lpFloorForLeague,
+} from '../src/data/LeagueDefs.js';
+
+// ---------------------------------------------------------------------------
+// LeagueDefs structure
+// ---------------------------------------------------------------------------
+
+test('LeagueDefs contains all 6 leagues', () => {
+  assert.deepEqual(Object.keys(LeagueDefs), LEAGUE_ORDER);
+});
+
+test('every league has required fields', () => {
+  for (const id of LEAGUE_ORDER) {
+    const def = LeagueDefs[id];
+    assert.equal(typeof def.id, 'string', `${id}.id`);
+    assert.equal(typeof def.name, 'string', `${id}.name`);
+    assert.equal(typeof def.lpRequired, 'number', `${id}.lpRequired`);
+    assert.equal(typeof def.upgradeTierCap, 'number', `${id}.upgradeTierCap`);
+    assert.ok(def.upgradeTierCap >= 1 && def.upgradeTierCap <= 5, `${id}.upgradeTierCap in [1,5]`);
+    assert.equal(typeof def.ai, 'object', `${id}.ai`);
+    assert.equal(typeof def.lpGains, 'object', `${id}.lpGains`);
+    assert.equal(typeof def.teamComposition, 'object', `${id}.teamComposition`);
+  }
+});
+
+test('lpRequired is strictly increasing', () => {
+  for (let i = 1; i < LEAGUE_ORDER.length; i++) {
+    const prev = LeagueDefs[LEAGUE_ORDER[i - 1]].lpRequired;
+    const curr = LeagueDefs[LEAGUE_ORDER[i]].lpRequired;
+    assert.ok(curr > prev, `${LEAGUE_ORDER[i]}.lpRequired (${curr}) > ${LEAGUE_ORDER[i-1]}.lpRequired (${prev})`);
+  }
+});
+
+test('champion lpToPromote is Infinity', () => {
+  assert.equal(LeagueDefs.champion.lpToPromote, Infinity);
+});
+
+test('lpRequired matches VISION.md table', () => {
+  assert.equal(LeagueDefs.bronze.lpRequired, 0);
+  assert.equal(LeagueDefs.silver.lpRequired, 500);
+  assert.equal(LeagueDefs.gold.lpRequired, 1200);
+  assert.equal(LeagueDefs.platinum.lpRequired, 2200);
+  assert.equal(LeagueDefs.diamond.lpRequired, 3500);
+  assert.equal(LeagueDefs.champion.lpRequired, 5000);
+});
+
+test('upgrade tier caps match VISION.md', () => {
+  assert.equal(LeagueDefs.bronze.upgradeTierCap, 2);
+  assert.equal(LeagueDefs.silver.upgradeTierCap, 3);
+  assert.equal(LeagueDefs.gold.upgradeTierCap, 4);
+  assert.equal(LeagueDefs.platinum.upgradeTierCap, 5);
+  assert.equal(LeagueDefs.diamond.upgradeTierCap, 5);
+  assert.equal(LeagueDefs.champion.upgradeTierCap, 5);
+});
+
+test('lpGains match VISION.md table for bronze', () => {
+  const { lpGains } = LeagueDefs.bronze;
+  assert.equal(lpGains.win20, 40);
+  assert.equal(lpGains.win21, 25);
+  assert.equal(lpGains.lose12, -10);
+  assert.equal(lpGains.lose02, -20);
+});
+
+test('teamComposition: bronze ally has 5 slots, enemy has 6', () => {
+  const tc = LeagueDefs.bronze.teamComposition;
+  assert.equal(tc.ally.length, 5);
+  assert.equal(tc.enemy.length, 6);
+});
+
+// ---------------------------------------------------------------------------
+// getLeagueDef
+// ---------------------------------------------------------------------------
+
+test('getLeagueDef returns the correct entry', () => {
+  const def = getLeagueDef('gold');
+  assert.equal(def.id, 'gold');
+  assert.equal(def.lpRequired, 1200);
+});
+
+test('getLeagueDef throws for unknown id', () => {
+  assert.throws(() => getLeagueDef('mythril'), /Unknown league id/);
+});
+
+// ---------------------------------------------------------------------------
+// lpFloorForLeague
+// ---------------------------------------------------------------------------
+
+test('lpFloorForLeague: bronze floor is 0', () => {
+  assert.equal(lpFloorForLeague('bronze'), 0);
+});
+
+test('lpFloorForLeague: silver floor equals bronze lpRequired (0)', () => {
+  assert.equal(lpFloorForLeague('silver'), LeagueDefs.bronze.lpRequired);
+});
+
+test('lpFloorForLeague: gold floor equals silver lpRequired (500)', () => {
+  assert.equal(lpFloorForLeague('gold'), LeagueDefs.silver.lpRequired);
+});
+
+test('lpFloorForLeague: champion floor equals diamond lpRequired (3500)', () => {
+  assert.equal(lpFloorForLeague('champion'), LeagueDefs.diamond.lpRequired);
+});
+
+// ---------------------------------------------------------------------------
+// getLeagueForLP
+// ---------------------------------------------------------------------------
+
+test('getLeagueForLP: 0 → bronze', () => {
+  assert.equal(getLeagueForLP(0), 'bronze');
+});
+
+test('getLeagueForLP: 499 → bronze', () => {
+  assert.equal(getLeagueForLP(499), 'bronze');
+});
+
+test('getLeagueForLP: 500 → silver', () => {
+  assert.equal(getLeagueForLP(500), 'silver');
+});
+
+test('getLeagueForLP: 1199 → silver', () => {
+  assert.equal(getLeagueForLP(1199), 'silver');
+});
+
+test('getLeagueForLP: 1200 → gold', () => {
+  assert.equal(getLeagueForLP(1200), 'gold');
+});
+
+test('getLeagueForLP: 2200 → platinum', () => {
+  assert.equal(getLeagueForLP(2200), 'platinum');
+});
+
+test('getLeagueForLP: 3500 → diamond', () => {
+  assert.equal(getLeagueForLP(3500), 'diamond');
+});
+
+test('getLeagueForLP: 5000 → champion', () => {
+  assert.equal(getLeagueForLP(5000), 'champion');
+});
+
+test('getLeagueForLP: very large number → champion', () => {
+  assert.equal(getLeagueForLP(999999), 'champion');
+});

--- a/tests/LeagueSystem.test.js
+++ b/tests/LeagueSystem.test.js
@@ -1,0 +1,252 @@
+/**
+ * LeagueSystem.test.js — unit tests for LeagueSystem LP tracking and promotion logic.
+ *
+ * Run: node --test tests/LeagueSystem.test.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { LeagueSystem } from '../src/systems/LeagueSystem.js';
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+test('default construction starts at bronze, 0 LP', () => {
+  const ls = new LeagueSystem();
+  assert.equal(ls.leagueId, 'bronze');
+  assert.equal(ls.lp, 0);
+});
+
+test('constructor accepts initial leagueId and lp', () => {
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 800 });
+  assert.equal(ls.leagueId, 'silver');
+  assert.equal(ls.lp, 800);
+});
+
+test('constructor rejects unknown leagueId', () => {
+  assert.throws(
+    () => new LeagueSystem({ leagueId: 'mythril' }),
+    /Unknown leagueId/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// LP deltas from match results
+// ---------------------------------------------------------------------------
+
+test('applyMatchResult 2-0: +40 LP', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 100 });
+  const result = ls.applyMatchResult({ playerWins: 2, enemyWins: 0 });
+  assert.equal(result.lpDelta, 40);
+  assert.equal(ls.lp, 140);
+});
+
+test('applyMatchResult 2-1: +25 LP', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 100 });
+  const result = ls.applyMatchResult({ playerWins: 2, enemyWins: 1 });
+  assert.equal(result.lpDelta, 25);
+  assert.equal(ls.lp, 125);
+});
+
+test('applyMatchResult 1-2: -10 LP', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 100 });
+  const result = ls.applyMatchResult({ playerWins: 1, enemyWins: 2 });
+  assert.equal(result.lpDelta, -10);
+  assert.equal(ls.lp, 90);
+});
+
+test('applyMatchResult 0-2: -20 LP', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 100 });
+  const result = ls.applyMatchResult({ playerWins: 0, enemyWins: 2 });
+  assert.equal(result.lpDelta, -20);
+  assert.equal(ls.lp, 80);
+});
+
+test('applyMatchResult rejects invalid match result', () => {
+  const ls = new LeagueSystem();
+  assert.throws(
+    () => ls.applyMatchResult({ playerWins: 3, enemyWins: 0 }),
+    /Invalid match result/
+  );
+});
+
+// ---------------------------------------------------------------------------
+// LP floor (no demotion below tier floor)
+// ---------------------------------------------------------------------------
+
+test('LP cannot drop below 0 in bronze', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 10 });
+  ls.applyMatchResult({ playerWins: 0, enemyWins: 2 }); // -20, floor at 0
+  assert.equal(ls.lp, 0);
+});
+
+test('LP floor in silver is 0 (bronze lpRequired)', () => {
+  // silver floor = bronze.lpRequired = 0
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 510 });
+  ls.applyMatchResult({ playerWins: 0, enemyWins: 2 }); // -20 → 490 (still silver)
+  assert.equal(ls.lp, 490);
+});
+
+test('LP does not drop below silver floor via repeated losses', () => {
+  // silver floor = 0 (bronze.lpRequired); start at 500
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 505 });
+  // -20 → 485, demoted to bronze since 485 < 500
+  const result = ls.applyMatchResult({ playerWins: 0, enemyWins: 2 });
+  assert.equal(result.demoted, true);
+  assert.equal(ls.leagueId, 'bronze');
+  // bronze floor is 0, LP should be 485
+  assert.equal(ls.lp, 485);
+});
+
+// ---------------------------------------------------------------------------
+// Promotion
+// ---------------------------------------------------------------------------
+
+test('promotes to silver when LP reaches 500 from bronze', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 460 });
+  const result = ls.applyMatchResult({ playerWins: 2, enemyWins: 0 }); // +40 → 500
+  assert.equal(ls.lp, 500);
+  assert.equal(result.promoted, true);
+  assert.equal(result.oldLeagueId, 'bronze');
+  assert.equal(result.newLeagueId, 'silver');
+  assert.equal(ls.leagueId, 'silver');
+});
+
+test('promotes to gold when LP reaches 1200 from silver', () => {
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 1175 });
+  const result = ls.applyMatchResult({ playerWins: 2, enemyWins: 0 }); // +40 → 1215
+  assert.equal(result.promoted, true);
+  assert.equal(ls.leagueId, 'gold');
+});
+
+test('no promotion flag when win stays within same league', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 100 });
+  const result = ls.applyMatchResult({ playerWins: 2, enemyWins: 0 });
+  assert.equal(result.promoted, false);
+  assert.equal(result.demoted, false);
+});
+
+// ---------------------------------------------------------------------------
+// Demotion
+// ---------------------------------------------------------------------------
+
+test('demotes to bronze when LP drops below 500', () => {
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 505 });
+  const result = ls.applyMatchResult({ playerWins: 0, enemyWins: 2 }); // -20 → 485
+  assert.equal(result.demoted, true);
+  assert.equal(result.oldLeagueId, 'silver');
+  assert.equal(result.newLeagueId, 'bronze');
+  assert.equal(ls.leagueId, 'bronze');
+});
+
+test('no demotion flag when loss stays within same league', () => {
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 800 });
+  const result = ls.applyMatchResult({ playerWins: 0, enemyWins: 2 }); // -20 → 780 (still silver)
+  assert.equal(result.demoted, false);
+  assert.equal(ls.leagueId, 'silver');
+});
+
+// ---------------------------------------------------------------------------
+// Champion tier
+// ---------------------------------------------------------------------------
+
+test('champion tier: isMaxLeague is true', () => {
+  const ls = new LeagueSystem({ leagueId: 'champion', lp: 5000 });
+  assert.equal(ls.isMaxLeague, true);
+});
+
+test('non-champion: isMaxLeague is false', () => {
+  const ls = new LeagueSystem({ leagueId: 'diamond', lp: 4000 });
+  assert.equal(ls.isMaxLeague, false);
+});
+
+test('champion tier: lpToNextLeague is Infinity', () => {
+  const ls = new LeagueSystem({ leagueId: 'champion', lp: 5000 });
+  assert.equal(ls.lpToNextLeague, Infinity);
+});
+
+test('champion: no promotion on win', () => {
+  const ls = new LeagueSystem({ leagueId: 'champion', lp: 5500 });
+  const result = ls.applyMatchResult({ playerWins: 2, enemyWins: 0 });
+  assert.equal(result.promoted, false);
+  assert.equal(ls.leagueId, 'champion');
+});
+
+// ---------------------------------------------------------------------------
+// Tier progress
+// ---------------------------------------------------------------------------
+
+test('tierProgress: 0 LP in bronze → 0', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 0 });
+  assert.equal(ls.tierProgress, 0);
+});
+
+test('tierProgress: 250 LP in bronze (mid-way to 500) → ~0.5', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 250 });
+  assert.ok(Math.abs(ls.tierProgress - 0.5) < 0.01);
+});
+
+test('tierProgress: champion → 1.0', () => {
+  const ls = new LeagueSystem({ leagueId: 'champion', lp: 5000 });
+  assert.equal(ls.tierProgress, 1.0);
+});
+
+// ---------------------------------------------------------------------------
+// Unlock / league checks
+// ---------------------------------------------------------------------------
+
+test('meetsLeagueRequirement: silver player meets bronze requirement', () => {
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 600 });
+  assert.equal(ls.meetsLeagueRequirement('bronze'), true);
+});
+
+test('meetsLeagueRequirement: bronze player does not meet silver requirement', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 200 });
+  assert.equal(ls.meetsLeagueRequirement('silver'), false);
+});
+
+test('upgradeTierCap: gold → 4', () => {
+  const ls = new LeagueSystem({ leagueId: 'gold', lp: 1300 });
+  assert.equal(ls.upgradeTierCap, 4);
+});
+
+test('canAffordUpgradeTier: bronze cannot buy tier 3', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 200 });
+  assert.equal(ls.canAffordUpgradeTier(3), false);
+});
+
+test('canAffordUpgradeTier: silver can buy tier 3', () => {
+  const ls = new LeagueSystem({ leagueId: 'silver', lp: 700 });
+  assert.equal(ls.canAffordUpgradeTier(3), true);
+});
+
+// ---------------------------------------------------------------------------
+// loadFromSave
+// ---------------------------------------------------------------------------
+
+test('loadFromSave restores league and LP', () => {
+  const ls = new LeagueSystem();
+  ls.loadFromSave('gold', 1500);
+  assert.equal(ls.leagueId, 'gold');
+  assert.equal(ls.lp, 1500);
+});
+
+test('loadFromSave falls back to bronze on unknown leagueId', () => {
+  const ls = new LeagueSystem();
+  ls.loadFromSave('mythril', 9999);
+  assert.equal(ls.leagueId, 'bronze');
+});
+
+// ---------------------------------------------------------------------------
+// History
+// ---------------------------------------------------------------------------
+
+test('getMatchHistory records applied results', () => {
+  const ls = new LeagueSystem({ leagueId: 'bronze', lp: 100 });
+  ls.applyMatchResult({ playerWins: 2, enemyWins: 0 });
+  ls.applyMatchResult({ playerWins: 1, enemyWins: 2 });
+  const history = ls.getMatchHistory();
+  assert.equal(history.length, 2);
+  assert.equal(history[0].lpDelta, 40);
+  assert.equal(history[1].lpDelta, -10);
+});


### PR DESCRIPTION
## Summary

Implements t020 (LeagueSystem) plus the missing `lpFloorForLeague()` helper integrated into the existing LeagueDefs.js (from PR #82).

- `src/systems/LeagueSystem.js` — LP tracking per VISION.md table (+40/+25/-10/-20), promotion/demotion on each match result, single-tier demotion floor, `tierProgress` fraction for UI bars, `meetsLeagueRequirement()`, `canAffordUpgradeTier()`, `loadFromSave()` for SaveSystem integration.
- `src/data/LeagueDefs.js` — Added `lpFloorForLeague()` helper (minimum LP per tier, prevents multi-tier demotions in a single match).
- `tests/LeagueDefs.test.js` + `tests/LeagueSystem.test.js` — 54 tests covering all LP delta cases, promotion, demotion, LP floor, tier caps, unlock checks, and save/load round-trip.

## Testing

```
node --test tests/LeagueDefs.test.js tests/LeagueSystem.test.js
# 54 tests pass, 0 failures
```

Resolves #36