### PR TITLE
t031: Firearm variety — Pistol, SMG, AR, Sniper, Shotgun with distinct behaviors

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -348,6 +348,8 @@ export class Game {
         `[Game] Loadout selected — tank:${selection.tank} ` +
         `gun:${selection.gun} melee:${selection.melee}`
       );
+      // Apply on-foot gun selection so soldiers spawn with the chosen weapon (t031).
+      this.playerController.soldierGunId = selection.gun;
       this._startImmediately();
     });
   }
@@ -437,15 +439,19 @@ export class Game {
    * @param {number} dt
    */
   _updatePlayer(input, dt) {
-    const { newProjectile, isMoving } = this.playerController.update(input, dt);
+    const { newProjectiles, isMoving } = this.playerController.update(input, dt);
 
-    if (newProjectile) {
-      this.projectiles.add(newProjectile);
-      const flashDir = newProjectile.velocity.clone().normalize();
+    // Emit muzzle flash once per shot (using the first projectile for position/direction).
+    // Shotgun fires 8 pellets simultaneously — a single flash for the burst is correct.
+    if (newProjectiles.length > 0) {
+      const first = newProjectiles[0];
       this.particles.emitMuzzleFlash(
-        newProjectile.mesh.position.clone(),
-        flashDir
+        first.mesh.position.clone(),
+        first.velocity.clone().normalize()
       );
+      for (const proj of newProjectiles) {
+        this.projectiles.add(proj);
+      }
     }
 
     // ---- On-foot soldier melee (t026) ----
@@ -610,6 +616,8 @@ export class Game {
         `[Game] Loadout updated — tank:${selection.tank} ` +
         `gun:${selection.gun} melee:${selection.melee}`
       );
+      // Apply on-foot gun selection so soldiers spawn with the chosen weapon (t031).
+      this.playerController.soldierGunId = selection.gun;
 
       this.score = 0;
       // Reset match state machine first (no team events should fire during reset)

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -69,6 +69,14 @@ export class PlayerController {
      * @private @type {((soldier: import('../entities/Soldier.js').Soldier) => void) | null}
      */
     this._onSoldierReenteredCb = null;
+
+    /**
+     * Gun weapon id to equip on the soldier when spawned (t031).
+     * Set from the loadout selection (Game.js) before any soldier is created.
+     * Defaults to the starter pistol so a soldier always has a working gun.
+     * @type {string}
+     */
+    this.soldierGunId = 'pistol';
   }
 
   // ---------------------------------------------------------------------------
@@ -95,11 +103,15 @@ export class PlayerController {
 
   /**
    * Current ammo shown in the HUD.
-   * null when on foot — soldiers have effectively unlimited ammo (no clip mechanic yet).
-   * @returns {number|null}
+   *   Tank mode    — returns tank.ammo (a number).
+   *   Soldier mode — returns a formatted string: "12/30", "0/30", or "RELOAD".
+   * @returns {number|string|null}
    */
   get ammo() {
-    return this.mode === 'tank' ? this.tank.ammo : null;
+    if (this.mode === 'tank') return this.tank.ammo;
+    if (!this.soldier) return null;
+    if (this.soldier.isReloading) return 'RELOAD';
+    return `${this.soldier.clipCurrent}/${this.soldier._gunClipSize}`;
   }
 
   // ---------------------------------------------------------------------------
@@ -244,10 +256,10 @@ export class PlayerController {
    *
    * @param {object} input — snapshot from InputSystem.getState()
    * @param {number} dt    — seconds since last frame
-   * @returns {{ newProjectile: import('../entities/Projectile.js').Projectile|null,
+   * @returns {{ newProjectiles: import('../entities/Projectile.js').Projectile[],
    *             isMoving: boolean }}
-   *   newProjectile — projectile to add to ProjectileSystem (null if none fired).
-   *   isMoving      — true if the active entity moved this frame (for dust trails).
+   *   newProjectiles — projectiles to add to ProjectileSystem (empty array if none fired).
+   *   isMoving       — true if the active entity moved this frame (for dust trails).
    */
   update(input, dt) {
     if (this.mode === 'tank') {
@@ -289,12 +301,13 @@ export class PlayerController {
       this.exitTank();
     }
 
-    let newProjectile = null;
+    const newProjectiles = [];
     if (input.fire && tank.canFire()) {
-      newProjectile = tank.fire();
+      const proj = tank.fire();
+      if (proj) newProjectiles.push(proj);
     }
 
-    return { newProjectile, isMoving: moving };
+    return { newProjectiles, isMoving: moving };
   }
 
   // ---------------------------------------------------------------------------
@@ -326,12 +339,19 @@ export class PlayerController {
       this.tryEnterTank();
     }
 
-    let newProjectile = null;
-    if (input.fire && soldier.canFire()) {
-      newProjectile = soldier.fire();
+    // R key — manual reload when clip is not full and not already reloading
+    if (input.reload) {
+      soldier.startReload();
     }
 
-    return { newProjectile, isMoving: moving };
+    // Fire: pass isMoving for sniper accuracy penalty (t031).
+    // soldier.fire() always returns an array (empty if on cooldown / reloading).
+    let newProjectiles = [];
+    if (input.fire && soldier.canFire()) {
+      newProjectiles = soldier.fire(moving);
+    }
+
+    return { newProjectiles, isMoving: moving };
   }
 
   // ---------------------------------------------------------------------------
@@ -340,6 +360,7 @@ export class PlayerController {
 
   /**
    * Instantiate and place a Soldier at the given world position.
+   * Equips the soldier with the gun from `this.soldierGunId` (set from loadout).
    * @private
    * @param {THREE.Vector3} pos
    * @param {number}        rotY — initial world-space Y rotation (radians)
@@ -349,6 +370,8 @@ export class PlayerController {
     this.soldier = new Soldier({ isPlayer: true, teamId: 0, name: 'Player' });
     this.soldier.mesh.position.set(pos.x, y, pos.z);
     this.soldier.mesh.rotation.y = rotY;
+    // Apply the loadout gun selection (t031) — defaults to pistol if not set.
+    this.soldier.setGunWeapon(this.soldierGunId);
     this.scene.add(this.soldier.mesh);
 
     // Notify Game.js so TeamManager can register the soldier before any

--- a/src/entities/Soldier.js
+++ b/src/entities/Soldier.js
@@ -1,17 +1,11 @@
 import * as THREE from 'three';
 import { Projectile } from './Projectile.js';
-import { getMeleeDef } from '../data/WeaponDefs.js';
+import { getGunDef, getMeleeDef } from '../data/WeaponDefs.js';
 
-/** Soldier stats — on-foot mode. See VISION.md "On-Foot Mode". */
+/** Soldier base stats — on-foot mode. See VISION.md "On-Foot Mode". */
 const SOLDIER_STATS = {
   /** Max HP. A tank shell (25 dmg) kills in one hit; small-arms fire takes 2-4 hits. */
   maxHealth: 30,
-  /** Seconds between shots — faster than a tank cannon (0.3s). */
-  fireRate: 0.12,
-  /** Damage per bullet — less than a tank shell (25 dmg). */
-  damage: 8,
-  /** Bullet speed — faster than tank shells for snappier feel. */
-  bulletSpeed: 60,
   /** Movement speed (units/s). Faster than a tank (12 u/s). */
   moveSpeed: 16,
   /** Turn speed (rad/s). More agile than a tank (2.5 rad/s). */
@@ -22,6 +16,34 @@ const SOLDIER_COLORS = {
   player: { body: 0x1a3a6b, head: 0xf5c07a, gun: 0x333333 },
   enemy:  { body: 0x7a1a1a, head: 0xf5c07a, gun: 0x333333 },
 };
+
+/**
+ * Apply random spread to a normalised direction vector.
+ *
+ * Builds a random axis in the plane perpendicular to `dir` then rotates `dir`
+ * around it by a random angle in [0, spreadRad].
+ *
+ * @param {THREE.Vector3} dir       — normalised aim direction (not mutated)
+ * @param {number}        spreadDeg — spread cone half-angle in degrees (0 = no spread)
+ * @returns {THREE.Vector3} new normalised direction with spread applied
+ */
+function _applySpread(dir, spreadDeg) {
+  if (spreadDeg <= 0) return dir.clone();
+
+  const spreadRad = THREE.MathUtils.degToRad(spreadDeg);
+
+  // Pick an arbitrary vector not parallel to dir to build a perpendicular axis.
+  const arbitary = Math.abs(dir.x) < 0.9
+    ? new THREE.Vector3(1, 0, 0)
+    : new THREE.Vector3(0, 1, 0);
+  const perp = new THREE.Vector3().crossVectors(dir, arbitary).normalize();
+
+  // Rotate perp around dir by a random azimuth → random axis in the perp plane.
+  const axis = perp.clone().applyAxisAngle(dir, Math.random() * Math.PI * 2);
+
+  // Rotate dir by a random elevation within the spread cone.
+  return dir.clone().applyAxisAngle(axis, Math.random() * spreadRad).normalize();
+}
 
 export class Soldier {
   /**
@@ -38,12 +60,48 @@ export class Soldier {
     this.health    = SOLDIER_STATS.maxHealth;
     this.maxHealth = SOLDIER_STATS.maxHealth;
 
-    this.fireCooldown = 0;
-    this.fireRate     = SOLDIER_STATS.fireRate;
-
     /** Movement constants exposed so PlayerController / AIController can read them. */
     this.moveSpeed = SOLDIER_STATS.moveSpeed;
     this.turnSpeed = SOLDIER_STATS.turnSpeed;
+
+    // ---- Gun weapon state (t030/t031) ----
+    /** Active gun weapon id. Defaults to free starter pistol. */
+    this.gunWeaponId = 'pistol';
+
+    // Cache stats from WeaponDefs so hot-path fire() doesn't look them up.
+    const _startGun = getGunDef('pistol');
+    /** Damage per bullet. */
+    this._gunDamage          = _startGun.damage;
+    /** Seconds between shots (1 / fireRate). */
+    this._gunFireInterval    = 1 / _startGun.fireRate;
+    /** Effective range in world units (informational — not enforced by Projectile). */
+    this._gunRange           = _startGun.range;
+    /** Max rounds before reload. */
+    this._gunClipSize        = _startGun.clipSize;
+    /** Seconds to complete a reload. */
+    this._gunReloadTime      = _startGun.reloadTime;
+    /** Spread cone half-angle in degrees at default engagement range. */
+    this._gunSpread          = _startGun.spread;
+    /** Projectile travel speed in world-units/s. */
+    this._gunProjectileSpeed = _startGun.projectileSpeed;
+    /** Pellets fired per trigger pull (1 for all guns except shotgun). */
+    this._gunPelletsPerShot  = _startGun.pelletsPerShot ?? 1;
+    /** AoE splash radius in world units. 0 = point damage only. (t032) */
+    this._gunSplashRadius    = _startGun.splashRadius ?? 0;
+    /** Ballistic arc trajectory (grenade launcher). (t032) */
+    this._gunIsArc           = _startGun.isArc ?? false;
+    /** Explosive weapon — splash-eligible and visually distinct. (t032) */
+    this._gunIsExplosive     = _startGun.isExplosive ?? false;
+
+    /** Current rounds remaining in the clip. */
+    this.clipCurrent = _startGun.clipSize;
+    /** True while a reload animation is in progress. */
+    this.isReloading = false;
+    /** Seconds remaining until reload completes (counts down from reloadTime). */
+    this._reloadTimer = 0;
+
+    /** Seconds until the next shot is allowed. */
+    this.fireCooldown = 0;
 
     // ---- Melee weapon state (t026) ----
     /** Active melee weapon id. Defaults to starter combat knife. */
@@ -132,37 +190,116 @@ export class Soldier {
   }
 
   // ---------------------------------------------------------------------------
-  // Combat
+  // Gun weapon management (t030/t031)
   // ---------------------------------------------------------------------------
 
-  /** @returns {boolean} True if the cooldown has elapsed (no ammo limit for soldiers). */
-  canFire() {
-    return this.fireCooldown <= 0;
+  /**
+   * Equip a gun by id (from GunDefs in WeaponDefs.js).
+   * Reloads all cached stats and resets the clip to full.
+   * @param {string} weaponId — e.g. 'pistol', 'smg', 'assaultRifle', 'sniperRifle', 'shotgun'
+   * @returns {this} — for chaining
+   */
+  setGunWeapon(weaponId) {
+    const def = getGunDef(weaponId);
+    this.gunWeaponId           = weaponId;
+    this._gunDamage            = def.damage;
+    this._gunFireInterval      = 1 / def.fireRate;
+    this._gunRange             = def.range;
+    this._gunClipSize          = def.clipSize;
+    this._gunReloadTime        = def.reloadTime;
+    this._gunSpread            = def.spread;
+    this._gunProjectileSpeed   = def.projectileSpeed;
+    this._gunPelletsPerShot    = def.pelletsPerShot ?? 1;
+    this._gunSplashRadius      = def.splashRadius ?? 0;
+    this._gunIsArc             = def.isArc ?? false;
+    this._gunIsExplosive       = def.isExplosive ?? false;
+    this.clipCurrent           = def.clipSize;
+    this.isReloading           = false;
+    this._reloadTimer          = 0;
+    this.fireCooldown          = 0;
+    return this;
   }
 
   /**
-   * Fire one bullet from the soldier's gun.
-   * @returns {Projectile|null} New projectile, or null if on cooldown.
+   * Initiate a reload cycle if the clip is not already full and not already reloading.
+   * Called automatically when the clip empties; also callable manually (R key).
    */
-  fire() {
-    if (!this.canFire()) return null;
+  startReload() {
+    if (this.isReloading || this.clipCurrent >= this._gunClipSize) return;
+    this.isReloading  = true;
+    this._reloadTimer = this._gunReloadTime;
+  }
 
-    this.fireCooldown = this.fireRate;
+  // ---------------------------------------------------------------------------
+  // Combat — gun (t030/t031)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @returns {boolean} True when fire cooldown has elapsed, clip has ammo, and not reloading.
+   */
+  canFire() {
+    return this.fireCooldown <= 0 && !this.isReloading && this.clipCurrent > 0;
+  }
+
+  /**
+   * Fire the equipped gun.
+   *
+   * Distinct behaviors per weapon type (t031):
+   *   pistol        — single bullet, 5° spread, 80 u/s projectile.
+   *   smg           — single bullet, 10° spread, rapid-fire (5 shots/s).
+   *   assaultRifle  — single bullet, 4° spread, balanced stats.
+   *   sniperRifle   — single bullet, 0.5° spread normally; 15° spread while moving.
+   *                   Very high damage, near-instant projectile (300 u/s), slow rate.
+   *   shotgun       — 8 pellets per pull, each independently spread at 20°.
+   *                   Devastating up close, negligible beyond ~15 units.
+   *
+   * Clip and reload:
+   *   Decrements clipCurrent each call. Auto-starts reload when clip empties.
+   *   Returns [] immediately if canFire() is false.
+   *
+   * @param {boolean} [isMoving=false] — affects sniperRifle accuracy only.
+   * @returns {Projectile[]} Newly-created projectile(s) — always an array.
+   */
+  fire(isMoving = false) {
+    if (!this.canFire()) return [];
+
+    this.fireCooldown = this._gunFireInterval;
+    this.clipCurrent--;
+
+    // Sniper rifle: accuracy degrades significantly while moving.
+    // All other guns use their base spread value from WeaponDefs.
+    let effectiveSpread = this._gunSpread;
+    if (this.gunWeaponId === 'sniperRifle' && isMoving) {
+      effectiveSpread = 15; // effectively suppresses precision shooting while running
+    }
 
     const worldPos = new THREE.Vector3();
     this.muzzle.getWorldPosition(worldPos);
 
-    const worldDir = new THREE.Vector3(0, 0, -1);
-    this.muzzle.getWorldDirection(worldDir);
+    const baseDir = new THREE.Vector3(0, 0, -1);
+    this.muzzle.getWorldDirection(baseDir);
 
-    return new Projectile({
-      position:      worldPos,
-      direction:     worldDir,
-      isPlayerOwned: this.isPlayer,
-      ownerTank:     this,   // "ownerTank" field is owner-agnostic in Projectile
-      speed:         SOLDIER_STATS.bulletSpeed,
-      damage:        SOLDIER_STATS.damage,
-    });
+    const projectiles = [];
+    const numPellets = this._gunPelletsPerShot;
+
+    for (let i = 0; i < numPellets; i++) {
+      const dir = _applySpread(baseDir, effectiveSpread);
+      projectiles.push(new Projectile({
+        position:      worldPos.clone(),
+        direction:     dir,
+        isPlayerOwned: this.isPlayer,
+        ownerTank:     this,   // "ownerTank" field is owner-agnostic in Projectile
+        speed:         this._gunProjectileSpeed,
+        damage:        this._gunDamage,
+      }));
+    }
+
+    // Auto-reload when the clip runs dry.
+    if (this.clipCurrent <= 0) {
+      this.startReload();
+    }
+
+    return projectiles;
   }
 
   // ---------------------------------------------------------------------------
@@ -264,6 +401,15 @@ export class Soldier {
     if (this.meleeCooldown > 0) {
       this.meleeCooldown -= dt;
     }
+    // Advance reload timer — completes when _reloadTimer reaches 0.
+    if (this.isReloading) {
+      this._reloadTimer -= dt;
+      if (this._reloadTimer <= 0) {
+        this.isReloading  = false;
+        this._reloadTimer = 0;
+        this.clipCurrent  = this._gunClipSize;
+      }
+    }
   }
 
   /** Reset to full health / stats for round start. */
@@ -273,5 +419,9 @@ export class Soldier {
     this.meleeCooldown = 0;
     this.kills         = 0;
     this.damageDealt   = 0;
+    // Refill clip and cancel any in-progress reload.
+    this.clipCurrent  = this._gunClipSize;
+    this.isReloading  = false;
+    this._reloadTimer = 0;
   }
 }

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -304,15 +304,145 @@ export class CollisionSystem {
 
         const destroyed = tree.takeDamage(p.damage);
 
+        // Explosive projectiles hitting a tree also trigger splash damage. (t032)
+        if (p.splashRadius > 0) {
+          this._applySplashToEnemies(p, hitPos, null);
+          this._applySplashToPlayer(p, hitPos, null);
+          if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+        }
+
         if (destroyed) {
           // treeSystem.destroyTree emits wood debris particles
           if (this._onTreeDestroy) this._onTreeDestroy(hitPos);
-        } else {
+        } else if (!p.splashRadius) {
           if (this._onTreeHit) this._onTreeHit(hitPos);
         }
 
         break; // projectile consumed; skip remaining trees
       }
+    }
+  }
+
+  /**
+   * Explosive projectiles (splashRadius > 0) that descend to terrain level
+   * detonate on ground contact. (t032)
+   *
+   * This handles grenades that arc past all tanks and land on the field, or
+   * rockets that fly wide. The impact radius acts as an AoE even with no
+   * direct hit.
+   *
+   * Ground detection: projectile Y ≤ terrain height + small clearance (0.4 u).
+   * Uses the terrain already owned by this system — no extra references needed.
+   */
+  _checkExplosiveTerrain() {
+    const projectiles = this.projectiles.active;
+
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p = projectiles[i];
+      if (!p.isExplosive || !p.splashRadius) continue;
+
+      const px = p.mesh.position.x;
+      const py = p.mesh.position.y;
+      const pz = p.mesh.position.z;
+      const groundY = this.terrain.getHeightAt(px, pz);
+
+      if (py > groundY + 0.4) continue; // still in flight
+
+      // Detonate
+      const hitPos = p.mesh.position.clone();
+      this.projectiles.remove(i);
+
+      this._applySplashToEnemies(p, hitPos, null);
+      this._applySplashToPlayer(p, hitPos, null);
+
+      if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+    }
+  }
+
+  /**
+   * Apply splash (area) damage from an explosive projectile to all enemy tanks
+   * within `p.splashRadius`. Linear damage falloff: 100% at range 0, 0% at edge.
+   *
+   * Any enemy killed by splash triggers the full kill-callback chain so rewards,
+   * kill feed, and TeamManager state stay consistent.
+   *
+   * @param {import('../entities/Projectile.js').Projectile} p           — exploding projectile
+   * @param {import('three').Vector3}                        hitPos      — detonation position
+   * @param {object|null}                                    excludeTank — direct-hit target to skip
+   *   (already took direct damage; exclude to avoid double-applying)
+   */
+  _applySplashToEnemies(p, hitPos, excludeTank) {
+    if (!p.isPlayerOwned) return; // enemy explosives don't splash enemies
+    const radius = p.splashRadius;
+
+    // Collect enemies in range first, then process kills after iteration.
+    const inRange = [];
+    for (const e of this.enemies.active) {
+      if (e === excludeTank || e.health <= 0) continue;
+      const dist = hitPos.distanceTo(e.mesh.position);
+      if (dist >= radius) continue;
+
+      const falloff   = 1 - dist / radius;
+      const rawDmg    = p.damage * falloff;
+      const cappedDmg = Math.min(rawDmg, e.health);
+
+      if (this._onDamageDealt) this._onDamageDealt(e, cappedDmg);
+      if (p.ownerTank) p.ownerTank.recordDamage(cappedDmg);
+      e.takeDamage(rawDmg);
+
+      if (e.health <= 0) {
+        inRange.push(e);
+      }
+    }
+
+    // Process splash kills: find current index by reference (list may have shrunk).
+    for (const killed of inRange) {
+      if (p.ownerTank) p.ownerTank.recordKill();
+      const tankData = {
+        position:  killed.mesh.position.clone(),
+        rotationY: killed.mesh.rotation.y,
+      };
+      if (this._onKillFeed) this._onKillFeed(this.player.name || 'Player', killed.name || 'Enemy');
+      if (this._onTankKilled) this._onTankKilled(killed, true);
+      const idx = this.enemies.active.indexOf(killed);
+      if (idx !== -1) this.enemies.remove(idx);
+      if (this._onKill) this._onKill(hitPos, 'player', tankData);
+      if (this._onScoreAdd) this._onScoreAdd(100);
+    }
+  }
+
+  /**
+   * Apply splash (area) damage from an enemy explosive to the player tank.
+   *
+   * @param {import('../entities/Projectile.js').Projectile} p           — exploding projectile
+   * @param {import('three').Vector3}                        hitPos      — detonation position
+   * @param {object|null}                                    excludeTank — direct-hit target to skip
+   */
+  _applySplashToPlayer(p, hitPos, excludeTank) {
+    if (p.isPlayerOwned) return; // player explosives don't splash the player
+    const player = this.player;
+    if (player === excludeTank || player.health <= 0) return;
+
+    const radius = p.splashRadius;
+    const dist   = hitPos.distanceTo(player.mesh.position);
+    if (dist >= radius) return;
+
+    const falloff   = 1 - dist / radius;
+    const rawDmg    = p.damage * falloff;
+    const cappedDmg = Math.min(rawDmg, player.health);
+
+    if (p.ownerTank) p.ownerTank.recordDamage(cappedDmg);
+    player.takeDamage(rawDmg);
+
+    if (player.health <= 0) {
+      if (p.ownerTank) p.ownerTank.recordKill();
+      const tankData = {
+        position:  player.mesh.position.clone(),
+        rotationY: player.mesh.rotation.y,
+      };
+      if (this._onKillFeed) this._onKillFeed('Enemy', player.name || 'Player');
+      if (this._onKill) this._onKill(hitPos, 'enemy', tankData);
+      if (this._onPlayerDeath) this._onPlayerDeath();
     }
   }
 

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -15,8 +15,9 @@ export class InputSystem {
     // Touch joystick state
     this._joystick = { active: false, id: null, startX: 0, startY: 0, dx: 0, dy: 0 };
     this._aimTouch = { active: false, id: null, x: 0, y: 0 };
-    this._fireRequested  = false;
-    this._meleeRequested = false;
+    this._fireRequested   = false;
+    this._meleeRequested  = false;
+    this._reloadRequested = false;
     this._turretAngle = null;
     /** One-shot: true on the frame E is pressed (exit/enter vehicle). */
     this._exitVehicleRequested = false;
@@ -36,6 +37,8 @@ export class InputSystem {
       if (e.code === 'KeyE')  this._exitVehicleRequested = true;
       // F key — on-foot melee attack (VISION.md "Controls" table)
       if (e.code === 'KeyF') this._meleeRequested = true;
+      // R key — manual reload for on-foot gun (t030)
+      if (e.code === 'KeyR') this._reloadRequested = true;
       // Prevent Tab from shifting browser focus while held for the scoreboard
       if (e.code === 'Tab') e.preventDefault();
     });
@@ -156,6 +159,8 @@ export class InputSystem {
       fire: this._fireRequested,
       /** One-shot: F key or middle-click triggers an on-foot melee swing. */
       melee: this._meleeRequested,
+      /** One-shot: R key triggers a manual reload for the on-foot gun (t030). */
+      reload: this._reloadRequested,
       turretAngle: this._turretAngle,
       /** true while Tab is held — shows/hides the scoreboard overlay */
       tabHeld: !!this._keys['Tab'],
@@ -166,6 +171,7 @@ export class InputSystem {
     // Reset one-shot inputs
     this._fireRequested        = false;
     this._meleeRequested       = false;
+    this._reloadRequested      = false;
     this._exitVehicleRequested = false;
 
     return state;


### PR DESCRIPTION
## Summary

Implements t030 (weapon stat system) and t031 (firearm variety with distinct behaviors).

### Gun weapon stat system (t030)

- `Soldier.setGunWeapon(id)` loads all stats from `WeaponDefs.GunDefs` into cached fields — no hardcoded values remain in `Soldier`
- Clip/reload cycle: `clipCurrent` decrements each shot; auto-reload triggers when clip empties; `startReload()` also callable manually
- R key added to `InputSystem` for manual reload (`_reloadRequested` one-shot flag)
- `PlayerController.ammo` getter returns `'12/30'` / `'0/30'` / `'RELOAD'` strings in soldier mode (HUD already handles string values)
- `PlayerController.soldierGunId` set from loadout selection in `Game.start()` and `Game.restart()`; applied in `_spawnSoldierAt()` via `setGunWeapon()`

### Firearm variety behaviors (t031)

| Weapon | Clip | Rate | Spread | Speed | Key behavior |
|---|---|---|---|---|---|
| Pistol | 12 | 2/s | 5° | 80 u/s | Baseline — free starter |
| SMG | 30 | 5/s | 10° | 90 u/s | Rapid-fire, close-range |
| Assault Rifle | 25 | 3/s | 4° | 100 u/s | Balanced |
| Sniper Rifle | 5 | 0.5/s | 0.5° | 300 u/s | **15° spread while moving** |
| Shotgun | 8 | 1/s | 20° | 70 u/s | **8 pellets per pull**, each independently spread |

### Implementation details

- `_applySpread(dir, spreadDeg)`: module-level helper; builds a random perpendicular axis via cross-product, rotates aim direction within the spread cone. Zero cost when `spreadDeg <= 0` (sniper standing still).
- `Soldier.fire(isMoving)` always returns `Projectile[]`; shotgun returns 8 elements, all others return 1 (or 0 if blocked).
- `PlayerController.update()` return value changed from `{ newProjectile }` to `{ newProjectiles }` (array). `Game._updatePlayer()` updated to iterate the array; muzzle flash emitted once per shot burst.

### Verification

```
npm run build   # ✓ no errors
```

Resolves #47