### PR TITLE
t032: Grenade Launcher (arc, splash) + Rocket Launcher (fast, splash)

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -183,6 +183,12 @@ export class Game {
       })
       .onKillFeed((killer, victim) => {
         this.killFeed.addMessage(killer, victim);
+      })
+      .onExplosion((pos, splashRadius) => {
+        // Explosive weapons produce a larger, multi-burst particle effect. (t032)
+        // Particle count scales with splash radius so bigger weapons feel bigger.
+        const count = Math.round(25 + splashRadius * 3);
+        this.particles.emitExplosion(pos, { count, speed: 10, lifetime: 1.0 });
       });
 
     // SaveSystem: load persisted player profile from localStorage (t015).

--- a/src/entities/Projectile.js
+++ b/src/entities/Projectile.js
@@ -1,5 +1,10 @@
 import * as THREE from 'three';
 
+// ---------------------------------------------------------------------------
+// Shared geometries and materials — allocated once, reused across instances.
+// ---------------------------------------------------------------------------
+
+// Standard bullet — small sphere
 const PROJECTILE_GEO = new THREE.SphereGeometry(0.2, 6, 6);
 const PLAYER_MAT = new THREE.MeshStandardMaterial({
   color: 0xffdd44,
@@ -12,26 +17,114 @@ const ENEMY_MAT = new THREE.MeshStandardMaterial({
   emissiveIntensity: 0.8,
 });
 
+// Grenade — larger olive-green sphere (arc trajectory, t032)
+const GRENADE_GEO = new THREE.SphereGeometry(0.35, 6, 6);
+const GRENADE_PLAYER_MAT = new THREE.MeshStandardMaterial({
+  color: 0x5a7a2a,
+  emissive: 0x2a4a0a,
+  emissiveIntensity: 0.3,
+  roughness: 0.8,
+  metalness: 0.1,
+});
+const GRENADE_ENEMY_MAT = new THREE.MeshStandardMaterial({
+  color: 0x7a3a2a,
+  emissive: 0x4a1a0a,
+  emissiveIntensity: 0.3,
+  roughness: 0.8,
+  metalness: 0.1,
+});
+
+// Rocket — slightly larger glowing sphere (direct trajectory, t032)
+const ROCKET_GEO = new THREE.SphereGeometry(0.28, 6, 6);
+const ROCKET_PLAYER_MAT = new THREE.MeshStandardMaterial({
+  color: 0xcccccc,
+  emissive: 0xff4400,
+  emissiveIntensity: 1.2,
+  metalness: 0.6,
+  roughness: 0.3,
+});
+const ROCKET_ENEMY_MAT = new THREE.MeshStandardMaterial({
+  color: 0x999999,
+  emissive: 0xff2200,
+  emissiveIntensity: 1.2,
+  metalness: 0.6,
+  roughness: 0.3,
+});
+
+// ---------------------------------------------------------------------------
+// Gravity multipliers per projectile type
+// ---------------------------------------------------------------------------
+
+/** Full ballistic arc: grenade launcher (isArc = true). */
+const GRAVITY_ARC      = 1.0;
+/** Rocket: flies nearly straight (isExplosive = true, isArc = false). */
+const GRAVITY_ROCKET   = 0.05;
+/** Standard bullet: mild drop over long range. */
+const GRAVITY_STANDARD = 0.3;
+
+// ---------------------------------------------------------------------------
+// Projectile
+// ---------------------------------------------------------------------------
+
 export class Projectile {
   /**
    * @param {object} opts
-   * @param {import('three').Vector3} opts.position
-   * @param {import('three').Vector3} opts.direction
-   * @param {boolean} opts.isPlayerOwned
-   * @param {number} [opts.speed=50]
-   * @param {number} [opts.damage=25]
-   * @param {import('./Tank.js').Tank|null} [opts.ownerTank=null] — tank that fired this shell (for kill/damage attribution)
+   * @param {import('three').Vector3} opts.position        World-space spawn position.
+   * @param {import('three').Vector3} opts.direction       Normalised fire direction.
+   * @param {boolean} opts.isPlayerOwned                   Owner team flag.
+   * @param {number}  [opts.speed=50]                      Initial speed (units/s).
+   * @param {number}  [opts.damage=25]                     Base damage per hit.
+   * @param {object|null} [opts.ownerTank=null]            Firing entity (for attribution).
+   * @param {number}  [opts.splashRadius=0]                AoE radius (0 = point damage only). (t032)
+   * @param {boolean} [opts.isArc=false]                   If true: strong gravity, ballistic arc. (t032)
+   * @param {boolean} [opts.isExplosive=false]             If true: splash-eligible, explosive visual. (t032)
    */
-  constructor({ position, direction, isPlayerOwned, speed = 50, damage = 25, ownerTank = null }) {
+  constructor({
+    position,
+    direction,
+    isPlayerOwned,
+    speed = 50,
+    damage = 25,
+    ownerTank = null,
+    splashRadius = 0,
+    isArc = false,
+    isExplosive = false,
+  }) {
     this.isPlayerOwned = isPlayerOwned;
-    this.ownerTank = ownerTank;
-    this.speed = speed;
-    this.damage = damage;
-    this.lifetime = 3; // seconds
-    this.age = 0;
+    this.ownerTank     = ownerTank;
+    this.speed         = speed;
+    this.damage        = damage;
+    this.splashRadius  = splashRadius;
+    this.isArc         = isArc;
+    this.isExplosive   = isExplosive;
 
-    const mat = isPlayerOwned ? PLAYER_MAT : ENEMY_MAT;
-    this.mesh = new THREE.Mesh(PROJECTILE_GEO, mat);
+    // Longer lifetime for slow arc projectiles that need travel time.
+    this.lifetime = isArc ? 6 : 3;
+    this.age      = 0;
+
+    // Gravity multiplier determines trajectory shape.
+    if (isArc) {
+      this._gravityMult = GRAVITY_ARC;
+    } else if (isExplosive) {
+      this._gravityMult = GRAVITY_ROCKET;
+    } else {
+      this._gravityMult = GRAVITY_STANDARD;
+    }
+
+    // Select geometry and material based on weapon type.
+    let geo, mat;
+    if (isArc) {
+      geo = GRENADE_GEO;
+      mat = isPlayerOwned ? GRENADE_PLAYER_MAT : GRENADE_ENEMY_MAT;
+    } else if (isExplosive) {
+      geo = ROCKET_GEO;
+      mat = isPlayerOwned ? ROCKET_PLAYER_MAT : ROCKET_ENEMY_MAT;
+    } else {
+      geo = PROJECTILE_GEO;
+      mat = isPlayerOwned ? PLAYER_MAT : ENEMY_MAT;
+    }
+
+    this.mesh = new THREE.Mesh(geo, mat);
     this.mesh.position.copy(position);
 
     this.velocity = direction.clone().normalize().multiplyScalar(speed);
@@ -40,8 +133,10 @@ export class Projectile {
   update(dt) {
     this.mesh.position.addScaledVector(this.velocity, dt);
     this.age += dt;
-    // Gravity
-    this.velocity.y -= 9.8 * dt * 0.3;
+
+    // Apply gravity based on weapon type.
+    this.velocity.y -= 9.8 * this._gravityMult * dt;
+
     return this.age < this.lifetime && this.mesh.position.y > -1;
   }
 }

--- a/src/entities/Soldier.js
+++ b/src/entities/Soldier.js
@@ -291,6 +291,9 @@ export class Soldier {
         ownerTank:     this,   // "ownerTank" field is owner-agnostic in Projectile
         speed:         this._gunProjectileSpeed,
         damage:        this._gunDamage,
+        splashRadius:  this._gunSplashRadius,
+        isArc:         this._gunIsArc,
+        isExplosive:   this._gunIsExplosive,
       }));
     }
 

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -186,9 +186,13 @@ export class CollisionSystem {
           if (this._onDamageDealt) this._onDamageDealt(e, actualDamage);
           e.takeDamage(p.damage);
           this.projectiles.remove(i);
+
           if (e.health <= 0) {
+            // Process direct-hit kill BEFORE splash (t032):
+            // Ensures enemies.remove(j) uses the correct index before any
+            // splash removal could shift the active list.
             if (p.ownerTank) p.ownerTank.recordKill();
-            // Snapshot position+rotation before remove() clears the mesh from scene
+            // Snapshot position+rotation before remove() clears the mesh from scene.
             const tankData = {
               position: e.mesh.position.clone(),
               rotationY: e.mesh.rotation.y,
@@ -198,8 +202,19 @@ export class CollisionSystem {
             this.enemies.remove(j);
             if (this._onKill) this._onKill(hitPos, 'player', tankData);
             if (this._onScoreAdd) this._onScoreAdd(100);
+            // Splash AFTER direct-hit kill: e is already removed → pass null exclude. (t032)
+            if (p.splashRadius > 0) {
+              this._applySplashToEnemies(p, hitPos, null);
+              if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+            }
           } else {
-            if (this._onHit) this._onHit(hitPos, 'player');
+            // Non-lethal hit: apply splash to nearby enemies then pick particle. (t032)
+            if (p.splashRadius > 0) {
+              this._applySplashToEnemies(p, hitPos, e); // exclude e (already hit)
+              if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+            } else {
+              if (this._onHit) this._onHit(hitPos, 'player');
+            }
           }
           break; // projectile consumed
         }
@@ -223,6 +238,12 @@ export class CollisionSystem {
         if (p.ownerTank) p.ownerTank.recordDamage(actualDamage);
         player.takeDamage(p.damage);
         this.projectiles.remove(i);
+
+        // Fire onExplosion for visual effect regardless of kill. (t032)
+        if (p.splashRadius > 0) {
+          if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+        }
+
         if (player.health <= 0) {
           if (p.ownerTank) p.ownerTank.recordKill();
           const tankData = {
@@ -233,7 +254,8 @@ export class CollisionSystem {
           if (this._onKill) this._onKill(hitPos, 'enemy', tankData);
           if (this._onPlayerDeath) this._onPlayerDeath();
         } else {
-          if (this._onHit) this._onHit(hitPos, 'enemy');
+          // Only emit regular hit effect if NOT explosive. (t032)
+          if (!p.isExplosive && this._onHit) this._onHit(hitPos, 'enemy');
         }
       }
     }
@@ -251,7 +273,14 @@ export class CollisionSystem {
           if (distSq < hitRadius * hitRadius) {
             const hitPos = p.mesh.position.clone();
             this.projectiles.remove(i);
-            if (this._onHit) this._onHit(hitPos, 'wreck');
+            // Explosives detonating on wrecks still trigger splash. (t032)
+            if (p.splashRadius > 0) {
+              this._applySplashToEnemies(p, hitPos, null);
+              this._applySplashToPlayer(p, hitPos, null);
+              if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+            } else {
+              if (this._onHit) this._onHit(hitPos, 'wreck');
+            }
             break; // projectile consumed
           }
         }
@@ -262,6 +291,9 @@ export class CollisionSystem {
     if (this.treeSystem) {
       this._checkProjectileTreeCollisions();
     }
+
+    // Explosive projectiles that reach terrain level explode on impact. (t032)
+    this._checkExplosiveTerrain();
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements the two explosive on-foot weapons for M6 — Weapon Arsenal.

- **Grenade Launcher**: ballistic arc trajectory (full gravity), 55 damage, 6-unit splash radius, olive-green sphere visual
- **Rocket Launcher**: near-straight flight (5% gravity), 90 damage, 8-unit splash radius, glowing orange sphere visual

## Changes

**`src/entities/Projectile.js`**
- Added `splashRadius`, `isArc`, `isExplosive` constructor params
- Distinct shared geometries/materials per type (grenade, rocket, standard)
- Gravity multipliers: arc=1.0 (grenade), 0.05 (rocket), 0.3 (standard bullet)
- Lifetime extended to 6s for arc projectiles

**`src/entities/Soldier.js`**
- `fire()` now passes `splashRadius`, `isArc`, `isExplosive` from weapon stats to Projectile

**`src/systems/CollisionSystem.js`**
- `_applySplashToEnemies()`: linear-falloff AoE on all enemies within radius
- `_applySplashToPlayer()`: same for enemy explosives
- `_checkExplosiveTerrain()`: explosives detonate on ground contact (terrain height check)
- `onExplosion(cb)` callback for larger particle bursts
- Splash on wreck and tree impacts too
- Direct-hit kill processed before splash to prevent index drift

**`src/core/Game.js`**
- Registers `onExplosion` callback with scaled particle count

## Verification

Build: `npm run build` — passes (no errors). Gameplay: equip grenadeLauncher or rocketLauncher in LoadoutScreen (Gold+ league required), bail out from tank, fire — grenades arc ballistically, rockets fly straight, both explode with AoE on impact.

Resolves #48