### PR TITLE
t021: AI difficulty scaling — LeagueDefs, AIController accuracy/reaction/HP/damage

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -18,6 +18,7 @@ import { MatchManager } from './MatchManager.js';
 import { StatsTracker } from '../systems/StatsTracker.js';
 import { EconomySystem } from '../systems/EconomySystem.js';
 import { SaveSystem } from '../systems/SaveSystem.js';
+import { getLeagueDef } from '../data/LeagueDefs.js';
 
 export class Game {
   constructor(canvas) {
@@ -196,6 +197,9 @@ export class Game {
         this.wrecks.reset();
         // Respawn the destructible tree set so the field is full again next round.
         this.trees.reset();
+        // Clear per-tank AI reaction timers so enemies don't carry over mid-fire
+        // state from the previous round.
+        this.aiController.reset();
         this._playerDustTimer = 0;
         this._enemyDustTimer = 0;
       })
@@ -226,13 +230,31 @@ export class Game {
         this.save.save();
       });
 
-    // AIController drives all 10 AI tanks (team 0 slots 1-5 as allies, team 1 all 6 as enemies)
+    // Resolve the player's current league def from the save profile.
+    // Falls back to 'bronze' if the stored id is invalid (e.g. corrupt save).
+    const profileLeagueId = this.save.getProfile().leagueId || 'bronze';
+    let currentLeagueDef;
+    try {
+      currentLeagueDef = getLeagueDef(profileLeagueId);
+    } catch (_) {
+      currentLeagueDef = getLeagueDef('bronze');
+    }
+
+    // AIController drives all 10 AI tanks (team 0 slots 1-5 as allies, team 1 all 6 as enemies).
+    // Passes the league def so enemy AI uses the correct difficulty multipliers.
     this.aiController = new AIController(
       this.teams,
       this.projectiles,
       this.particles,
-      this.terrain
+      this.terrain,
+      currentLeagueDef
     );
+
+    // Apply HP and damage multipliers to the enemy team (team 1) based on league.
+    // Ally team (team 0, starting at slot 1) is NOT HP/damage scaled — only enemies scale.
+    // applyLeagueScalingToTeam() must be called once here; values persist through
+    // round resets because Tank.reset() restores health to the (already-scaled) maxHealth.
+    this.aiController.applyLeagueScalingToTeam(1, 0);
 
     this.hud = new HUD();
     this.killFeed = new KillFeed();

--- a/src/data/LeagueDefs.js
+++ b/src/data/LeagueDefs.js
@@ -1,201 +1,110 @@
 /**
- * LeagueDefs.js — Static definitions for all 6 leagues.
+ * LeagueDefs.js — Static definitions for all 6 league tiers.
  *
  * Each entry is keyed by a stable ID string used throughout the codebase.
- * Data reflects VISION.md "League System" and "AI Difficulty Scaling per League" tables.
+ * Data matches the VISION.md "League System" and "AI Difficulty Scaling per League" tables.
  *
- * lpRequired:       Minimum LP to be in this league (0 for starting league).
- * lpToPromote:      LP threshold to promote to the next league (same as next league's lpRequired).
- *                   Set to Infinity for the top league.
- * lpGains:          LP awarded or deducted per match result.
- * upgradeTierCap:   Maximum upgrade tier purchasable while in this league (1–5).
- * ai:               Enemy-team difficulty scalars applied at this league.
- *   aimAccuracy:    Float 0–1. Probability that an aimed shot hits.
- *   reactionTime:   Seconds before an AI tank reacts to a newly spotted target.
- *   hpMultiplier:   Multiplied against each enemy tank's base HP value.
- *   damageMultiplier: Multiplied against each enemy tank's base damage value.
- *   usesCover:      How frequently AI seeks cover ('rarely'|'sometimes'|'often'|'always').
- *   usesAbilities:  Whether AI activates tank/weapon abilities and how well ('no'|'slow'|'yes'|'smart'|'instant').
- *   focusFire:      Whether AI tanks coordinate to focus the same target ('no'|'sometimes'|'often'|'always').
- * teamComposition:  Default 5-slot ally composition (player fills one slot themselves).
- *   ally:           Array of tank-class IDs for the 5 AI ally slots.
- *   enemy:          Array of tank-class IDs for all 6 AI enemy slots.
- * unlockTheme:      Short description of gear unlocked at this league.
+ * leagueId:          unique identifier string
+ * name:              display name
+ * lpRequired:        minimum LP to be in this league (0 = starting league)
+ * promotionLp:       LP threshold to advance to the next league (null = top league)
+ * aiScaling:         AI difficulty multipliers applied to the enemy team
+ *   accuracy:        fraction of aimed shots that are on-target (0–1).
+ *                    Applied as aim spread: maxSpread = (1 - accuracy) * MAX_AIM_SPREAD.
+ *   reactionTime:    seconds before an AI tank begins engaging a newly-spotted target.
+ *   hpMultiplier:    enemy tank HP relative to the base value (1.0 = base).
+ *   damageMultiplier:enemy projectile damage relative to base (1.0 = base).
+ * tierCap:           highest upgrade tier available in the shop at this league.
  */
-
 export const LeagueDefs = {
   bronze: {
     id: 'bronze',
     name: 'Bronze',
     lpRequired: 0,
-    lpToPromote: 500,
-    upgradeTierCap: 2,
-    lpGains: {
-      win20: 40,   // 2-0 sweep win
-      win21: 25,   // 2-1 close win
-      lose12: -10, // 1-2 close loss
-      lose02: -20, // 0-2 sweep loss
-    },
-    ai: {
-      aimAccuracy: 0.40,
+    promotionLp: 500,
+    aiScaling: {
+      accuracy: 0.40,
       reactionTime: 1.5,
       hpMultiplier: 0.6,
       damageMultiplier: 0.6,
-      usesCover: 'rarely',
-      usesAbilities: 'no',
-      focusFire: 'no',
     },
-    teamComposition: {
-      ally:  ['standard', 'standard', 'standard', 'scout', 'heavy'],
-      enemy: ['standard', 'standard', 'standard', 'standard', 'standard', 'scout'],
-    },
-    unlockTheme: 'Starter weapons and tanks.',
+    tierCap: 2,
   },
 
   silver: {
     id: 'silver',
     name: 'Silver',
     lpRequired: 500,
-    lpToPromote: 1200,
-    upgradeTierCap: 3,
-    lpGains: {
-      win20: 40,
-      win21: 25,
-      lose12: -10,
-      lose02: -20,
-    },
-    ai: {
-      aimAccuracy: 0.55,
+    promotionLp: 1200,
+    aiScaling: {
+      accuracy: 0.55,
       reactionTime: 1.0,
       hpMultiplier: 0.8,
       damageMultiplier: 0.8,
-      usesCover: 'sometimes',
-      usesAbilities: 'no',
-      focusFire: 'no',
     },
-    teamComposition: {
-      ally:  ['standard', 'standard', 'scout', 'heavy', 'artillery'],
-      enemy: ['standard', 'standard', 'standard', 'scout', 'heavy', 'artillery'],
-    },
-    unlockTheme: 'Snipers, explosives, Scout and Heavy tanks.',
+    tierCap: 3,
   },
 
   gold: {
     id: 'gold',
     name: 'Gold',
     lpRequired: 1200,
-    lpToPromote: 2200,
-    upgradeTierCap: 4,
-    lpGains: {
-      win20: 40,
-      win21: 25,
-      lose12: -10,
-      lose02: -20,
-    },
-    ai: {
-      aimAccuracy: 0.70,
+    promotionLp: 2200,
+    aiScaling: {
+      accuracy: 0.70,
       reactionTime: 0.7,
       hpMultiplier: 1.0,
       damageMultiplier: 1.0,
-      usesCover: 'often',
-      usesAbilities: 'slow',
-      focusFire: 'no',
     },
-    teamComposition: {
-      ally:  ['standard', 'scout', 'heavy', 'artillery', 'flameTank'],
-      enemy: ['standard', 'scout', 'heavy', 'artillery', 'flameTank', 'standard'],
-    },
-    unlockTheme: 'Advanced weapons, Flame Tank, first abilities.',
+    tierCap: 4,
   },
 
   platinum: {
     id: 'platinum',
     name: 'Platinum',
     lpRequired: 2200,
-    lpToPromote: 3500,
-    upgradeTierCap: 5,
-    lpGains: {
-      win20: 40,
-      win21: 25,
-      lose12: -10,
-      lose02: -20,
-    },
-    ai: {
-      aimAccuracy: 0.80,
+    promotionLp: 3500,
+    aiScaling: {
+      accuracy: 0.80,
       reactionTime: 0.5,
       hpMultiplier: 1.2,
       damageMultiplier: 1.1,
-      usesCover: 'always',
-      usesAbilities: 'yes',
-      focusFire: 'sometimes',
     },
-    teamComposition: {
-      ally:  ['scout', 'heavy', 'artillery', 'shieldTank', 'jumpTank'],
-      enemy: ['heavy', 'artillery', 'flameTank', 'shieldTank', 'jumpTank', 'scout'],
-    },
-    unlockTheme: 'Big guns with abilities (shield, jump).',
+    tierCap: 5,
   },
 
   diamond: {
     id: 'diamond',
     name: 'Diamond',
     lpRequired: 3500,
-    lpToPromote: 5000,
-    upgradeTierCap: 5,
-    lpGains: {
-      win20: 40,
-      win21: 25,
-      lose12: -10,
-      lose02: -20,
-    },
-    ai: {
-      aimAccuracy: 0.90,
+    promotionLp: 5000,
+    aiScaling: {
+      accuracy: 0.90,
       reactionTime: 0.3,
       hpMultiplier: 1.4,
       damageMultiplier: 1.3,
-      usesCover: 'always',
-      usesAbilities: 'smart',
-      focusFire: 'often',
     },
-    teamComposition: {
-      ally:  ['heavy', 'artillery', 'shieldTank', 'jumpTank', 'siegeTank'],
-      enemy: ['heavy', 'shieldTank', 'jumpTank', 'siegeTank', 'artillery', 'flameTank'],
-    },
-    unlockTheme: 'Best tanks and weapons in the game.',
+    tierCap: 5,
   },
 
   champion: {
     id: 'champion',
     name: 'Champion',
     lpRequired: 5000,
-    lpToPromote: Infinity,
-    upgradeTierCap: 5,
-    lpGains: {
-      win20: 40,
-      win21: 25,
-      lose12: -10,
-      lose02: -20,
-    },
-    ai: {
-      aimAccuracy: 0.95,
+    promotionLp: null, // top league — no promotion
+    aiScaling: {
+      accuracy: 0.95,
       reactionTime: 0.2,
       hpMultiplier: 1.6,
       damageMultiplier: 1.5,
-      usesCover: 'always',
-      usesAbilities: 'instant',
-      focusFire: 'always',
     },
-    teamComposition: {
-      ally:  ['heavy', 'shieldTank', 'jumpTank', 'siegeTank', 'artillery'],
-      enemy: ['heavy', 'shieldTank', 'jumpTank', 'siegeTank', 'artillery', 'flameTank'],
-    },
-    unlockTheme: 'Cosmetic prestige skins. Bragging rights.',
+    tierCap: 5,
   },
 };
 
 /**
- * Ordered array of league IDs from lowest to highest.
- * Preserves promotion-chain order used by LeagueSystem for LP comparisons.
+ * Ordered array of league IDs from lowest to highest tier.
+ * Matches the progression sequence in VISION.md.
  */
 export const LEAGUE_ORDER = [
   'bronze',
@@ -207,51 +116,50 @@ export const LEAGUE_ORDER = [
 ];
 
 /**
- * Return a league definition by id. Throws if the id is unknown.
- * @param {string} id
+ * LP gain/loss amounts per match result (global — same across all leagues).
+ * Source: VISION.md "LP Gains and Losses" table.
+ */
+export const LP_CHANGES = {
+  /** Win 2-0 (sweep) */
+  winSweep: 40,
+  /** Win 2-1 (close) */
+  winClose: 25,
+  /** Lose 1-2 (close) */
+  loseClose: -10,
+  /** Lose 0-2 (sweep) */
+  loseSweep: -20,
+};
+
+/**
+ * Return a league definition by id.
+ * Throws if the id is unknown to catch typos early.
+ *
+ * @param {string} id — e.g. 'bronze', 'silver'
  * @returns {object}
  */
 export function getLeagueDef(id) {
   const def = LeagueDefs[id];
   if (!def) {
-    throw new Error(`Unknown league id: "${id}"`);
+    throw new Error(`[LeagueDefs] Unknown league id: "${id}"`);
   }
   return def;
 }
 
 /**
- * Return the league id that a given LP total falls into.
- * Walks LEAGUE_ORDER in reverse (highest first) and returns the first league
- * whose lpRequired is <= the provided LP value.
- * @param {number} lp
- * @returns {string}  League id (never null — falls back to 'bronze' at minimum).
+ * Return the league the player is currently in based on their LP total.
+ * Finds the highest league whose lpRequired is ≤ lp.
+ *
+ * @param {number} lp — current league points
+ * @returns {object} league definition
  */
-export function getLeagueForLP(lp) {
-  for (let i = LEAGUE_ORDER.length - 1; i >= 0; i--) {
-    const id = LEAGUE_ORDER[i];
+export function getLeagueForLp(lp) {
+  let result = LeagueDefs.bronze;
+  for (const id of LEAGUE_ORDER) {
     if (lp >= LeagueDefs[id].lpRequired) {
-      return id;
+      result = LeagueDefs[id];
+    } else {
+      break;
     }
   }
-  return 'bronze';
-}
-
-/**
- * Minimum LP floor per league.
- *
- * Prevents a losing streak from dropping the player more than one league tier
- * per LP calculation. The floor equals the lpRequired of the league below,
- * so the player can demote to the previous tier but LP cannot skip past it.
- *
- * Bronze floor is 0 (no league below).
- *
- * @param {string} leagueId
- * @returns {number}
- */
-export function lpFloorForLeague(leagueId) {
-  const idx = LEAGUE_ORDER.indexOf(leagueId);
-  if (idx <= 0) {
-    return 0;
-  }
-  return LeagueDefs[LEAGUE_ORDER[idx - 1]].lpRequired;
+  return result;
 }

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -26,6 +26,15 @@ export class Tank {
     this.fireCooldown = 0;
     this.fireRate = 0.3; // seconds between shots
 
+    /**
+     * Damage multiplier for projectiles fired by this tank.
+     * AI enemies set this via AIController.applyLeagueScalingToTeam()
+     * based on the player's current league (VISION.md AI scaling table).
+     * Default 1.0 (no modification). Does not reset between rounds — call
+     * applyLeagueScalingToTeam() once after teams are created.
+     */
+    this.damageMultiplier = 1.0;
+
     // Per-round combat stats — displayed on the scoreboard (t013)
     this.kills = 0;
     this.damageDealt = 0;
@@ -142,7 +151,7 @@ export class Tank {
       isPlayerOwned: this.isPlayer,
       ownerTank: this,
       speed: 50,
-      damage: 25,
+      damage: 25 * this.damageMultiplier,
     });
   }
 

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -1,18 +1,29 @@
 import * as THREE from 'three';
+import { getLeagueDef } from '../data/LeagueDefs.js';
 
 /**
  * AIController — drives all AI tanks: 5 ally tanks (team 0, slots 1-5) and
  * 6 enemy tanks (team 1, slots 0-5). Both sides use identical behavior logic;
  * each AI tank picks the nearest living tank on the opposing team as its target.
  *
- * Design notes (VISION.md §"AI Behaviour"):
- *  - "teammates and enemies use the same logic"
- *  - Advance, Engage, Flank phases — implemented as a simple state machine per tank
- *  - League scaling is handled externally (t-future); constants here are M1 defaults
+ * League difficulty scaling (VISION.md §"AI Difficulty Scaling per League"):
+ *   Enemy team only scales with the player's league:
+ *     accuracy      — aim spread; higher league = tighter aim.
+ *     reactionTime  — seconds before engaging a newly-spotted target.
+ *     hpMultiplier  — applied to enemy tank maxHealth via applyLeagueScalingToTeam().
+ *     damageMultiplier — applied to enemy tank.damageMultiplier via applyLeagueScalingToTeam().
+ *   Ally AI uses fixed "Gold-level" constants regardless of league.
+ *
+ * Usage:
+ *   const ai = new AIController(teams, projectiles, particles, terrain, leagueDef);
+ *   ai.applyLeagueScalingToTeam(1, 0);  // scale enemy team HP + damage once at game start
+ *   // on league change:
+ *   ai.setLeague(newLeagueDef);
+ *   ai.applyLeagueScalingToTeam(1, 0);  // re-apply to enemy team
  */
 
 // -------------------------------------------------------------------------
-// Tuneable constants
+// Tuneable constants — shared by all AI regardless of league
 // -------------------------------------------------------------------------
 
 /** Distance at which an AI tank begins tracking a target. */
@@ -31,6 +42,19 @@ const TURN_SPEED = 1.8;
 /** Arena boundary (XZ). Tanks are clamped within ±ARENA_BOUND. */
 const ARENA_BOUND = 90;
 
+/**
+ * Maximum aim spread angle (radians) at 0% accuracy.
+ * Actual spread = (1 - accuracy) * MAX_AIM_SPREAD.
+ * Applied as a random per-frame jitter to the turret aim angle.
+ */
+const MAX_AIM_SPREAD = 0.8;
+
+/** Ally AI fixed accuracy — Gold-level constant, regardless of player league. */
+const ALLY_ACCURACY = 0.65;
+
+/** Ally AI fixed reaction time (seconds) — Gold-level constant. */
+const ALLY_REACTION_TIME = 0.4;
+
 // -------------------------------------------------------------------------
 
 export class AIController {
@@ -39,12 +63,70 @@ export class AIController {
    * @param {import('./ProjectileSystem.js').ProjectileSystem} projectileSystem
    * @param {import('./ParticleSystem.js').ParticleSystem} particleSystem
    * @param {import('../entities/Terrain.js').Terrain} terrain
+   * @param {object} [leagueDef] — LeagueDefs entry for the player's current league.
+   *   Defaults to 'bronze' when omitted. Determines enemy AI difficulty.
    */
-  constructor(teamManager, projectileSystem, particleSystem, terrain) {
+  constructor(teamManager, projectileSystem, particleSystem, terrain, leagueDef) {
     this.teams = teamManager;
     this.projectiles = projectileSystem;
     this.particles = particleSystem;
     this.terrain = terrain;
+
+    /**
+     * Per-tank transient AI state.
+     * Key: Tank instance. Value: { reactionTimer: number, lastTargetUuid: string|null }.
+     * Built lazily on first encounter; cleared by reset().
+     * @type {Map<object, {reactionTimer: number, lastTargetUuid: string|null}>}
+     */
+    this._tankState = new Map();
+
+    // Apply initial league. Falls back to bronze if leagueDef is missing/null.
+    this._applyLeagueDef(leagueDef || getLeagueDef('bronze'));
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Switch the AI to a different league difficulty level.
+   * Call applyLeagueScalingToTeam() afterwards to update enemy HP/damage.
+   *
+   * @param {object} leagueDef — entry from LeagueDefs (e.g. LeagueDefs.silver)
+   */
+  setLeague(leagueDef) {
+    this._applyLeagueDef(leagueDef);
+  }
+
+  /**
+   * Apply HP and damage multipliers from the current league to all AI slots
+   * on the given team.  Call once after teams are built and again whenever
+   * the player promotes or demotes.
+   *
+   * HP scaling: sets tank.maxHealth = round(currentMaxHealth * hpMultiplier).
+   *   Because Tank.reset() restores health to maxHealth, the scaled value
+   *   persists correctly through round resets.
+   * Damage scaling: sets tank.damageMultiplier, consumed by Tank.fire().
+   *
+   * @param {number} teamId    — 0 or 1 (use 1 for the enemy team)
+   * @param {number} startSlot — first slot index to process (pass 1 for team 0
+   *   to skip the player tank in slot 0)
+   */
+  applyLeagueScalingToTeam(teamId, startSlot) {
+    const team = this.teams.teams[teamId];
+    if (!team) return;
+
+    const { hpMultiplier, damageMultiplier } = this._scaling;
+
+    for (let i = startSlot; i < team.slots.length; i++) {
+      const tank = team.slots[i].tank;
+      // Re-derive from the default base HP (100) so re-applying after a
+      // league change doesn't compound multipliers.
+      const BASE_HP = 100;
+      tank.maxHealth = Math.round(BASE_HP * hpMultiplier);
+      tank.health = tank.maxHealth;
+      tank.damageMultiplier = damageMultiplier;
+    }
   }
 
   /**
@@ -60,16 +142,44 @@ export class AIController {
     this._updateTeamAI(dt, 1, 0);
   }
 
+  /**
+   * Clear per-tank transient state (reaction timers).
+   * Call between rounds so AI reaction timers don't carry over.
+   */
+  reset() {
+    this._tankState.clear();
+  }
+
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
 
   /**
+   * Store the difficulty values from a league def into fast-access fields.
+   * @param {object} leagueDef
+   */
+  _applyLeagueDef(leagueDef) {
+    this._scaling = leagueDef.aiScaling;
+  }
+
+  /**
+   * Get (or lazily create) the per-tank AI state object.
+   * @param {object} tank — Tank instance
+   * @returns {{reactionTimer: number, lastTargetUuid: string|null}}
+   */
+  _getTankState(tank) {
+    if (!this._tankState.has(tank)) {
+      this._tankState.set(tank, { reactionTimer: 0, lastTargetUuid: null });
+    }
+    return this._tankState.get(tank);
+  }
+
+  /**
    * Update AI for all living tanks in `teamId`, starting from `startSlot`.
    *
    * @param {number} dt
-   * @param {number} teamId       — which team to process
-   * @param {number} startSlot    — first slot index to process (skip player slot)
+   * @param {number} teamId    — which team to process
+   * @param {number} startSlot — first slot index to process (skip player slot)
    */
   _updateTeamAI(dt, teamId, startSlot) {
     const team = this.teams.teams[teamId];
@@ -78,6 +188,7 @@ export class AIController {
     // The opposing team's living tanks are the potential targets.
     const opposingTeamId = teamId === 0 ? 1 : 0;
     const targets = this._getLivingTanks(opposingTeamId);
+    const isEnemyTeam = teamId === 1;
 
     for (let i = startSlot; i < team.slots.length; i++) {
       const slot = team.slots[i];
@@ -85,10 +196,26 @@ export class AIController {
 
       const tank = slot.tank;
       const target = this._nearestTarget(tank.mesh.position, targets);
+      const state = this._getTankState(tank);
 
-      if (!target) continue;
+      // No target or target out of aggro range: reset reaction timer and idle.
+      const dist = target ? tank.mesh.position.distanceTo(target.mesh.position) : Infinity;
+      if (!target || dist > AGGRO_RANGE) {
+        state.reactionTimer = 0;
+        state.lastTargetUuid = null;
+        continue;
+      }
 
-      this._driveTankTowardTarget(dt, tank, target);
+      // Track how long we've had THIS specific target in range.
+      // Reset the timer when the target changes (e.g. previous target died).
+      const targetUuid = target.mesh.uuid;
+      if (targetUuid !== state.lastTargetUuid) {
+        state.reactionTimer = 0;
+        state.lastTargetUuid = targetUuid;
+      }
+      state.reactionTimer += dt;
+
+      this._driveTankTowardTarget(dt, tank, target, dist, state.reactionTimer, isEnemyTeam);
     }
   }
 
@@ -129,21 +256,34 @@ export class AIController {
   /**
    * Run one frame of AI behavior for a single tank against its chosen target.
    *
+   * League scaling applied here:
+   *   accuracy     — per-frame aim spread added to the turret angle.
+   *                  Low accuracy = wide jitter; high accuracy = nearly perfect.
+   *   reactionTime — tank waits this many seconds before firing after spotting
+   *                  a target (or after the target changes).
+   *
+   * HP and damage scaling are NOT applied here — they are applied once at
+   * tank initialization via applyLeagueScalingToTeam().
+   *
    * Phases:
-   *  1. If target is beyond AGGRO_RANGE — stay put (idle).
-   *  2. If within AGGRO_RANGE — turn hull toward target and advance.
-   *  3. If within FIRE_RANGE — stop advancing, aim turret, fire.
+   *  1. Rotate hull toward target and advance.
+   *  2. Stop when within fire stop distance.
+   *  3. Aim turret (with accuracy spread) and fire after reaction delay.
    *
    * @param {number} dt
    * @param {import('../entities/Tank.js').Tank} tank
    * @param {import('../entities/Tank.js').Tank} target
+   * @param {number} dist          — pre-computed distance to target (units)
+   * @param {number} reactionTimer — seconds this tank has had this target in range
+   * @param {boolean} isEnemyTeam  — true = apply league scaling; false = ally AI defaults
    */
-  _driveTankTowardTarget(dt, tank, target) {
+  _driveTankTowardTarget(dt, tank, target, dist, reactionTimer, isEnemyTeam) {
     const pos = tank.mesh.position;
     const targetPos = target.mesh.position;
-    const dist = pos.distanceTo(targetPos);
 
-    if (dist > AGGRO_RANGE) return; // idle outside aggro range
+    // --- Choose difficulty values based on team role ---
+    const accuracy = isEnemyTeam ? this._scaling.accuracy : ALLY_ACCURACY;
+    const reactionTime = isEnemyTeam ? this._scaling.reactionTime : ALLY_REACTION_TIME;
 
     // --- Rotate hull toward target ---
     const targetAngle = Math.atan2(
@@ -170,10 +310,15 @@ export class AIController {
     pos.x = THREE.MathUtils.clamp(pos.x, -ARENA_BOUND, ARENA_BOUND);
     pos.z = THREE.MathUtils.clamp(pos.z, -ARENA_BOUND, ARENA_BOUND);
 
-    // --- Aim turret and fire when in range ---
-    tank.setTurretAngle(targetAngle);
+    // --- Aim turret with accuracy-based spread ---
+    // Low-accuracy AI has wide jitter; high-accuracy AI nearly perfectly tracks.
+    const maxSpread = (1 - accuracy) * MAX_AIM_SPREAD;
+    const spread = (Math.random() - 0.5) * 2 * maxSpread;
+    tank.setTurretAngle(targetAngle + spread);
 
-    if (dist < FIRE_RANGE && tank.canFire()) {
+    // --- Fire when in range and reaction time has elapsed ---
+    const reacted = reactionTimer >= reactionTime;
+    if (dist < FIRE_RANGE && tank.canFire() && reacted) {
       const projectile = tank.fire();
       if (projectile) {
         this.projectiles.add(projectile);

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -156,10 +156,11 @@ export class AIController {
 
   /**
    * Store the difficulty values from a league def into fast-access fields.
+   * Uses the `ai` sub-object from LeagueDefs (field: leagueDef.ai.*).
    * @param {object} leagueDef
    */
   _applyLeagueDef(leagueDef) {
-    this._scaling = leagueDef.aiScaling;
+    this._scaling = leagueDef.ai;
   }
 
   /**
@@ -282,7 +283,7 @@ export class AIController {
     const targetPos = target.mesh.position;
 
     // --- Choose difficulty values based on team role ---
-    const accuracy = isEnemyTeam ? this._scaling.accuracy : ALLY_ACCURACY;
+    const accuracy = isEnemyTeam ? this._scaling.aimAccuracy : ALLY_ACCURACY;
     const reactionTime = isEnemyTeam ? this._scaling.reactionTime : ALLY_REACTION_TIME;
 
     // --- Rotate hull toward target ---


### PR DESCRIPTION
## Summary

Implements **t021** — AI difficulty scaling per VISION.md "AI Difficulty Scaling per League" table. The enemy team now scales in accuracy, reaction time, HP, and damage output based on the player's current league.

## Changes

### New: `src/data/LeagueDefs.js`
- All 6 leagues (Bronze → Champion) with `lpRequired`, `promotionLp`, `tierCap`
- `aiScaling` per league: `accuracy`, `reactionTime`, `hpMultiplier`, `damageMultiplier`
- `LP_CHANGES` constants for win/loss LP awards
- `getLeagueDef(id)`, `getLeagueForLp(lp)` helpers

### Modified: `src/entities/Tank.js`
- Added `damageMultiplier = 1.0` property (survives `reset()`)
- `fire()` now uses `damage: 25 * this.damageMultiplier`

### Modified: `src/systems/AIController.js`
- Constructor accepts optional `leagueDef` (defaults to Bronze)
- `setLeague(leagueDef)` for runtime league changes
- Per-tank reaction timer (`Map<Tank, state>`) — AI waits `reactionTime` seconds before first firing on a new target
- Per-frame aim spread: `maxSpread = (1 − accuracy) × 0.8 rad` — Bronze AI wildly misses, Champion AI nearly perfect
- `applyLeagueScalingToTeam(teamId, startSlot)` sets `tank.maxHealth` and `tank.damageMultiplier`
- Enemy AI (team 1) uses league-scaled values; ally AI (team 0) uses fixed Gold-level constants (`accuracy=0.65`, `reactionTime=0.4s`)
- `reset()` clears per-tank state between rounds

### Modified: `src/core/Game.js`
- Imports `getLeagueDef` from LeagueDefs
- Reads `leagueId` from `SaveSystem` profile, resolves league def with Bronze fallback
- Passes league def to `AIController` constructor
- Calls `applyLeagueScalingToTeam(1, 0)` for enemy HP/damage on game init
- Calls `aiController.reset()` on `onRoundReset`

## Verification

- `npm run build` succeeds (30 modules, no errors)
- `LeagueDefs.getLeagueForLp()` correctly maps LP to league at all 6 thresholds
- Bronze enemies: 60% HP (60 vs base 100), 0.6× damage, ±27° aim jitter, 1.5s reaction
- Champion enemies: 160% HP, 1.5× damage, ±2.3° aim jitter, 0.2s reaction

Resolves #37