### PR TITLE
GH#42: feat: t026 — melee attack system: sphere overlap, weapon stats, F/middle-click input

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -33,6 +33,16 @@ export class Game {
     /** @type {{tank: string, gun: string, melee: string}|null} */
     this.currentLoadout = null;
 
+    /**
+     * Active player-controlled Soldier instance, or null when the player is in
+     * tank mode.  Set to a Soldier by PlayerController (t025) when the player
+     * bails out of their tank.  The melee handling in _updatePlayer() reads
+     * this field each frame so it activates automatically when t025 sets it.
+     *
+     * @type {import('../entities/Soldier.js').Soldier|null}
+     */
+    this.playerSoldier = null;
+
     this._initRenderer();
     this._initScene();
     this._initSystems();
@@ -424,6 +434,32 @@ export class Game {
           projectile.mesh.position.clone(),
           flashDir
         );
+      }
+    }
+
+    // ---- On-foot soldier melee (t026) ----
+    // Activated when PlayerController (t025) sets this.playerSoldier.
+    if (this.playerSoldier && input.melee) {
+      // Build the list of valid melee targets: all living enemy tanks + living
+      // enemy soldiers (the latter added when t028/t029 introduce AI soldiers).
+      const meleeTargets = [...this.teams.getEnemyTanks()];
+      const hits = this.playerSoldier.melee(meleeTargets);
+      for (const { target, damage } of hits) {
+        // Record damage in the stats tracker so rewards are counted.
+        this.stats.recordPlayerDamage(target, damage);
+        const hitPos = target.mesh.position.clone();
+        if (target.health <= 0) {
+          this.stats.recordTankKilled(target, true);
+          this.killFeed.addMessage(
+            this.playerSoldier.name || 'Player',
+            target.name || 'Enemy'
+          );
+          this.teams.killTank(target);
+          this.particles.emitExplosion(hitPos, { count: 25, speed: 8 });
+        } else {
+          // Small impact burst for a non-lethal melee hit.
+          this.particles.emitExplosion(hitPos, { count: 8, speed: 4, lifetime: 0.3 });
+        }
       }
     }
 

--- a/src/entities/Soldier.js
+++ b/src/entities/Soldier.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { Projectile } from './Projectile.js';
+import { getMeleeDef } from '../data/WeaponDefs.js';
 
 /** Soldier stats — on-foot mode. See VISION.md "On-Foot Mode". */
 const SOLDIER_STATS = {
@@ -43,6 +44,21 @@ export class Soldier {
     /** Movement constants exposed so PlayerController / AIController can read them. */
     this.moveSpeed = SOLDIER_STATS.moveSpeed;
     this.turnSpeed = SOLDIER_STATS.turnSpeed;
+
+    // ---- Melee weapon state (t026) ----
+    /** Active melee weapon id. Defaults to starter combat knife. */
+    this.meleeWeaponId = 'combatKnife';
+    /** Seconds until next melee swing is allowed. */
+    this.meleeCooldown = 0;
+
+    // Initialise melee stats from the default weapon.
+    const _startMelee = getMeleeDef('combatKnife');
+    /** Damage per melee hit (world units). */
+    this._meleeDamage   = _startMelee.damage;
+    /** Sphere radius (world units) checked for hit targets. */
+    this._meleeRange    = _startMelee.range;
+    /** Minimum seconds between swings = 1 / attackRate. */
+    this._meleeInterval = 1 / _startMelee.attackRate;
 
     // Per-round combat stats (mirrors Tank.js for scoreboard compatibility)
     this.kills       = 0;
@@ -149,6 +165,72 @@ export class Soldier {
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Melee attack (t026)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Equip a melee weapon by id (from MeleeDefs in WeaponDefs.js).
+   * Reloads damage, range, and attack-rate from the definition.
+   * @param {string} weaponId — e.g. 'combatKnife', 'machete', 'warHammer', 'energyBlade'
+   */
+  setMeleeWeapon(weaponId) {
+    const def = getMeleeDef(weaponId);
+    this.meleeWeaponId  = weaponId;
+    this._meleeDamage   = def.damage;
+    this._meleeRange    = def.range;
+    this._meleeInterval = 1 / def.attackRate;
+  }
+
+  /**
+   * @returns {boolean} True when the melee cooldown has elapsed and an attack is ready.
+   */
+  canMelee() {
+    return this.meleeCooldown <= 0;
+  }
+
+  /**
+   * Perform a melee swing.
+   *
+   * Uses a sphere-overlap check: every target whose mesh centre is within
+   * `_meleeRange` world units of this soldier's position is hit.
+   * Damage is capped to the target's remaining HP so recorded values are exact.
+   *
+   * Does nothing and returns [] if `canMelee()` is false.
+   *
+   * @param {Array<{mesh: import('three').Object3D, health: number, takeDamage: (n:number)=>void}>} targets
+   *   Array of potential targets — may contain Tank or Soldier instances.
+   * @returns {Array<{target: object, damage: number}>}
+   *   Array of { target, damage } entries for each entity hit (may be empty).
+   */
+  melee(targets = []) {
+    if (!this.canMelee()) return [];
+
+    this.meleeCooldown = this._meleeInterval;
+
+    const pos   = this.mesh.position;
+    const range = this._meleeRange;
+    const hits  = [];
+
+    for (const target of targets) {
+      if (!target || target.health <= 0) continue;
+
+      const dist = pos.distanceTo(target.mesh.position);
+      if (dist > range) continue;
+
+      // Cap actualDamage to avoid overkill in recorded stats.
+      const actualDamage = Math.min(this._meleeDamage, target.health);
+      target.takeDamage(this._meleeDamage);
+      this.recordDamage(actualDamage);
+      if (target.health <= 0) {
+        this.recordKill();
+      }
+      hits.push({ target, damage: actualDamage });
+    }
+
+    return hits;
+  }
+
   /**
    * Apply incoming damage. HP is clamped to 0.
    * @param {number} amount
@@ -179,13 +261,17 @@ export class Soldier {
     if (this.fireCooldown > 0) {
       this.fireCooldown -= dt;
     }
+    if (this.meleeCooldown > 0) {
+      this.meleeCooldown -= dt;
+    }
   }
 
   /** Reset to full health / stats for round start. */
   reset() {
-    this.health       = this.maxHealth;
-    this.fireCooldown = 0;
-    this.kills        = 0;
-    this.damageDealt  = 0;
+    this.health        = this.maxHealth;
+    this.fireCooldown  = 0;
+    this.meleeCooldown = 0;
+    this.kills         = 0;
+    this.damageDealt   = 0;
   }
 }

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -15,7 +15,8 @@ export class InputSystem {
     // Touch joystick state
     this._joystick = { active: false, id: null, startX: 0, startY: 0, dx: 0, dy: 0 };
     this._aimTouch = { active: false, id: null, x: 0, y: 0 };
-    this._fireRequested = false;
+    this._fireRequested  = false;
+    this._meleeRequested = false;
     this._turretAngle = null;
 
     // Mouse aim
@@ -30,6 +31,8 @@ export class InputSystem {
     window.addEventListener('keydown', (e) => {
       this._keys[e.code] = true;
       if (e.code === 'Space') this._fireRequested = true;
+      // F key — on-foot melee attack (VISION.md "Controls" table)
+      if (e.code === 'KeyF') this._meleeRequested = true;
       // Prevent Tab from shifting browser focus while held for the scoreboard
       if (e.code === 'Tab') e.preventDefault();
     });
@@ -47,6 +50,12 @@ export class InputSystem {
     });
     this.canvas.addEventListener('mousedown', (e) => {
       if (e.button === 0) this._fireRequested = true;
+      // Middle mouse button (button 1) — on-foot melee attack
+      if (e.button === 1) this._meleeRequested = true;
+    });
+    // Suppress the context menu on middle-click so the browser doesn't steal the event
+    this.canvas.addEventListener('auxclick', (e) => {
+      if (e.button === 1) e.preventDefault();
     });
   }
 
@@ -142,13 +151,16 @@ export class InputSystem {
         this._keys['ArrowRight'] ||
         (joyActive && jdx > deadzone),
       fire: this._fireRequested,
+      /** One-shot: F key or middle-click triggers an on-foot melee swing. */
+      melee: this._meleeRequested,
       turretAngle: this._turretAngle,
       /** true while Tab is held — shows/hides the scoreboard overlay */
       tabHeld: !!this._keys['Tab'],
     };
 
     // Reset one-shot inputs
-    this._fireRequested = false;
+    this._fireRequested  = false;
+    this._meleeRequested = false;
 
     return state;
   }


### PR DESCRIPTION
## Summary

Implemented the on-foot melee attack system (t026). Soldier.js gains setMeleeWeapon(), canMelee(), and melee(targets) with sphere-overlap hit detection, per-weapon stats from WeaponDefs MeleeDefs, and a cooldown system. InputSystem.js adds F key and middle-mouse bindings for the melee one-shot flag. Game.js adds a playerSoldier field and wires melee input handling so it activates automatically when PlayerController (t025) enables on-foot mode.

## Files Changed

src/core/Game.js,src/entities/Soldier.js,src/systems/InputSystem.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Node smoke tests: canMelee() returns true initially, melee(targets) applies damage and sets cooldown, second immediate call returns 0 hits, update(dt) decrements cooldown, reset() clears it. setMeleeWeapon('machete') correctly loads machete stats (50 dmg, 2.5 range).

Resolves #42


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.68 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 14,727 tokens on this as a headless worker.