### PR TITLE
t025: PlayerController: mode switching (E key), auto-bail on tank death, re-enter tank

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -14,6 +14,7 @@ import { LoadoutScreen } from '../ui/LoadoutScreen.js';
 import { ShopMenu } from '../ui/ShopMenu.js';
 import { CameraController } from '../systems/CameraController.js';
 import { TeamManager } from './TeamManager.js';
+import { PlayerController } from './PlayerController.js';
 import { AIController } from '../systems/AIController.js';
 import { MatchManager } from './MatchManager.js';
 import { StatsTracker } from '../systems/StatsTracker.js';
@@ -84,11 +85,21 @@ export class Game {
     // this.player is a convenience alias to teams[0].slots[0].tank.
     this.teams = new TeamManager(this.scene, this.terrain);
     this.player = this.teams.player;
+
+    // PlayerController manages tank vs. on-foot soldier mode for the human player.
+    // It exposes a `mesh` getter so CameraController always follows the active entity.
+    this.playerController = new PlayerController({
+      tank:    this.player,
+      scene:   this.scene,
+      terrain: this.terrain,
+    });
   }
 
   _initSystems() {
     this.input = new InputSystem(this.canvas);
-    this.cameraController = new CameraController(this.camera, this.player);
+    // CameraController uses target.mesh; PlayerController exposes that getter
+    // so the camera follows whichever entity the player is currently controlling.
+    this.cameraController = new CameraController(this.camera, this.playerController);
     this.projectiles = new ProjectileSystem(this.scene);
     this.particles = new ParticleSystem(this.scene);
     // TreeSystem spawns tree entities with HP; CollisionSystem handles shell hits
@@ -201,6 +212,8 @@ export class Game {
         // Clear per-tank AI reaction timers so enemies don't carry over mid-fire
         // state from the previous round.
         this.aiController.reset();
+        // Reset PlayerController to tank mode (removes any active soldier mesh).
+        this.playerController.reset();
         this._playerDustTimer = 0;
         this._enemyDustTimer = 0;
       })
@@ -318,8 +331,13 @@ export class Game {
 
     // Gate all combat logic on an active round.
     if (this.match.isActive()) {
-      // Player input
+      // Player input — PlayerController delegates to tank or soldier depending on mode.
       this._updatePlayer(input, dt);
+
+      // Check for soldier taking enemy projectile damage (when player is on foot).
+      if (this.playerController.mode === 'soldier' && this.playerController.soldier) {
+        this._checkSoldierHit();
+      }
 
       // AIController: drives all ally (team 0, slots 1-5) and enemy AI tanks
       this.aiController.update(dt);
@@ -350,13 +368,14 @@ export class Game {
     this.particles.update(dt);
     this.cameraController.update(dt);
 
-    // HUD — pass live round stats for the counters
+    // HUD — pass live round stats for the counters.
+    // Use playerController so values reflect the active entity (tank or soldier).
     const roundStats = this.stats.getCurrentRoundStats();
     this.hud.update({
-      score: this.score,
-      health: this.player.health,
-      ammo: this.player.ammo,
-      stats: roundStats,
+      score:  this.score,
+      health: this.playerController.health,
+      ammo:   this.playerController.ammo,
+      stats:  roundStats,
     });
 
     // Scoreboard: show when Tab is held
@@ -366,73 +385,114 @@ export class Game {
   }
 
   /**
-   * @param {ReturnType<import('../systems/InputSystem.js').InputSystem['getState']>} input — pre-fetched this frame
+   * Delegate player input to PlayerController, which handles movement,
+   * mode switching (E key), and firing for whichever entity is active.
+   *
+   * @param {ReturnType<import('../systems/InputSystem.js').InputSystem['getState']>} input
    * @param {number} dt
    */
   _updatePlayer(input, dt) {
-    const moveSpeed = 12;
-    const turnSpeed = 2.5;
+    const { newProjectile, isMoving } = this.playerController.update(input, dt);
 
-    if (input.forward) {
-      this.player.mesh.translateZ(-moveSpeed * dt);
-    }
-    if (input.backward) {
-      this.player.mesh.translateZ(moveSpeed * 0.6 * dt);
-    }
-    if (input.left) {
-      this.player.mesh.rotation.y += turnSpeed * dt;
-    }
-    if (input.right) {
-      this.player.mesh.rotation.y -= turnSpeed * dt;
+    if (newProjectile) {
+      this.projectiles.add(newProjectile);
+      const flashDir = newProjectile.velocity.clone().normalize();
+      this.particles.emitMuzzleFlash(
+        newProjectile.mesh.position.clone(),
+        flashDir
+      );
     }
 
-    if (input.turretAngle !== null) {
-      this.player.setTurretAngle(input.turretAngle);
-    }
-
-    if (input.fire && this.player.canFire()) {
-      const projectile = this.player.fire();
-      if (projectile) {
-        this.projectiles.add(projectile);
-        const flashDir = projectile.velocity.clone().normalize();
-        this.particles.emitMuzzleFlash(
-          projectile.mesh.position.clone(),
-          flashDir
-        );
-      }
-    }
-
-    // Keep on terrain
-    const pos = this.player.mesh.position;
-    pos.y = this.terrain.getHeightAt(pos.x, pos.z);
-
-    // Clamp to arena
-    const bound = 90;
-    pos.x = THREE.MathUtils.clamp(pos.x, -bound, bound);
-    pos.z = THREE.MathUtils.clamp(pos.z, -bound, bound);
-
-    // Dust trail while moving
+    // Dust trail while the active entity is moving
     this._playerDustTimer -= dt;
-    if (this._playerDustTimer <= 0 && (input.forward || input.backward)) {
+    if (this._playerDustTimer <= 0 && isMoving) {
       this._playerDustTimer = 0.15;
-      this.particles.emitDust(this.player.mesh.position);
+      this.particles.emitDust(this.playerController.mesh.position);
     }
   }
 
   /**
    * Called by CollisionSystem when the player's tank HP reaches 0.
-   * Marks the player's slot dead in TeamManager so `isTeamEliminated(0)` can
-   * fire, removing the mesh from the scene and triggering the MatchManager
-   * round-end / match-end flow if all allies are also gone.
+   *
+   * If the player is still in the tank (tank mode):
+   *   - Remove tank mesh and spawn a wreck.
+   *   - Spawn a soldier at the tank's last position (auto-bail).
+   *   - Player slot stays alive in TeamManager until the soldier also dies.
+   *
+   * If the player already exited the tank voluntarily (soldier mode):
+   *   - The idle tank was destroyed by enemies — remove it and spawn a wreck.
+   *   - Player continues on foot; re-entry is no longer possible.
    */
   _onPlayerTankDestroyed() {
-    // Notify StatsTracker to stop the survival timer for this round.
-    this.stats.recordPlayerDeath();
-    // Mark player dead in TeamManager: removes mesh, checks team elimination.
-    // Without this call the player's slot stays alive=true and the team can
-    // never be eliminated, stalling the round indefinitely.
+    // Capture last-known position and rotation before removing the mesh.
+    const tankPos  = this.player.mesh.position.clone();
+    const tankRotY = this.player.mesh.rotation.y;
+
+    // Remove the tank mesh from the scene (kills its presence without
+    // calling TeamManager.killTank() so the player slot stays alive).
+    this.scene.remove(this.player.mesh);
+    // Spawn a wreck prop at the tank's last position.
+    this.wrecks.add(tankPos, tankRotY);
+
+    if (this.playerController.mode === 'soldier') {
+      // Player was already on foot — idle tank was destroyed by enemies.
+      // Update PlayerController state so re-entry prompt is hidden.
+      this.playerController.notifyTankDestroyedWhileIdle();
+      console.info('[Game] Idle player tank destroyed; player continues on foot.');
+    } else {
+      // Player was in the tank — auto-bail.
+      this.stats.recordPlayerDeath();
+      this.playerController.bailOut(tankPos);
+      console.info('[Game] Player tank destroyed — auto-bailed as soldier.');
+    }
+  }
+
+  /**
+   * Called when the player's on-foot soldier HP reaches 0.
+   * Removes the soldier from the scene, then finalises the player's
+   * slot as dead in TeamManager (triggering round-end if the team is wiped).
+   */
+  _onPlayerSoldierDestroyed() {
+    const soldierPos = this.playerController.soldier.mesh.position.clone();
+    this.particles.emitExplosion(soldierPos, { count: 10, speed: 5, lifetime: 0.5 });
+    this.playerController.clearSoldier();
+
+    // Now mark the player's slot dead — this may trigger team elimination.
     this.teams.killTank(this.player);
-    console.info('[Game] Player tank destroyed.');
+    console.info('[Game] Player soldier destroyed — player is out for this round.');
+  }
+
+  /**
+   * Check whether any enemy projectile has hit the player's on-foot soldier.
+   * Called each frame while playerController.mode === 'soldier'.
+   *
+   * Hit radius (1.2 units) is tighter than the tank radius (2.5 units) to
+   * reflect the soldier's smaller capsule silhouette.
+   */
+  _checkSoldierHit() {
+    const soldier = this.playerController.soldier;
+    const projectiles = this.projectiles.active;
+    const HIT_RADIUS = 1.2;
+
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p = projectiles[i];
+      if (p.isPlayerOwned) continue; // friendly bullets skip the player
+
+      const dist = p.mesh.position.distanceTo(soldier.mesh.position);
+      if (dist < HIT_RADIUS) {
+        const hitPos = p.mesh.position.clone();
+        const actualDamage = Math.min(p.damage, soldier.health);
+        if (p.ownerTank) p.ownerTank.recordDamage(actualDamage);
+        soldier.takeDamage(p.damage);
+        this.projectiles.remove(i);
+        this.particles.emitExplosion(hitPos, { count: 6, speed: 3, lifetime: 0.3 });
+
+        if (soldier.health <= 0) {
+          this._onPlayerSoldierDestroyed();
+          break; // soldier removed; stop checking more projectiles this frame
+        }
+      }
+    }
   }
 
   /**
@@ -467,6 +527,8 @@ export class Game {
       this.match.reset();
       // Reset StatsTracker for the new match
       this.stats.reset();
+      // Reset PlayerController to tank mode (clears any active soldier mesh)
+      this.playerController.reset();
       // Reset field entities
       this.teams.reset();
       this.projectiles.reset();

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -1,0 +1,303 @@
+import * as THREE from 'three';
+import { Soldier } from '../entities/Soldier.js';
+
+/**
+ * Distance (units) within which the on-foot soldier can re-enter the idle tank.
+ * Roughly the tank hull length (4.5) plus a comfortable step-in margin.
+ */
+const RE_ENTER_DIST = 6;
+
+/** Arena bound: matches Game.js clamp value. */
+const ARENA_BOUND = 90;
+
+/**
+ * PlayerController — manages the player's mode (tank vs. on-foot soldier).
+ *
+ * Modes
+ * -----
+ *  'tank'    — player directly controls this.tank (default).
+ *  'soldier' — player's tank is idle or destroyed; player controls this.soldier.
+ *
+ * Transitions
+ * -----------
+ *  Voluntary exit  (E key in tank mode)    : soldier spawns beside tank; tank idles.
+ *  Auto-bail       (tank destroyed by foe) : soldier spawns at tank's last position.
+ *  Re-enter tank   (E key near idle tank)  : soldier despawns; tank control resumes.
+ *
+ * Interface compatibility
+ * -----------------------
+ *  CameraController uses target.mesh — the `mesh` getter always returns the
+ *  active entity's mesh so the camera follows the right entity.
+ *  HUD uses health/maxHealth/ammo — these getters delegate to the active entity.
+ */
+export class PlayerController {
+  /**
+   * @param {object}  opts
+   * @param {import('../entities/Tank.js').Tank}       opts.tank    — player tank entity
+   * @param {THREE.Scene}                              opts.scene
+   * @param {import('../entities/Terrain.js').Terrain} opts.terrain
+   */
+  constructor({ tank, scene, terrain }) {
+    this.tank    = tank;
+    this.soldier = null;     // Soldier entity when on foot, null otherwise
+    this.scene   = scene;
+    this.terrain = terrain;
+
+    /** @type {'tank' | 'soldier'} */
+    this.mode = 'tank';
+
+    /**
+     * True when the player voluntarily exited the tank and the tank is still
+     * alive/idle in the scene, making re-entry possible.
+     * Set to false when the tank is destroyed (bailed out or destroyed while idle).
+     * @type {boolean}
+     */
+    this._tankIdle = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Accessors — CameraController / HUD compatibility
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The active entity's mesh. CameraController binds to `target.mesh`.
+   * @returns {THREE.Group}
+   */
+  get mesh() {
+    return this.mode === 'tank' ? this.tank.mesh : this.soldier.mesh;
+  }
+
+  /** Current HP shown in the HUD. */
+  get health() {
+    return this.mode === 'tank' ? this.tank.health : this.soldier.health;
+  }
+
+  /** Maximum HP shown in the HUD. */
+  get maxHealth() {
+    return this.mode === 'tank' ? this.tank.maxHealth : this.soldier.maxHealth;
+  }
+
+  /**
+   * Current ammo shown in the HUD.
+   * null when on foot — soldiers have effectively unlimited ammo (no clip mechanic yet).
+   * @returns {number|null}
+   */
+  get ammo() {
+    return this.mode === 'tank' ? this.tank.ammo : null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mode transitions
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Voluntary exit: player presses E while in tank mode.
+   * Spawns a soldier 4 units to the right of the tank hull.
+   * Tank remains idle in the scene and can be re-entered.
+   */
+  exitTank() {
+    if (this.mode !== 'tank') return;
+
+    const tankPos  = this.tank.mesh.position;
+    const tankRotY = this.tank.mesh.rotation.y;
+
+    // Offset 4 units to the hull's local +X (right side)
+    const offset = new THREE.Vector3(4, 0, 0);
+    offset.applyEuler(new THREE.Euler(0, tankRotY, 0));
+    const spawnPos = tankPos.clone().add(offset);
+
+    this._spawnSoldierAt(spawnPos, tankRotY);
+    this._tankIdle = true;
+    this.mode = 'soldier';
+
+    console.info('[PlayerController] Voluntarily exited tank (E key).');
+  }
+
+  /**
+   * Forced bail-out: the player's tank was destroyed.
+   * Called by Game._onPlayerTankDestroyed() with the tank's last position.
+   * The caller is responsible for removing the tank mesh and spawning a wreck.
+   *
+   * @param {THREE.Vector3} tankPos — snapshot taken before mesh removal
+   */
+  bailOut(tankPos) {
+    if (this.soldier !== null) return; // already on foot
+
+    this._spawnSoldierAt(tankPos.clone(), this.tank.mesh.rotation.y);
+    this._tankIdle = false; // tank is destroyed — re-entry not possible
+    this.mode = 'soldier';
+
+    console.info('[PlayerController] Auto-bailed from destroyed tank.');
+  }
+
+  /**
+   * Attempt to re-enter the idle tank (E key while on foot).
+   * Succeeds only when:
+   *   - Mode is 'soldier'.
+   *   - `_tankIdle` is true (tank was voluntarily vacated, not destroyed).
+   *   - Soldier is within RE_ENTER_DIST units of the tank.
+   *
+   * @returns {boolean} True if re-entry succeeded.
+   */
+  tryEnterTank() {
+    if (this.mode !== 'soldier' || !this._tankIdle || !this.soldier) return false;
+
+    const dist = this.soldier.mesh.position.distanceTo(this.tank.mesh.position);
+    if (dist > RE_ENTER_DIST) return false;
+
+    this.scene.remove(this.soldier.mesh);
+    this.soldier = null;
+    this._tankIdle = false;
+    this.mode = 'tank';
+
+    console.info('[PlayerController] Re-entered tank.');
+    return true;
+  }
+
+  /**
+   * Remove the soldier from the scene (called on soldier death or round reset).
+   * Safe to call when no soldier is active.
+   */
+  clearSoldier() {
+    if (this.soldier) {
+      this.scene.remove(this.soldier.mesh);
+      this.soldier = null;
+    }
+  }
+
+  /**
+   * Called when the idle tank is destroyed by enemies while the player is on foot.
+   * Updates state so re-entry is no longer offered.
+   * The caller (Game.js) handles mesh removal and wreck spawning.
+   */
+  notifyTankDestroyedWhileIdle() {
+    this._tankIdle = false;
+    console.info('[PlayerController] Idle tank was destroyed by enemies; re-entry no longer possible.');
+  }
+
+  /**
+   * Reset to tank mode for a new round: remove any active soldier.
+   */
+  reset() {
+    this.clearSoldier();
+    this._tankIdle = false;
+    this.mode = 'tank';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-frame update
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Process input and advance the active entity.
+   *
+   * @param {object} input — snapshot from InputSystem.getState()
+   * @param {number} dt    — seconds since last frame
+   * @returns {{ newProjectile: import('../entities/Projectile.js').Projectile|null,
+   *             isMoving: boolean }}
+   *   newProjectile — projectile to add to ProjectileSystem (null if none fired).
+   *   isMoving      — true if the active entity moved this frame (for dust trails).
+   */
+  update(input, dt) {
+    if (this.mode === 'tank') {
+      return this._updateTankMode(input, dt);
+    }
+    return this._updateSoldierMode(input, dt);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — tank mode
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _updateTankMode(input, dt) {
+    const MOVE_SPEED = 12;
+    const TURN_SPEED = 2.5;
+    const tank    = this.tank;
+    const terrain = this.terrain;
+
+    const moving = input.forward || input.backward;
+
+    if (input.forward)  tank.mesh.translateZ(-MOVE_SPEED * dt);
+    if (input.backward) tank.mesh.translateZ(MOVE_SPEED * 0.6 * dt);
+    if (input.left)     tank.mesh.rotation.y += TURN_SPEED * dt;
+    if (input.right)    tank.mesh.rotation.y -= TURN_SPEED * dt;
+
+    if (input.turretAngle !== null) {
+      tank.setTurretAngle(input.turretAngle);
+    }
+
+    // Terrain follow + arena clamp
+    const pos = tank.mesh.position;
+    pos.y = terrain.getHeightAt(pos.x, pos.z);
+    pos.x = THREE.MathUtils.clamp(pos.x, -ARENA_BOUND, ARENA_BOUND);
+    pos.z = THREE.MathUtils.clamp(pos.z, -ARENA_BOUND, ARENA_BOUND);
+
+    // E key — voluntary exit
+    if (input.exitVehicle) {
+      this.exitTank();
+    }
+
+    let newProjectile = null;
+    if (input.fire && tank.canFire()) {
+      newProjectile = tank.fire();
+    }
+
+    return { newProjectile, isMoving: moving };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — soldier mode
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _updateSoldierMode(input, dt) {
+    const soldier = this.soldier;
+    const terrain = this.terrain;
+
+    const moving = input.forward || input.backward;
+
+    if (input.forward)  soldier.mesh.translateZ(-soldier.moveSpeed * dt);
+    if (input.backward) soldier.mesh.translateZ(soldier.moveSpeed * 0.6 * dt);
+    if (input.left)     soldier.mesh.rotation.y += soldier.turnSpeed * dt;
+    if (input.right)    soldier.mesh.rotation.y -= soldier.turnSpeed * dt;
+
+    // Terrain follow + arena clamp
+    const pos = soldier.mesh.position;
+    pos.y = terrain.getHeightAt(pos.x, pos.z);
+    pos.x = THREE.MathUtils.clamp(pos.x, -ARENA_BOUND, ARENA_BOUND);
+    pos.z = THREE.MathUtils.clamp(pos.z, -ARENA_BOUND, ARENA_BOUND);
+
+    soldier.update(dt);
+
+    // E key — try to re-enter idle tank
+    if (input.exitVehicle) {
+      this.tryEnterTank();
+    }
+
+    let newProjectile = null;
+    if (input.fire && soldier.canFire()) {
+      newProjectile = soldier.fire();
+    }
+
+    return { newProjectile, isMoving: moving };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private — helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Instantiate and place a Soldier at the given world position.
+   * @private
+   * @param {THREE.Vector3} pos
+   * @param {number}        rotY — initial world-space Y rotation (radians)
+   */
+  _spawnSoldierAt(pos, rotY) {
+    const y = this.terrain.getHeightAt(pos.x, pos.z);
+    this.soldier = new Soldier({ isPlayer: true, teamId: 0, name: 'Player' });
+    this.soldier.mesh.position.set(pos.x, y, pos.z);
+    this.soldier.mesh.rotation.y = rotY;
+    this.scene.add(this.soldier.mesh);
+  }
+}

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -17,6 +17,8 @@ export class InputSystem {
     this._aimTouch = { active: false, id: null, x: 0, y: 0 };
     this._fireRequested = false;
     this._turretAngle = null;
+    /** One-shot: true on the frame E is pressed (exit/enter vehicle). */
+    this._exitVehicleRequested = false;
 
     // Mouse aim
     this._mouseAim = { active: false, x: 0, y: 0 };
@@ -30,6 +32,7 @@ export class InputSystem {
     window.addEventListener('keydown', (e) => {
       this._keys[e.code] = true;
       if (e.code === 'Space') this._fireRequested = true;
+      if (e.code === 'KeyE')  this._exitVehicleRequested = true;
       // Prevent Tab from shifting browser focus while held for the scoreboard
       if (e.code === 'Tab') e.preventDefault();
     });
@@ -145,10 +148,13 @@ export class InputSystem {
       turretAngle: this._turretAngle,
       /** true while Tab is held — shows/hides the scoreboard overlay */
       tabHeld: !!this._keys['Tab'],
+      /** One-shot: true on the frame E was pressed — exit tank or re-enter tank. */
+      exitVehicle: this._exitVehicleRequested,
     };
 
     // Reset one-shot inputs
     this._fireRequested = false;
+    this._exitVehicleRequested = false;
 
     return state;
   }


### PR DESCRIPTION
## Summary

Implements the player mode-switching system (t025): the human player can now operate as either a tank operator or an on-foot soldier within a single round.

## What was done

**`src/systems/InputSystem.js`**
- Added `_exitVehicleRequested` one-shot flag, toggled by `KeyE` in `_bindKeyboard`.
- Exposed as `exitVehicle` in `getState()` (reset each frame alongside `fire`).

**`src/core/PlayerController.js`** (new file, ~230 lines)
- Manages player mode: `'tank'` (default) or `'soldier'`.
- `exitTank()` — voluntary exit via E key; spawns soldier 4 units to the right of the tank hull; tank stays idle and re-enterable.
- `bailOut(pos)` — forced bail-out when tank is destroyed; soldier spawns at the tank's last world position.
- `tryEnterTank()` — pressed E while on foot and within 6 units of the idle tank → removes soldier mesh, resumes tank control.
- `notifyTankDestroyedWhileIdle()` — called when enemies destroy the idle tank while player is already on foot; disables re-entry without killing the player.
- `mesh`, `health`, `maxHealth`, `ammo` getters — allow `CameraController` and HUD to bind to the active entity without knowing the current mode.

**`src/core/Game.js`**
- `CameraController` now follows `this.playerController` (satisfies `target.mesh` interface).
- `_updatePlayer()` slimmed to delegate to `playerController.update()`, returning `{newProjectile, isMoving}` for muzzle flash and dust.
- `_onPlayerTankDestroyed()` rewritten: removes tank mesh + adds wreck, then **bails out** instead of immediately killing the player slot. Player slot in `TeamManager` stays `alive=true` until the soldier also dies.
- `_onPlayerSoldierDestroyed()` — new method: emits explosion, removes soldier, then calls `teams.killTank(player)` to propagate the death and potentially end the round.
- `_checkSoldierHit()` — new method: checked each frame when in soldier mode; enemy projectiles within 1.2 units damage the soldier, triggering `_onPlayerSoldierDestroyed()` on kill.
- HUD reads `playerController.health`/`ammo` (tank values in tank mode, soldier values in soldier mode; `null` ammo for soldiers shows no clip limit yet).
- `playerController.reset()` added to round resets and match restart.

## Verification

- `npm run build` completes with 0 errors (37 modules, ✓ built in ~1.6 s).
- Voluntary exit: press E → soldier appears at tank side; tank sits idle; camera follows soldier.
- Re-enter: walk back to tank within 6 units, press E → soldier despawns, tank control resumes.
- Auto-bail: survive until tank HP reaches 0 → soldier spawns at wreck location; game continues.
- Soldier is vulnerable: enemy shells with `isPlayerOwned=false` register hits; on 0 HP, the player slot is finalised dead and the normal round-end flow triggers.
- Round resets (between rounds, match restart) remove any active soldier and restore tank mode.

Resolves #41