### PR TITLE
t029: Round ends only when all tanks AND soldiers on a team dead

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -95,6 +95,18 @@ export class Game {
       scene:   this.scene,
       terrain: this.terrain,
     });
+
+    // t029 — Register / unregister the player's soldier with TeamManager so the
+    // round-end check waits for the soldier before declaring the team eliminated.
+    // onSoldierSpawned fires from _spawnSoldierAt() (both voluntary exit and bail-out).
+    // onSoldierReentered fires from tryEnterTank() before the soldier is removed.
+    this.playerController
+      .onSoldierSpawned((soldier) => {
+        this.teams.registerSoldier(soldier, 0);
+      })
+      .onSoldierReentered((soldier) => {
+        this.teams.unregisterSoldier(soldier);
+      });
   }
 
   _initSystems() {
@@ -208,7 +220,13 @@ export class Game {
       })
       .onRoundEnd((roundWinnerId) => {
         // Finalise stats while team alive-state still reflects the round outcome.
-        const playerAlive = this.teams.teams[0].slots[0].alive;
+        // The player "survived" if their tank slot is still alive OR they are
+        // actively on foot as a soldier (t029: tank slot is now properly killed
+        // on tank destruction, so a live soldier counts as survival too).
+        const playerTankAlive   = this.teams.teams[0].slots[0].alive;
+        const playerSoldierAlive = this.playerController.mode === 'soldier' &&
+                                   this.playerController.soldier !== null;
+        const playerAlive = playerTankAlive || playerSoldierAlive;
         const result = this.stats.endRound(playerAlive);
         console.info(
           `[StatsTracker] Round ${this.match.roundNumber} ended — ` +
@@ -435,7 +453,7 @@ export class Game {
     const activeSoldier = this.playerController.soldier;
     if (activeSoldier && input.melee) {
       // Build the list of valid melee targets: all living enemy tanks.
-      // Living enemy soldiers are added here when t028/t029 introduce AI soldiers.
+      // Living enemy soldiers will be added here when t028 introduces AI soldiers.
       const meleeTargets = [...this.teams.getEnemyTanks()];
       const hits = activeSoldier.melee(meleeTargets);
       for (const { target, damage } of hits) {
@@ -469,12 +487,15 @@ export class Game {
    * Called by CollisionSystem when the player's tank HP reaches 0.
    *
    * If the player is still in the tank (tank mode):
-   *   - Remove tank mesh and spawn a wreck.
-   *   - Spawn a soldier at the tank's last position (auto-bail).
-   *   - Player slot stays alive in TeamManager until the soldier also dies.
+   *   - Remove tank mesh, spawn wreck.
+   *   - bailOut() spawns a soldier and fires onSoldierSpawned → registerSoldier.
+   *   - Then killTank() marks the player slot dead; isTeamEliminated() now sees
+   *     the live soldier and will NOT fire the team-eliminated callback yet.
    *
    * If the player already exited the tank voluntarily (soldier mode):
    *   - The idle tank was destroyed by enemies — remove it and spawn a wreck.
+   *   - killTank() marks the player's tank slot dead.  The soldier is already
+   *     registered so isTeamEliminated() still returns false while it lives.
    *   - Player continues on foot; re-entry is no longer possible.
    */
   _onPlayerTankDestroyed() {
@@ -482,37 +503,49 @@ export class Game {
     const tankPos  = this.player.mesh.position.clone();
     const tankRotY = this.player.mesh.rotation.y;
 
-    // Remove the tank mesh from the scene (kills its presence without
-    // calling TeamManager.killTank() so the player slot stays alive).
+    // Remove tank mesh from the scene and leave a wreck prop in its place.
+    // killTank() would also call scene.remove(); calling it first is safe
+    // because Three.js scene.remove() is idempotent.
     this.scene.remove(this.player.mesh);
-    // Spawn a wreck prop at the tank's last position.
     this.wrecks.add(tankPos, tankRotY);
 
     if (this.playerController.mode === 'soldier') {
-      // Player was already on foot — idle tank was destroyed by enemies.
-      // Update PlayerController state so re-entry prompt is hidden.
+      // Player was already on foot — idle tank destroyed by enemies.
+      // Update PlayerController so the re-entry prompt is hidden.
       this.playerController.notifyTankDestroyedWhileIdle();
+      // Mark the tank slot dead.  The soldier is already registered with
+      // TeamManager (registered when the player first exited), so
+      // isTeamEliminated(0) will return false while the soldier is alive.
+      this.teams.killTank(this.player);
       console.info('[Game] Idle player tank destroyed; player continues on foot.');
     } else {
       // Player was in the tank — auto-bail.
       this.stats.recordPlayerDeath();
+      // bailOut() spawns a Soldier and fires onSoldierSpawned → registerSoldier().
+      // Soldier must be registered BEFORE killTank() so isTeamEliminated() sees
+      // the live soldier and does not fire team elimination prematurely.
       this.playerController.bailOut(tankPos);
+      this.teams.killTank(this.player);
       console.info('[Game] Player tank destroyed — auto-bailed as soldier.');
     }
   }
 
   /**
    * Called when the player's on-foot soldier HP reaches 0.
-   * Removes the soldier from the scene, then finalises the player's
-   * slot as dead in TeamManager (triggering round-end if the team is wiped).
+   * Captures the soldier reference, emits death particles, clears the soldier
+   * from PlayerController, then calls TeamManager.killSoldier() which handles
+   * the final elimination check (t029).
    */
   _onPlayerSoldierDestroyed() {
-    const soldierPos = this.playerController.soldier.mesh.position.clone();
+    // Capture soldier before clearSoldier() nulls the reference.
+    const soldier    = this.playerController.soldier;
+    const soldierPos = soldier.mesh.position.clone();
     this.particles.emitExplosion(soldierPos, { count: 10, speed: 5, lifetime: 0.5 });
+    // Remove the soldier mesh from the scene via PlayerController.
     this.playerController.clearSoldier();
-
-    // Now mark the player's slot dead — this may trigger team elimination.
-    this.teams.killTank(this.player);
+    // killSoldier() marks the entry dead in TeamManager and checks whether
+    // the team is now fully eliminated (all tanks + all soldiers dead).
+    this.teams.killSoldier(soldier);
     console.info('[Game] Player soldier destroyed — player is out for this round.');
   }
 

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -53,6 +53,22 @@ export class PlayerController {
      * @type {boolean}
      */
     this._tankIdle = false;
+
+    /**
+     * Fired whenever a new Soldier is spawned (voluntary exit or auto-bail).
+     * Receives the Soldier instance.  Game.js uses this to register the
+     * soldier with TeamManager so round-end checks account for it (t029).
+     * @private @type {((soldier: import('../entities/Soldier.js').Soldier) => void) | null}
+     */
+    this._onSoldierSpawnedCb = null;
+
+    /**
+     * Fired when a live Soldier re-enters the idle tank.
+     * Receives the Soldier instance before it is removed from the scene.
+     * Game.js uses this to unregister the soldier from TeamManager (t029).
+     * @private @type {((soldier: import('../entities/Soldier.js').Soldier) => void) | null}
+     */
+    this._onSoldierReenteredCb = null;
   }
 
   // ---------------------------------------------------------------------------
@@ -84,6 +100,35 @@ export class PlayerController {
    */
   get ammo() {
     return this.mode === 'tank' ? this.tank.ammo : null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Soldier lifecycle callbacks (t029)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a callback that fires whenever a new Soldier is spawned.
+   * Use this in Game.js to register the soldier with TeamManager so the
+   * round-end check waits for the soldier before declaring the team eliminated.
+   * @param {(soldier: import('../entities/Soldier.js').Soldier) => void} cb
+   * @returns {this}
+   */
+  onSoldierSpawned(cb) {
+    this._onSoldierSpawnedCb = cb;
+    return this;
+  }
+
+  /**
+   * Register a callback that fires when a live Soldier successfully re-enters
+   * the idle tank.  Receives the Soldier before its mesh is removed.
+   * Use this in Game.js to unregister the soldier from TeamManager (the
+   * soldier is alive — no elimination check should fire).
+   * @param {(soldier: import('../entities/Soldier.js').Soldier) => void} cb
+   * @returns {this}
+   */
+  onSoldierReentered(cb) {
+    this._onSoldierReenteredCb = cb;
+    return this;
   }
 
   // ---------------------------------------------------------------------------
@@ -144,6 +189,12 @@ export class PlayerController {
 
     const dist = this.soldier.mesh.position.distanceTo(this.tank.mesh.position);
     if (dist > RE_ENTER_DIST) return false;
+
+    // Notify Game.js so TeamManager can unregister the soldier (t029).
+    // Must fire before the soldier reference is cleared.
+    if (this._onSoldierReenteredCb) {
+      this._onSoldierReenteredCb(this.soldier);
+    }
 
     this.scene.remove(this.soldier.mesh);
     this.soldier = null;
@@ -299,5 +350,11 @@ export class PlayerController {
     this.soldier.mesh.position.set(pos.x, y, pos.z);
     this.soldier.mesh.rotation.y = rotY;
     this.scene.add(this.soldier.mesh);
+
+    // Notify Game.js so TeamManager can register the soldier before any
+    // subsequent killTank() call checks for team elimination (t029).
+    if (this._onSoldierSpawnedCb) {
+      this._onSoldierSpawnedCb(this.soldier);
+    }
   }
 }

--- a/src/core/TeamManager.js
+++ b/src/core/TeamManager.js
@@ -15,7 +15,17 @@ import { Tank } from '../entities/Tank.js';
  *   Each slot is an object { tank, alive }.
  *   Call killTank(tank) when a tank is destroyed; it sets alive=false and
  *   removes the mesh from the scene.
- *   isTeamEliminated(teamId) returns true when all 6 slots are dead.
+ *   isTeamEliminated(teamId) returns true when all tank slots AND all
+ *   registered soldiers on that team are dead.
+ *
+ * Soldier tracking (t029):
+ *   When a tank occupant bails out as a Soldier, register the Soldier via
+ *   registerSoldier(soldier, teamId) so the round-end check waits for the
+ *   soldier to die before declaring the team eliminated.
+ *   Call killSoldier(soldier) when a soldier's HP reaches 0.
+ *   Call unregisterSoldier(soldier) when a soldier re-enters a tank (alive
+ *   but no longer a free agent — removes from tracking without triggering
+ *   the elimination check).
  *
  * Integration with EnemySystem / CollisionSystem:
  *   Use getEnemyTanks() to get the live enemy Tank instances so existing
@@ -51,6 +61,14 @@ export class TeamManager {
     this.teams = [];
 
     this._onTeamEliminatedCb = null;
+
+    /**
+     * Soldier tracking for round-end logic (t029).
+     * Maps each active Soldier instance to its { teamId, alive } state.
+     * Populated via registerSoldier() when a combatant bails out of a tank.
+     * @type {Map<import('../entities/Soldier.js').Soldier, {teamId: number, alive: boolean}>}
+     */
+    this._soldiers = new Map();
 
     this._buildTeams();
   }
@@ -121,14 +139,75 @@ export class TeamManager {
   }
 
   /**
-   * Returns true if every tank on the given team is dead.
+   * Returns true when every tank slot AND every registered soldier on the
+   * given team is dead.  A live soldier keeps the team in the fight even
+   * after all tanks are destroyed.
    * @param {number} teamId — 0 or 1
    * @returns {boolean}
    */
   isTeamEliminated(teamId) {
     const team = this.teams[teamId];
     if (!team) return false;
-    return team.slots.every(slot => !slot.alive);
+    if (!team.slots.every(slot => !slot.alive)) return false;
+    // Check registered soldiers — any live soldier keeps the team alive.
+    for (const [, entry] of this._soldiers) {
+      if (entry.teamId === teamId && entry.alive) return false;
+    }
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Soldier tracking (t029)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a live Soldier so the round-end check waits for it to die.
+   * Call this immediately after spawning a soldier from a bailed-out tank,
+   * BEFORE calling killTank() for that tank, to prevent a false early
+   * team-elimination signal.
+   *
+   * @param {import('../entities/Soldier.js').Soldier} soldier
+   * @param {number} teamId — 0 or 1
+   */
+  registerSoldier(soldier, teamId) {
+    this._soldiers.set(soldier, { teamId, alive: true });
+  }
+
+  /**
+   * Mark a soldier as dead.  Removes their mesh from the scene if still
+   * attached, then checks whether the team is now fully eliminated.
+   *
+   * @param {import('../entities/Soldier.js').Soldier} soldier
+   * @returns {boolean} true if the soldier was found and marked dead.
+   */
+  killSoldier(soldier) {
+    const entry = this._soldiers.get(soldier);
+    if (!entry || !entry.alive) return false;
+
+    entry.alive = false;
+
+    // Remove mesh from scene if it hasn't already been removed.
+    if (soldier.mesh && soldier.mesh.parent) {
+      this.scene.remove(soldier.mesh);
+    }
+
+    if (this.isTeamEliminated(entry.teamId) && this._onTeamEliminatedCb) {
+      this._onTeamEliminatedCb(entry.teamId);
+    }
+
+    return true;
+  }
+
+  /**
+   * Remove a soldier from tracking without killing them.
+   * Use this when a soldier re-enters a tank (alive, just no longer a
+   * free combatant).  Does NOT trigger the elimination check.
+   *
+   * @param {import('../entities/Soldier.js').Soldier} soldier
+   * @returns {boolean} true if the soldier was found and removed.
+   */
+  unregisterSoldier(soldier) {
+    return this._soldiers.delete(soldier);
   }
 
   /**
@@ -153,9 +232,15 @@ export class TeamManager {
 
   /**
    * Reset both teams to full health, restore meshes to scene, reposition.
+   * Also clears all registered soldiers — PlayerController.reset() removes
+   * the soldier mesh; this ensures the tracking map starts clean.
    * Called by MatchManager/round reset (t009).
    */
   reset() {
+    // Clear soldier tracking before restoring tank slots so no stale entries
+    // prevent the first-round elimination check from working correctly.
+    this._soldiers.clear();
+
     for (const team of this.teams) {
       const isPlayerTeam = team.id === 0;
       for (let i = 0; i < team.slots.length; i++) {


### PR DESCRIPTION
## Summary

Implements t029: the round-end check now waits for every bailed-out soldier to die before declaring a team eliminated. Previously, all 6 tank slots dying immediately triggered elimination even if the player had bailed out and was still alive on foot.

## Changes

### `src/core/TeamManager.js`
- Add `_soldiers` Map tracking every active `Soldier` instance and its `{ teamId, alive }` state.
- `registerSoldier(soldier, teamId)` — called when a soldier spawns, before any `killTank()` on the same entity, so the live soldier prevents premature elimination.
- `killSoldier(soldier)` — marks dead, safely removes mesh, re-checks `isTeamEliminated()`.
- `unregisterSoldier(soldier)` — alive soldier re-enters tank; removes from tracking without triggering elimination.
- `isTeamEliminated()` — extended to check both all tank slots and all `_soldiers` entries for the team.
- `reset()` — clears `_soldiers` so each round starts clean.

### `src/core/PlayerController.js`
- `onSoldierSpawned(cb)` / `onSoldierReentered(cb)` — new lifecycle callbacks.
- `_spawnSoldierAt()` fires `onSoldierSpawned` after the Soldier is fully initialised.
- `tryEnterTank()` fires `onSoldierReentered` before the soldier is removed from the scene.

### `src/core/Game.js`
- Wires `onSoldierSpawned` → `teams.registerSoldier(soldier, 0)` and `onSoldierReentered` → `teams.unregisterSoldier(soldier)`.
- `_onPlayerTankDestroyed()`: calls `bailOut()` first (fires `onSoldierSpawned` → registers soldier), then `teams.killTank(player)` — `isTeamEliminated` sees the live soldier and does not fire prematurely. Idle-tank-destroyed path also calls `killTank`.
- `_onPlayerSoldierDestroyed()`: captures soldier ref before `clearSoldier()` nulls it, then calls `teams.killSoldier(soldier)` — this is now the authoritative final elimination-check trigger.
- `onRoundEnd`: `playerAlive` now checks `slot[0].alive || (mode==='soldier' && soldier!==null)` since the tank slot is properly killed on tank destruction.

## Verification

The round-end logic is exercised through the state machine in `MatchManager` — `_handleTeamEliminated` only fires when `isTeamEliminated()` returns true. With this change:

1. Player tank destroyed, soldier alive → `isTeamEliminated(0)` returns false → round continues ✓  
2. Player tank destroyed, soldier then dies → `killSoldier()` → `isTeamEliminated(0)` true → round ends ✓  
3. Player re-enters idle tank → `unregisterSoldier()` removes soldier, tank slot still alive → no false elimination ✓  
4. Enemy team: no soldiers registered → `isTeamEliminated(1)` behaviour unchanged ✓

Resolves #45