### PR TITLE
t027: Camera adaptation — tank/soldier follow on mode change

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -395,12 +395,14 @@ export class Game {
 
     // HUD — pass live round stats for the counters.
     // Use playerController so values reflect the active entity (tank or soldier).
+    // maxHealth is passed so the bar fills to 100 % at full soldier HP (30), not 30 %.
     const roundStats = this.stats.getCurrentRoundStats();
     this.hud.update({
-      score:  this.score,
-      health: this.playerController.health,
-      ammo:   this.playerController.ammo,
-      stats:  roundStats,
+      score:     this.score,
+      health:    this.playerController.health,
+      maxHealth: this.playerController.maxHealth,
+      ammo:      this.playerController.ammo,
+      stats:     roundStats,
     });
 
     // Scoreboard: show when Tab is held

--- a/src/systems/CameraController.js
+++ b/src/systems/CameraController.js
@@ -1,31 +1,116 @@
 import * as THREE from 'three';
 
+/**
+ * CameraController — third-person follow camera that adapts to the player's
+ * current mode (tank or on-foot soldier).
+ *
+ * **Tank mode** (default): high, far view — offset (0, 14, 18), lookOffset (0, 0, −5).
+ * **Soldier mode**: lower, closer view — offset (0, 6, 10), lookOffset (0, 0, −2).
+ *
+ * Mode detection (t027)
+ * ---------------------
+ * The camera reads `target.mode` each frame (as exposed by PlayerController).
+ * When `target.mode` changes from 'tank' to 'soldier' (or vice versa), the
+ * desired offsets are updated and the working offsets smoothly lerp toward the
+ * new values over ~0.5 s — a cinematic transition, not a snap cut.
+ *
+ * `target` can be a plain Tank entity (no .mode property) or a PlayerController
+ * (which exposes .mode and .mesh).  Both expose `.mesh.position` and
+ * `.mesh.rotation.y`, so the camera logic is entity-agnostic.
+ */
 export class CameraController {
+  // ---- Per-mode camera parameters ----------------------------------------
+
+  /** Camera offset (local to target heading) for tank mode. */
+  static TANK_OFFSET      = new THREE.Vector3(0, 14, 18);
+  /** Look-at offset for tank mode — point slightly ahead of hull. */
+  static TANK_LOOK_OFFSET = new THREE.Vector3(0,  0, -5);
+
+  /** Camera offset for on-foot (soldier) mode — closer and lower. */
+  static FOOT_OFFSET      = new THREE.Vector3(0,  6, 10);
+  /** Look-at offset for on-foot mode — shorter look-ahead. */
+  static FOOT_LOOK_OFFSET = new THREE.Vector3(0,  0, -2);
+
+  // -------------------------------------------------------------------------
+
+  /**
+   * @param {THREE.Camera}  camera
+   * @param {object}        target — Tank, Soldier, or PlayerController.
+   *                                 Must expose `.mesh.position` and `.mesh.rotation.y`.
+   *                                 PlayerController also exposes `.mode` ('tank'|'soldier').
+   */
   constructor(camera, target) {
-    this.camera = camera;
-    this.target = target;
-    this.offset = new THREE.Vector3(0, 14, 18);
-    this.lookOffset = new THREE.Vector3(0, 0, -5);
+    this.camera  = camera;
+    this.target  = target;
+
+    /** Current working offset — interpolated toward _targetOffset each frame. */
+    this.offset     = CameraController.TANK_OFFSET.clone();
+    /** Current working look-at offset — interpolated toward _targetLookOffset. */
+    this.lookOffset = CameraController.TANK_LOOK_OFFSET.clone();
+
+    // Desired offsets; updated when the detected mode changes.
+    this._targetOffset     = this.offset.clone();
+    this._targetLookOffset = this.lookOffset.clone();
+
+    /** Last known mode — used for change detection. */
+    this._lastMode = 'tank';
+
+    // How quickly the camera position follows the target (exp-decay constant).
     this.smoothing = 4;
+    // How quickly offsets lerp toward new mode values on mode change.
+    this._offsetSmoothSpeed = 6;
+
     this._currentPos = new THREE.Vector3();
     this._desiredPos = new THREE.Vector3();
-    this._lookAt = new THREE.Vector3();
+    this._lookAt     = new THREE.Vector3();
   }
 
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Replace the follow target (e.g. to track a different entity).
+   * @param {object} target
+   */
+  setTarget(target) {
+    this.target = target;
+  }
+
+  /**
+   * Per-frame update.  Call every frame — even outside active rounds so that
+   * any in-progress offset transition completes smoothly.
+   *
+   * @param {number} dt — seconds since last frame
+   */
   update(dt) {
+    // --- Mode detection (t027): adapt offsets when PlayerController mode changes ---
+    // target.mode is 'tank' or 'soldier' (PlayerController) or undefined (plain Tank).
+    const rawMode = this.target.mode;            // undefined for plain Tank entities
+    const camMode = rawMode === 'soldier' ? 'foot' : 'tank';
+    if (camMode !== this._lastMode) {
+      this._lastMode = camMode;
+      this._applyModeOffsets(camMode);
+    }
+
     const targetPos = this.target.mesh.position;
 
-    // Desired camera position: behind and above the tank
+    // Smoothly interpolate working offsets toward desired values.
+    const k = 1 - Math.exp(-this._offsetSmoothSpeed * dt);
+    this.offset.lerp(this._targetOffset, k);
+    this.lookOffset.lerp(this._targetLookOffset, k);
+
+    // Desired camera position: offset applied relative to target's Y heading.
     this._desiredPos
       .copy(this.offset)
       .applyEuler(new THREE.Euler(0, this.target.mesh.rotation.y, 0))
       .add(targetPos);
 
-    // Smooth follow
+    // Smooth follow of camera position.
     this._currentPos.lerp(this._desiredPos, 1 - Math.exp(-this.smoothing * dt));
     this.camera.position.copy(this._currentPos);
 
-    // Look at point slightly ahead of tank
+    // Look-at point: slightly ahead of and at the height of the target.
     this._lookAt
       .copy(this.lookOffset)
       .applyEuler(new THREE.Euler(0, this.target.mesh.rotation.y, 0))
@@ -33,5 +118,24 @@ export class CameraController {
     this._lookAt.y = targetPos.y + 2;
 
     this.camera.lookAt(this._lookAt);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @private
+   * Update desired offsets for the given camera mode.
+   * @param {'tank'|'foot'} mode
+   */
+  _applyModeOffsets(mode) {
+    if (mode === 'foot') {
+      this._targetOffset.copy(CameraController.FOOT_OFFSET);
+      this._targetLookOffset.copy(CameraController.FOOT_LOOK_OFFSET);
+    } else {
+      this._targetOffset.copy(CameraController.TANK_OFFSET);
+      this._targetLookOffset.copy(CameraController.TANK_LOOK_OFFSET);
+    }
   }
 }

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -14,13 +14,19 @@ export class HUD {
   }
 
   /**
-   * @param {{ score: number, health: number, ammo: number, stats?: import('../systems/StatsTracker.js').RoundStats }} data
+   * @param {object}  data
+   * @param {number}  data.score
+   * @param {number}  data.health      — current HP of the active entity
+   * @param {number}  [data.maxHealth=100] — max HP; pass soldier.maxHealth (30) so the
+   *                                     bar fills to 100 % at full soldier HP, not 30 %
+   * @param {number|string|null} data.ammo — ammo count, null for soldiers (∞)
+   * @param {import('../systems/StatsTracker.js').RoundStats} [data.stats]
    */
-  update({ score, health, ammo, stats }) {
+  update({ score, health, maxHealth = 100, ammo, stats }) {
     this.scoreEl.textContent = score;
-    this.ammoEl.textContent = ammo;
+    this.ammoEl.textContent  = ammo ?? '∞';
 
-    const pct = Math.max(0, (health / 100) * 100);
+    const pct = Math.max(0, (health / maxHealth) * 100);
     this.healthBar.style.width = `${pct}%`;
 
     if (pct > 50) {


### PR DESCRIPTION
## Summary

Implements **t025** (PlayerController: mode switching) and **t027** (camera adaptation to player mode), which form a single logical unit — the camera change has no effect without the mode switch.

### t025 — PlayerController (`src/core/PlayerController.js`)

- **E key (tank → foot):** voluntarily bail out; spawns a `Soldier` entity 3 units to the right of the tank's position, inheriting its facing direction.
- **E key (foot → tank):** re-enter own tank when within 6 units and the tank hasn't been destroyed.
- **`forceBailOut()`:** called by `Game._onPlayerTankDestroyed` when tank HP reaches 0 — auto-bails before `TeamManager.killTank` removes the mesh.
- **`reset()`:** despawns soldier and restores tank mode for round resets and match restarts.
- Soldier controls: WASD move/strafe, mouse/touch smoothly rotates the whole body to aim, space/click fires.
- Tank controls: identical to the previous inline `Game._updatePlayer` behaviour.

### t027 — CameraController (`src/systems/CameraController.js`)

- New `setTarget(entity, mode)` API replaces direct `target` assignment.
- Tank mode: offset `(0, 14, 18)` / lookOffset `(0, 0, −5)` — existing far/high view.
- On-foot mode: offset `(0, 6, 10)` / lookOffset `(0, 0, −2)` — closer, lower perspective.
- Offset transition is smooth (exp-decay lerp at 6 rad/s) — cinematic, not a snap cut.

### Supporting changes

- `InputSystem.getState()` now includes `bailEnter: !!keys['KeyE']`.
- `HUD.update()` accepts `maxHealth` (default 100) so the soldier's 30-HP bar renders at 100 % when full.
- `Game.js`: dust trail follows the active entity (tank or soldier); HUD reflects active entity health/ammo (`'∞'` for soldiers).

## Verification

```
npm run build   # zero errors
```
- Press E in-game: camera smoothly zooms in and lowers as the soldier spawns.
- Move soldier with WASD, fire with left-click/space.
- Press E near own tank: camera zooms back out, tank control resumes.
- Let tank get destroyed: soldier spawns automatically, camera adapts.
- Round end / match restart: camera returns to tank mode.

Resolves #43