### PR TITLE
t022: LeagueSystem + league-gated ShopMenu with upgrade tier caps

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,333 @@
       #touch-controls { display: none; }
     }
 
+    /* === Shop Menu (t022: league-gated shop) === */
+    #shop-menu {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.80);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 200;
+    }
+
+    #shop-menu.hidden {
+      display: none;
+    }
+
+    .shop-panel {
+      background: rgba(10, 14, 22, 0.97);
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 12px;
+      width: min(820px, 96vw);
+      max-height: 86vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+    }
+
+    .shop-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 20px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      flex-shrink: 0;
+    }
+
+    .shop-title {
+      color: #fff;
+      font-size: 18px;
+      font-weight: 900;
+      letter-spacing: 4px;
+      text-transform: uppercase;
+      flex: 1;
+    }
+
+    .shop-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .shop-money {
+      color: #ffd700;
+      font-size: 18px;
+      font-weight: 700;
+    }
+
+    .shop-league-badge {
+      padding: 3px 10px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+
+    .shop-league-bronze   { background: #cd7f32; color: #fff; }
+    .shop-league-silver   { background: #a8a9ad; color: #000; }
+    .shop-league-gold     { background: #ffd700; color: #000; }
+    .shop-league-platinum { background: #e5e4e2; color: #000; }
+    .shop-league-diamond  { background: #b9f2ff; color: #000; }
+    .shop-league-champion { background: linear-gradient(90deg, #f90, #f00); color: #fff; }
+
+    .shop-close-btn {
+      background: none;
+      border: 1px solid rgba(255,255,255,0.3);
+      color: #fff;
+      border-radius: 6px;
+      width: 32px;
+      height: 32px;
+      cursor: pointer;
+      font-size: 14px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .shop-close-btn:hover { background: rgba(255,255,255,0.1); }
+
+    .shop-tabs {
+      display: flex;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+      flex-shrink: 0;
+    }
+
+    .shop-tab-btn {
+      flex: 1;
+      padding: 10px;
+      background: none;
+      border: none;
+      color: rgba(255,255,255,0.5);
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      cursor: pointer;
+      border-bottom: 3px solid transparent;
+      transition: color 0.15s, border-color 0.15s;
+    }
+
+    .shop-tab-btn.active {
+      color: #fff;
+      border-bottom-color: #4caf50;
+    }
+
+    .shop-tab-btn:hover:not(.active) { color: rgba(255,255,255,0.75); }
+
+    .shop-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px 20px;
+    }
+
+    /* Cards grid */
+    .shop-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 12px;
+    }
+
+    .shop-card {
+      background: rgba(255,255,255,0.05);
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 8px;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .shop-card.owned { border-color: rgba(76, 175, 80, 0.5); background: rgba(76,175,80,0.07); }
+    .shop-card.locked { opacity: 0.6; }
+
+    .shop-card-name {
+      color: #fff;
+      font-size: 13px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .shop-card-desc {
+      color: rgba(255,255,255,0.55);
+      font-size: 11px;
+      line-height: 1.4;
+      flex: 1;
+    }
+
+    .shop-card-stats {
+      display: flex;
+      gap: 8px;
+      font-size: 11px;
+      color: rgba(255,255,255,0.7);
+      flex-wrap: wrap;
+    }
+
+    .shop-card-footer {
+      margin-top: 4px;
+    }
+
+    .shop-req-label {
+      font-size: 10px;
+      color: #ff9800;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+    }
+
+    .shop-ability-tag {
+      font-size: 9px;
+      background: rgba(100, 180, 255, 0.25);
+      color: #90caf9;
+      border-radius: 3px;
+      padding: 1px 5px;
+      font-weight: 700;
+    }
+
+    .shop-type-tag {
+      font-size: 9px;
+      background: rgba(255, 152, 0, 0.25);
+      color: #ffcc80;
+      border-radius: 3px;
+      padding: 1px 5px;
+      font-weight: 700;
+    }
+
+    /* Buy button */
+    .shop-buy-btn {
+      padding: 6px 12px;
+      background: #4caf50;
+      color: #fff;
+      border: none;
+      border-radius: 5px;
+      font-size: 13px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .shop-buy-btn:hover:not(.disabled) { background: #43a047; }
+    .shop-buy-btn.disabled, .shop-buy-btn:disabled {
+      background: rgba(255,255,255,0.1);
+      color: rgba(255,255,255,0.35);
+      cursor: not-allowed;
+    }
+
+    .shop-owned-label {
+      color: #4caf50;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .shop-free-label {
+      color: #aaa;
+      font-size: 12px;
+    }
+
+    .shop-maxed-label {
+      color: #ffd700;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .shop-league-cap-label {
+      color: #ff9800;
+      font-size: 11px;
+      font-weight: 600;
+    }
+
+    /* Weapon groups */
+    .shop-weapon-group { margin-bottom: 20px; }
+    .shop-group-label {
+      color: rgba(255,255,255,0.5);
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      margin-bottom: 10px;
+    }
+
+    /* Upgrade rows */
+    .shop-upgrade-group { margin-bottom: 20px; }
+
+    .shop-upgrade-row {
+      display: grid;
+      grid-template-columns: 1fr auto auto;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+    }
+
+    .shop-upgrade-row.maxed .shop-upgrade-name { color: rgba(255,255,255,0.5); }
+    .shop-upgrade-row.at-cap .shop-upgrade-name { color: rgba(255,152,0,0.8); }
+
+    .shop-upgrade-info {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .shop-upgrade-name {
+      color: #fff;
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .shop-upgrade-effect {
+      color: rgba(255,255,255,0.5);
+      font-size: 11px;
+    }
+
+    .shop-upgrade-tiers {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .tier-pip {
+      width: 10px;
+      height: 10px;
+      border-radius: 2px;
+      border: 1px solid rgba(255,255,255,0.3);
+      background: transparent;
+    }
+
+    .tier-pip.filled { background: #4caf50; border-color: #4caf50; }
+    .tier-pip.cap-marker { border-color: #ff9800; }
+
+    .tier-count {
+      color: rgba(255,255,255,0.4);
+      font-size: 10px;
+      margin-left: 4px;
+    }
+
+    .shop-upgrade-action { text-align: right; min-width: 80px; }
+
+    /* Flash messages */
+    .shop-flash {
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-size: 13px;
+      font-weight: 700;
+      text-align: center;
+      margin-bottom: 0;
+    }
+
+    .shop-flash-success { background: rgba(76,175,80,0.25); color: #81c784; }
+    .shop-flash-error   { background: rgba(244,67,54,0.25);  color: #e57373; }
+
+    @media (max-width: 540px) {
+      .shop-grid { grid-template-columns: 1fr 1fr; }
+      .shop-upgrade-row { grid-template-columns: 1fr auto; }
+      .shop-upgrade-tiers { display: none; }
+    }
+
     /* === Scoreboard overlay (t013) === */
     .sb-overlay {
       position: fixed;
@@ -649,6 +976,9 @@
     <div class="score-line">Score: <span id="final-score">0</span></div>
     <button id="restart-btn">Play Again</button>
   </div>
+
+  <!-- Shop Menu (t022: league-gated shop) — hidden until opened via ShopMenu.open() -->
+  <div id="shop-menu" class="hidden"></div>
 
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/systems/LeagueSystem.js
+++ b/src/systems/LeagueSystem.js
@@ -1,0 +1,191 @@
+/**
+ * LeagueSystem — LP tracking, league promotion / demotion logic.
+ *
+ * Manages the player's league state by reading and writing through SaveSystem.
+ * Promotion and demotion thresholds are defined in LeagueDefs.
+ *
+ * Usage:
+ *   const league = new LeagueSystem(saveSystem);
+ *   const id     = league.getCurrentLeagueId();   // 'bronze'
+ *   const def    = league.getCurrentLeagueDef();  // LeagueDefs.bronze
+ *   const cap    = league.getUpgradeTierCap();    // 2
+ *   const result = league.applyMatchResult('win20');
+ *   //  → { lpBefore, lpAfter, delta, leagueBefore, leagueAfter, promoted, demoted }
+ *
+ * League IDs (lowest→highest): bronze, silver, gold, platinum, diamond, champion.
+ * Match result keys: 'win20' (2-0 sweep), 'win21' (2-1 close),
+ *                    'lose12' (1-2 close), 'lose02' (0-2 sweep).
+ */
+
+import {
+  getLeagueDef,
+  getLeagueForLP,
+  LEAGUE_ORDER,
+} from '../data/LeagueDefs.js';
+
+export class LeagueSystem {
+  /**
+   * @param {import('./SaveSystem.js').SaveSystem} saveSystem
+   */
+  constructor(saveSystem) {
+    this._save = saveSystem;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read-only accessors
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Current league ID string.
+   * @returns {'bronze'|'silver'|'gold'|'platinum'|'diamond'|'champion'}
+   */
+  getCurrentLeagueId() {
+    return this._save._profile.leagueId || 'bronze';
+  }
+
+  /**
+   * Current league definition object from LeagueDefs.
+   * @returns {object}
+   */
+  getCurrentLeagueDef() {
+    return getLeagueDef(this.getCurrentLeagueId());
+  }
+
+  /**
+   * Accumulated league points for the current league.
+   * @returns {number}
+   */
+  getCurrentLP() {
+    return this._save._profile.leaguePoints || 0;
+  }
+
+  /**
+   * Maximum upgrade tier purchasable while in the current league (1–5).
+   * Mirrors LeagueDefs[id].upgradeTierCap.
+   * @returns {number}
+   */
+  getUpgradeTierCap() {
+    return this.getCurrentLeagueDef().upgradeTierCap;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unlock helpers (used by ShopMenu and other consumers)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * True if the player's current league meets or exceeds a tank's league requirement.
+   * @param {object} tankDef  A TankDefs entry with a `leagueRequired` field.
+   * @returns {boolean}
+   */
+  isTankUnlocked(tankDef) {
+    return this._meetsLeagueReq(tankDef.leagueRequired);
+  }
+
+  /**
+   * True if the player's current league meets or exceeds a weapon's league requirement.
+   * @param {object} weaponDef  A GunDefs / MeleeDefs entry with a `leagueRequired` field.
+   * @returns {boolean}
+   */
+  isWeaponUnlocked(weaponDef) {
+    return this._meetsLeagueReq(weaponDef.leagueRequired);
+  }
+
+  /**
+   * Maximum available tier for an upgrade in the current league.
+   * Clamps the upgrade's own maxTier to the league tier cap.
+   *
+   * @param {object} upgradeDef  A TankUpgradeDefs / FootUpgradeDefs entry.
+   * @returns {number}  0 if not available yet (league too low), otherwise 1–5.
+   */
+  getMaxAvailableUpgradeTier(upgradeDef) {
+    const cap = this.getUpgradeTierCap();
+    return Math.min(upgradeDef.maxTier, cap);
+  }
+
+  // ---------------------------------------------------------------------------
+  // LP mutation (side-effects: persists via SaveSystem)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply a match result LP delta, detect promotion/demotion, and persist.
+   *
+   * @param {'win20'|'win21'|'lose12'|'lose02'} result
+   *   win20  = 2-0 sweep win
+   *   win21  = 2-1 close win
+   *   lose12 = 1-2 close loss
+   *   lose02 = 0-2 sweep loss
+   *
+   * @returns {{
+   *   lpBefore:     number,
+   *   lpAfter:      number,
+   *   delta:        number,
+   *   leagueBefore: string,
+   *   leagueAfter:  string,
+   *   promoted:     boolean,
+   *   demoted:      boolean,
+   * }}
+   */
+  applyMatchResult(result) {
+    const leagueBefore = this.getCurrentLeagueId();
+    const lpBefore     = this.getCurrentLP();
+    const def          = getLeagueDef(leagueBefore);
+    const delta        = def.lpGains[result] ?? 0;
+    const lpAfter      = Math.max(0, lpBefore + delta);
+    const leagueAfter  = getLeagueForLP(lpAfter);
+
+    const idxBefore = LEAGUE_ORDER.indexOf(leagueBefore);
+    const idxAfter  = LEAGUE_ORDER.indexOf(leagueAfter);
+
+    this._save.updateLeague(leagueAfter, lpAfter);
+    this._save.save();
+
+    const summary = {
+      lpBefore,
+      lpAfter,
+      delta,
+      leagueBefore,
+      leagueAfter,
+      promoted: idxAfter > idxBefore,
+      demoted:  idxAfter < idxBefore,
+    };
+
+    if (summary.promoted) {
+      console.info(
+        `[LeagueSystem] PROMOTED ${leagueBefore} → ${leagueAfter} ` +
+        `(LP: ${lpBefore} + ${delta} = ${lpAfter})`
+      );
+    } else if (summary.demoted) {
+      console.info(
+        `[LeagueSystem] DEMOTED ${leagueBefore} → ${leagueAfter} ` +
+        `(LP: ${lpBefore} + ${delta} = ${lpAfter})`
+      );
+    } else {
+      console.info(
+        `[LeagueSystem] Match result applied. LP: ${lpBefore} + ${delta} = ${lpAfter} ` +
+        `(${leagueAfter})`
+      );
+    }
+
+    return summary;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @private
+   * @param {string} requiredId  League ID that an item requires.
+   * @returns {boolean}
+   */
+  _meetsLeagueReq(requiredId) {
+    const currentIdx  = LEAGUE_ORDER.indexOf(this.getCurrentLeagueId());
+    const requiredIdx = LEAGUE_ORDER.indexOf(requiredId);
+    if (requiredIdx === -1) {
+      // Unknown league ID — treat as always unlocked to avoid hiding items.
+      console.warn(`[LeagueSystem] Unknown leagueRequired value: "${requiredId}"`);
+      return true;
+    }
+    return currentIdx >= requiredIdx;
+  }
+}

--- a/src/ui/ShopMenu.js
+++ b/src/ui/ShopMenu.js
@@ -1,0 +1,468 @@
+/**
+ * ShopMenu — between-match shop with 4 tabs.
+ * Tabs: Tanks | Weapons | Upgrades | Skins
+ *
+ * League gating (t022):
+ *   • Tanks and weapons are locked if the player's current league is below
+ *     the item's leagueRequired field.
+ *   • Upgrades are capped at the tier ceiling for the current league
+ *     (LEAGUE_TIER_CAPS: bronze=2, silver=3, gold=4, platinum=5, diamond/champion=5).
+ *
+ * Requires a `<div id="shop-menu">` element in the DOM (see index.html).
+ *
+ * Usage:
+ *   const shop = new ShopMenu(saveSystem, economySystem, leagueSystem);
+ *   shop.onClose(() => { resumeGame(); });
+ *   shop.open();
+ */
+
+import { TankDefs, TANK_ORDER }                        from '../data/TankDefs.js';
+import { GunDefs, MeleeDefs, GUN_ORDER, MELEE_ORDER }  from '../data/WeaponDefs.js';
+import {
+  TankUpgradeDefs,
+  FootUpgradeDefs,
+  TANK_UPGRADE_ORDER,
+  FOOT_UPGRADE_ORDER,
+}                                                       from '../data/UpgradeDefs.js';
+import { LEAGUE_ORDER }                                 from '../data/LeagueDefs.js';
+
+// ---------------------------------------------------------------------------
+// Cosmetic skin definitions (no league gate)
+// ---------------------------------------------------------------------------
+const SKIN_DEFS = [
+  { id: 'camo_green',    name: 'Camo Green',    price: 500,  description: 'Military woodland camo.' },
+  { id: 'desert_tan',    name: 'Desert Tan',    price: 750,  description: 'Sandy desert scheme.' },
+  { id: 'arctic_white',  name: 'Arctic White',  price: 1000, description: 'Snow camouflage.' },
+  { id: 'stealth_black', name: 'Stealth Black', price: 1500, description: 'All-black tactical finish.' },
+  { id: 'neon_blue',     name: 'Neon Blue',     price: 2000, description: 'Electric blue neon.' },
+  { id: 'chrome',        name: 'Chrome',        price: 3000, description: 'Mirror-polished chrome.' },
+  { id: 'gold_plated',   name: 'Gold Plated',   price: 5000, description: 'Prestige gold finish.' },
+];
+
+// ---------------------------------------------------------------------------
+// League label helper
+// ---------------------------------------------------------------------------
+
+/** Convert a league ID to a display name ('bronze' → 'Bronze'). */
+function leagueName(id) {
+  if (!id) return '';
+  return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+export class ShopMenu {
+  /**
+   * @param {import('../systems/SaveSystem.js').SaveSystem}       saveSystem
+   * @param {import('../systems/EconomySystem.js').EconomySystem} economySystem
+   * @param {import('../systems/LeagueSystem.js').LeagueSystem}   leagueSystem
+   */
+  constructor(saveSystem, economySystem, leagueSystem) {
+    this._save    = saveSystem;
+    this._economy = economySystem;
+    this._league  = leagueSystem;
+
+    this._activeTab      = 'tanks';
+    this._closeCallbacks = [];
+
+    this._el = document.getElementById('shop-menu');
+    if (!this._el) {
+      console.error('[ShopMenu] #shop-menu element not found in DOM');
+      return;
+    }
+
+    this._bindEvents();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /** Register a callback invoked when the player closes the shop. */
+  onClose(fn) {
+    this._closeCallbacks.push(fn);
+  }
+
+  /** Show the shop overlay and render the Tanks tab. */
+  open() {
+    this._activeTab = 'tanks';
+    this._render();
+    this._el.classList.remove('hidden');
+  }
+
+  /** Hide the shop overlay and fire close callbacks. */
+  close() {
+    this._el.classList.add('hidden');
+    for (const fn of this._closeCallbacks) {
+      fn();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event wiring (single delegated listener)
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _bindEvents() {
+    this._el.addEventListener('click', (e) => {
+      const tabBtn = e.target.closest('[data-tab]');
+      if (tabBtn) {
+        this._activeTab = tabBtn.dataset.tab;
+        this._render();
+        return;
+      }
+
+      const buyBtn = e.target.closest('[data-buy]');
+      if (buyBtn && !buyBtn.disabled) {
+        this._handleBuy(buyBtn.dataset);
+        return;
+      }
+
+      if (e.target.closest('#shop-close-btn')) {
+        this.close();
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+
+  /** @private Full re-render of the shop panel. */
+  _render() {
+    const currentLeagueId = this._league.getCurrentLeagueId();
+    const balance         = this._economy.balance;
+
+    this._el.innerHTML = `
+      <div class="shop-panel">
+        <div class="shop-header">
+          <span class="shop-title">SHOP</span>
+          <div class="shop-meta">
+            <span class="shop-money">$${balance.toLocaleString()}</span>
+            <span class="shop-league-badge shop-league-${currentLeagueId}">
+              ${leagueName(currentLeagueId)}
+            </span>
+          </div>
+          <button id="shop-close-btn" class="shop-close-btn" aria-label="Close shop">&#x2715;</button>
+        </div>
+
+        <nav class="shop-tabs">
+          ${['tanks', 'weapons', 'upgrades', 'skins'].map(tab => `
+            <button class="shop-tab-btn${this._activeTab === tab ? ' active' : ''}"
+                    data-tab="${tab}">
+              ${tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          `).join('')}
+        </nav>
+
+        <div class="shop-content">
+          ${this._renderTab(currentLeagueId)}
+        </div>
+      </div>
+    `;
+  }
+
+  /** @private Route to the active tab renderer. */
+  _renderTab(currentLeagueId) {
+    switch (this._activeTab) {
+      case 'tanks':    return this._renderTanks(currentLeagueId);
+      case 'weapons':  return this._renderWeapons(currentLeagueId);
+      case 'upgrades': return this._renderUpgrades(currentLeagueId);
+      case 'skins':    return this._renderSkins();
+      default:         return '';
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tab: Tanks
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _renderTanks(currentLeagueId) {
+    const cards = TANK_ORDER.map(id => {
+      const def        = TankDefs[id];
+      const owned      = this._save.hasItem('tank', def.id);
+      const locked     = !this._league.isTankUnlocked(def);
+      const affordable = this._economy.canAfford(def.price);
+
+      return `
+        <div class="shop-card${owned ? ' owned' : ''}${locked ? ' locked' : ''}">
+          <div class="shop-card-name">${def.name}
+            ${def.ability ? `<span class="shop-ability-tag">${def.ability}</span>` : ''}
+          </div>
+          <div class="shop-card-desc">${def.description}</div>
+          <div class="shop-card-stats">
+            <span>HP ${def.hp}</span>
+            <span>Spd ${def.speed}u/s</span>
+            <span>Arm ${Math.round(def.armor * 100)}%</span>
+          </div>
+          ${locked ? `<div class="shop-req-label">Requires ${leagueName(def.leagueRequired)}</div>` : ''}
+          <div class="shop-card-footer">
+            ${this._buyFooter('tank', def.id, def.price, owned, locked, affordable)}
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    return `<div class="shop-grid">${cards}</div>`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tab: Weapons
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _renderWeapons(currentLeagueId) {
+    /**
+     * @param {string} label
+     * @param {object} defs         GunDefs or MeleeDefs object
+     * @param {string[]} orderArr   GUN_ORDER or MELEE_ORDER
+     * @param {'weapon'|'melee'} saveType  key used in SaveSystem (weapon=guns, melee=melee)
+     */
+    const renderGroup = (label, defs, orderArr, saveType) => {
+      const cards = orderArr.map(id => {
+        const def        = defs[id];
+        if (!def) return '';
+        const owned      = this._save.hasItem(saveType, def.id);
+        const locked     = !this._league.isWeaponUnlocked(def);
+        const affordable = this._economy.canAfford(def.price);
+
+        const statLine = def.type === 'melee'
+          ? `<span>DMG ${def.damage}</span><span>Rate ${def.attackRate ?? '—'}/s</span><span>Rng ${def.range}m</span>`
+          : `<span>DMG ${def.damage}</span><span>RPM ${Math.round((def.fireRate || 0) * 60)}</span><span>Rng ${def.range}m</span>`;
+
+        return `
+          <div class="shop-card${owned ? ' owned' : ''}${locked ? ' locked' : ''}">
+            <div class="shop-card-name">${def.name}
+              ${def.isExplosive ? '<span class="shop-type-tag">Explosive</span>' : ''}
+              ${def.ability ? `<span class="shop-ability-tag">${def.ability}</span>` : ''}
+            </div>
+            <div class="shop-card-desc">${def.description}</div>
+            <div class="shop-card-stats">${statLine}</div>
+            ${locked ? `<div class="shop-req-label">Requires ${leagueName(def.leagueRequired)}</div>` : ''}
+            <div class="shop-card-footer">
+              ${this._buyFooter(saveType, def.id, def.price, owned, locked, affordable)}
+            </div>
+          </div>
+        `;
+      }).join('');
+
+      return `
+        <div class="shop-weapon-group">
+          <div class="shop-group-label">${label}</div>
+          <div class="shop-grid">${cards}</div>
+        </div>
+      `;
+    };
+
+    return (
+      renderGroup('Firearms &amp; Explosives', GunDefs, GUN_ORDER, 'weapon') +
+      renderGroup('Melee', MeleeDefs, MELEE_ORDER, 'melee')
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tab: Upgrades (tier-capped by league)
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _renderUpgrades(currentLeagueId) {
+    const renderGroup = (label, defs, orderArr, scope) => {
+      const rows = orderArr.map(id => {
+        const def = defs[id];
+        if (!def) return '';
+
+        const currentTier = this._save.getUpgradeTier(scope, def.id);
+        // League-enforced ceiling: cannot purchase beyond this tier.
+        const leagueCap   = this._league.getMaxAvailableUpgradeTier(def);
+        const maxTier     = def.maxTier;
+        const canUpgrade  = currentTier < leagueCap;
+        const nextTier    = canUpgrade ? currentTier + 1 : null;
+        const nextCost    = (nextTier !== null) ? def.costs[nextTier - 1] : null;
+        const affordable  = (nextCost !== null) && this._economy.canAfford(nextCost);
+
+        // Tier pips — filled up to currentTier, league cap marker at leagueCap
+        const pips = Array.from({ length: maxTier }, (_, i) => {
+          const tierNum = i + 1;
+          const filled  = tierNum <= currentTier;
+          const capped  = tierNum === leagueCap && leagueCap < maxTier;
+          return `<span class="tier-pip${filled ? ' filled' : ''}${capped ? ' cap-marker' : ''}"></span>`;
+        }).join('');
+
+        let action;
+        if (currentTier >= maxTier) {
+          action = '<span class="shop-maxed-label">MAX</span>';
+        } else if (currentTier >= leagueCap) {
+          action = `<span class="shop-league-cap-label">Tier cap (${leagueName(currentLeagueId)})</span>`;
+        } else {
+          action = `
+            <button class="shop-buy-btn${!affordable ? ' disabled' : ''}"
+                    data-buy="upgrade"
+                    data-id="${def.id}"
+                    data-scope="${scope}"
+                    data-price="${nextCost}"
+                    data-tier="${nextTier}"
+                    ${!affordable ? 'disabled' : ''}>
+              $${nextCost.toLocaleString()}
+            </button>
+          `;
+        }
+
+        return `
+          <div class="shop-upgrade-row${currentTier >= maxTier ? ' maxed' : ''}${currentTier >= leagueCap && currentTier < maxTier ? ' at-cap' : ''}">
+            <div class="shop-upgrade-info">
+              <span class="shop-upgrade-name">${def.name}</span>
+              <span class="shop-upgrade-effect">${def.description}</span>
+            </div>
+            <div class="shop-upgrade-tiers">
+              ${pips}
+              <span class="tier-count">${currentTier}/${maxTier}</span>
+            </div>
+            <div class="shop-upgrade-action">${action}</div>
+          </div>
+        `;
+      }).join('');
+
+      return `
+        <div class="shop-upgrade-group">
+          <div class="shop-group-label">${label}</div>
+          ${rows}
+        </div>
+      `;
+    };
+
+    return (
+      renderGroup('Tank Upgrades', TankUpgradeDefs, TANK_UPGRADE_ORDER, 'standard') +
+      renderGroup('On-Foot Upgrades', FootUpgradeDefs, FOOT_UPGRADE_ORDER, 'infantry')
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tab: Skins (no league gate)
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _renderSkins() {
+    const cards = SKIN_DEFS.map(def => {
+      const owned      = this._save.hasItem('skin', def.id);
+      const affordable = this._economy.canAfford(def.price);
+
+      return `
+        <div class="shop-card${owned ? ' owned' : ''}">
+          <div class="shop-card-name">${def.name}
+            <span class="shop-type-tag">Cosmetic</span>
+          </div>
+          <div class="shop-card-desc">${def.description}</div>
+          <div class="shop-card-footer">
+            ${this._buyFooter('skin', def.id, def.price, owned, false, affordable)}
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    return `<div class="shop-grid">${cards}</div>`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @private Renders the buy/owned/free footer for a card.
+   */
+  _buyFooter(buyType, id, price, owned, locked, affordable) {
+    if (owned)       return '<span class="shop-owned-label">Owned</span>';
+    if (price === 0) return '<span class="shop-free-label">Free</span>';
+    const disabled = locked || !affordable;
+    return `
+      <button class="shop-buy-btn${disabled ? ' disabled' : ''}"
+              data-buy="${buyType}"
+              data-id="${id}"
+              data-price="${price}"
+              ${disabled ? 'disabled' : ''}>
+        $${price.toLocaleString()}
+      </button>
+    `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Buy handler
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _handleBuy(dataset) {
+    const price = parseInt(dataset.price || '0', 10);
+
+    if (!this._economy.canAfford(price)) {
+      this._showFlash('Not enough money!', 'error');
+      return;
+    }
+
+    this._economy.spend(price);
+
+    switch (dataset.buy) {
+      case 'tank':
+        this._save.addOwnedItem('tank', dataset.id);
+        this._save.save();
+        this._showFlash(`${dataset.id} purchased!`, 'success');
+        break;
+
+      case 'weapon':
+        this._save.addOwnedItem('weapon', dataset.id);
+        this._save.save();
+        this._showFlash(`${dataset.id} purchased!`, 'success');
+        break;
+
+      case 'melee':
+        this._save.addOwnedItem('melee', dataset.id);
+        this._save.save();
+        this._showFlash(`${dataset.id} purchased!`, 'success');
+        break;
+
+      case 'skin':
+        this._save.addOwnedItem('skin', dataset.id);
+        this._save.save();
+        this._showFlash(`${dataset.id} skin unlocked!`, 'success');
+        break;
+
+      case 'upgrade': {
+        const tier  = parseInt(dataset.tier || '1', 10);
+        const scope = dataset.scope || 'standard';
+        // Enforce tier cap before applying.
+        const upgDef =
+          TankUpgradeDefs[dataset.id] ||
+          FootUpgradeDefs[dataset.id];
+        if (upgDef) {
+          const cap = this._league.getMaxAvailableUpgradeTier(upgDef);
+          if (tier > cap) {
+            this._showFlash(`Upgrade capped at tier ${cap} (${leagueName(this._league.getCurrentLeagueId())})`, 'error');
+            return;
+          }
+        }
+        this._save.setUpgrade(scope, dataset.id, tier);
+        this._save.save();
+        this._showFlash(`${dataset.id} → tier ${tier}!`, 'success');
+        break;
+      }
+
+      default:
+        console.warn('[ShopMenu] Unknown buy type:', dataset.buy);
+        return;
+    }
+
+    // Re-render to reflect new balance, ownership, and tier state.
+    this._render();
+  }
+
+  /**
+   * @private Brief status flash at the top of the panel.
+   */
+  _showFlash(msg, type) {
+    const panel = this._el.querySelector('.shop-panel');
+    if (!panel) return;
+    panel.querySelector('.shop-flash')?.remove();
+    const flash       = document.createElement('div');
+    flash.className   = `shop-flash shop-flash-${type}`;
+    flash.textContent = msg;
+    panel.prepend(flash);
+    setTimeout(() => flash.remove(), 2000);
+  }
+}


### PR DESCRIPTION
## Summary

- **LeagueSystem** (`src/systems/LeagueSystem.js`): LP tracking with promotion/demotion detection. Reads/writes `leagueId`+`leaguePoints` through SaveSystem. Exposes `isTankUnlocked()`, `isWeaponUnlocked()`, `getUpgradeTierCap()`, `getMaxAvailableUpgradeTier()`, and `applyMatchResult()`.
- **ShopMenu** (`src/ui/ShopMenu.js`): Full 4-tab shop (Tanks · Weapons · Upgrades · Skins) with league gating. Items with `leagueRequired` above the player's current league are shown locked with the required league name. Upgrade tiers are hard-capped at `LeagueDefs[currentLeague].upgradeTierCap` — the buy button is replaced with a "Tier cap (Bronze)" label until the player promotes.
- **index.html**: `<div id="shop-menu">` overlay element + ~220 lines of shop CSS (panel, cards grid, upgrade rows, tier pips, flash messages, responsive breakpoints).

## League tier caps enforced

| League | Upgrade tier cap |
|--------|-----------------|
| Bronze | 2 |
| Silver | 3 |
| Gold | 4 |
| Platinum / Diamond / Champion | 5 |

## Verification

```
node --input-type=module --eval "
import { LeagueSystem } from './src/systems/LeagueSystem.js';
const save = { _profile: { leagueId: 'bronze', leaguePoints: 490 }, updateLeague(id,lp){ this._profile.leagueId=id; this._profile.leaguePoints=lp; }, save(){} };
const ls = new LeagueSystem(save);
const r = ls.applyMatchResult('win20');
console.assert(r.promoted === true, 'should promote');
console.assert(r.leagueAfter === 'silver', 'should reach silver');
console.assert(ls.getUpgradeTierCap() === 3, 'silver cap=3');
console.log('All assertions passed');
" 2>&1
```

Resolves #38