### PR TITLE
t034: weapon equip/switch system — gun slot (1) + melee slot (2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1420,6 +1420,44 @@
       .shop-upgrade-row { grid-template-columns: 1fr auto; }
       .shop-upgrade-tiers { display: none; }
     }
+
+    /* === Weapon slot indicator (t034: on-foot weapon equip/switch) === */
+    #weapon-slots {
+      position: fixed;
+      bottom: 200px; /* above the touch controls area on mobile */
+      left: 16px;
+      display: none; /* hidden; shown via JS when in soldier mode */
+      gap: 8px;
+      pointer-events: none;
+      z-index: 10;
+    }
+
+    /* On desktop (pointer: fine) the touch controls are hidden; move slot bar lower */
+    @media (pointer: fine) {
+      #weapon-slots {
+        bottom: 44px;
+      }
+    }
+
+    .weapon-slot {
+      padding: 5px 10px;
+      background: rgba(0, 0, 0, 0.55);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 5px;
+      color: rgba(255, 255, 255, 0.55);
+      font-size: 12px;
+      font-weight: 700;
+      text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+      letter-spacing: 0.5px;
+      transition: background 0.12s, color 0.12s, border-color 0.12s;
+    }
+
+    /* Highlight the currently active slot */
+    .weapon-slot.weapon-slot-active {
+      background: rgba(255, 255, 255, 0.18);
+      border-color: rgba(255, 255, 255, 0.6);
+      color: #fff;
+    }
   </style>
 </head>
 <body>
@@ -1438,6 +1476,12 @@
       <span class="hud-label">Score</span>
       <span class="hud-value" id="score">0</span>
     </div>
+  </div>
+
+  <!-- Weapon slot indicator (t034: shown in soldier/on-foot mode) -->
+  <div id="weapon-slots">
+    <div class="weapon-slot weapon-slot-active" id="weapon-slot-gun">[1] Pistol</div>
+    <div class="weapon-slot" id="weapon-slot-melee">[2] Combat Knife</div>
   </div>
 
   <!-- Mobile touch controls indicator -->
@@ -1474,7 +1518,7 @@
   <div id="kill-feed"></div>
 
   <!-- Desktop hint -->
-  <div id="desktop-hint">WASD to move &middot; Mouse to aim &middot; Click to fire &middot; Tab = Scoreboard</div>
+  <div id="desktop-hint">WASD to move &middot; Mouse to aim &middot; Click to fire &middot; F = Melee &middot; 1/2 = Weapon slot &middot; Tab = Scoreboard</div>
 
   <!-- PRE_ROUND: countdown before each round -->
   <div id="pre-round-overlay" class="match-overlay">

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -363,8 +363,9 @@ export class Game {
         `[Game] Loadout selected — tank:${selection.tank} ` +
         `gun:${selection.gun} melee:${selection.melee}`
       );
-      // Apply on-foot gun selection so soldiers spawn with the chosen weapon (t031).
-      this.playerController.soldierGunId = selection.gun;
+      // Apply on-foot gun and melee selections so soldiers spawn with chosen weapons (t031/t034).
+      this.playerController.soldierGunId   = selection.gun;
+      this.playerController.soldierMeleeId = selection.melee;
       this._startImmediately();
     });
   }
@@ -445,11 +446,16 @@ export class Game {
     // maxHealth is passed so the bar fills to 100 % at full soldier HP (30), not 30 %.
     const roundStats = this.stats.getCurrentRoundStats();
     this.hud.update({
-      score:     this.score,
-      health:    this.playerController.health,
-      maxHealth: this.playerController.maxHealth,
-      ammo:      this.playerController.ammo,
-      stats:     roundStats,
+      score:             this.score,
+      health:            this.playerController.health,
+      maxHealth:         this.playerController.maxHealth,
+      ammo:              this.playerController.ammo,
+      stats:             roundStats,
+      // Weapon slot display (t034): only relevant in soldier mode.
+      soldierMode:       this.playerController.mode === 'soldier',
+      activeWeaponSlot:  this.playerController.activeWeaponSlot,
+      soldierGunId:      this.playerController.soldierGunId,
+      soldierMeleeId:    this.playerController.soldierMeleeId,
     });
 
     // Scoreboard: show when Tab is held
@@ -481,10 +487,17 @@ export class Game {
       }
     }
 
-    // ---- On-foot soldier melee (t026) ----
-    // playerController.soldier is set by PlayerController (t025) when on foot.
+    // ---- On-foot soldier melee (t026/t034) ----
+    // Melee swings are triggered by:
+    //   a) F key / middle-click (input.melee) — always swings regardless of active slot.
+    //   b) Fire button (input.fire) when the melee slot is active (activeWeaponSlot === 'melee').
+    // Case (b): PlayerController._updateSoldierMode suppresses gun fire in melee slot,
+    // but hit detection needs the full target list so it is resolved here in Game.js.
     const activeSoldier = this.playerController.soldier;
-    if (activeSoldier && input.melee) {
+    const meleeSlotFire = this.playerController.mode === 'soldier' &&
+      this.playerController.activeWeaponSlot === 'melee' &&
+      input.fire;
+    if (activeSoldier && (input.melee || meleeSlotFire)) {
       // Melee targets: living enemy tanks + living AI enemy soldiers (t028)
       const aiSoldiers = this.aiController.getActiveSoldiers()
         .filter(s => s.teamId === 1 && s.health > 0);
@@ -770,8 +783,9 @@ export class Game {
         `[Game] Loadout updated — tank:${selection.tank} ` +
         `gun:${selection.gun} melee:${selection.melee}`
       );
-      // Apply on-foot gun selection so soldiers spawn with the chosen weapon (t031).
-      this.playerController.soldierGunId = selection.gun;
+      // Apply on-foot gun and melee selections so soldiers spawn with chosen weapons (t031/t034).
+      this.playerController.soldierGunId   = selection.gun;
+      this.playerController.soldierMeleeId = selection.melee;
 
       this.score = 0;
       // Reset match state machine first (no team events should fire during reset)

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -77,6 +77,23 @@ export class PlayerController {
      * @type {string}
      */
     this.soldierGunId = 'pistol';
+
+    /**
+     * Melee weapon id to equip on the soldier when spawned (t034).
+     * Set from the loadout selection (Game.js) before any soldier is created.
+     * Defaults to the starter combat knife.
+     * @type {string}
+     */
+    this.soldierMeleeId = 'combatKnife';
+
+    /**
+     * Active weapon slot in soldier mode (t034).
+     * 'gun'   — fire button fires the equipped gun.
+     * 'melee' — fire button triggers a melee swing (targets resolved in Game.js).
+     * Resets to 'gun' on mode reset so each new life starts with gun selected.
+     * @type {'gun' | 'melee'}
+     */
+    this.activeWeaponSlot = 'gun';
   }
 
   // ---------------------------------------------------------------------------
@@ -240,11 +257,13 @@ export class PlayerController {
 
   /**
    * Reset to tank mode for a new round: remove any active soldier.
+   * Also resets weapon slot so the next bail-out starts with the gun selected.
    */
   reset() {
     this.clearSoldier();
     this._tankIdle = false;
     this.mode = 'tank';
+    this.activeWeaponSlot = 'gun';
   }
 
   // ---------------------------------------------------------------------------
@@ -344,10 +363,17 @@ export class PlayerController {
       soldier.startReload();
     }
 
-    // Fire: pass isMoving for sniper accuracy penalty (t031).
-    // soldier.fire() always returns an array (empty if on cooldown / reloading).
+    // Weapon slot switching (t034): 1 = gun, 2 = melee.
+    if (input.switchToGun)   this.activeWeaponSlot = 'gun';
+    if (input.switchToMelee) this.activeWeaponSlot = 'melee';
+
+    // Fire: only fire the gun when the gun slot is active.
+    // When the melee slot is active the fire button is handled by Game.js as a
+    // melee swing (hit detection needs the full target list, not available here).
+    // F key / input.melee always swings melee regardless of the active slot —
+    // that path is handled entirely in Game.js and is not repeated here.
     let newProjectiles = [];
-    if (input.fire && soldier.canFire()) {
+    if (input.fire && this.activeWeaponSlot === 'gun' && soldier.canFire()) {
       newProjectiles = soldier.fire(moving);
     }
 
@@ -372,6 +398,8 @@ export class PlayerController {
     this.soldier.mesh.rotation.y = rotY;
     // Apply the loadout gun selection (t031) — defaults to pistol if not set.
     this.soldier.setGunWeapon(this.soldierGunId);
+    // Apply the loadout melee selection (t034) — defaults to combat knife if not set.
+    this.soldier.setMeleeWeapon(this.soldierMeleeId);
     this.scene.add(this.soldier.mesh);
 
     // Notify Game.js so TeamManager can register the soldier before any

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -21,6 +21,10 @@ export class InputSystem {
     this._turretAngle = null;
     /** One-shot: true on the frame E is pressed (exit/enter vehicle). */
     this._exitVehicleRequested = false;
+    /** One-shot: true on the frame 1 is pressed — switch to gun slot (t034). */
+    this._switchToGunRequested   = false;
+    /** One-shot: true on the frame 2 is pressed — switch to melee slot (t034). */
+    this._switchToMeleeRequested = false;
 
     // Mouse aim
     this._mouseAim = { active: false, x: 0, y: 0 };
@@ -39,6 +43,9 @@ export class InputSystem {
       if (e.code === 'KeyF') this._meleeRequested = true;
       // R key — manual reload for on-foot gun (t030)
       if (e.code === 'KeyR') this._reloadRequested = true;
+      // 1/2 — weapon slot switching: 1 = gun, 2 = melee (t034)
+      if (e.code === 'Digit1') this._switchToGunRequested   = true;
+      if (e.code === 'Digit2') this._switchToMeleeRequested = true;
       // Prevent Tab from shifting browser focus while held for the scoreboard
       if (e.code === 'Tab') e.preventDefault();
     });
@@ -166,13 +173,19 @@ export class InputSystem {
       tabHeld: !!this._keys['Tab'],
       /** One-shot: true on the frame E was pressed — exit tank or re-enter tank. */
       exitVehicle: this._exitVehicleRequested,
+      /** One-shot: true on the frame 1 was pressed — switch to gun slot (t034). */
+      switchToGun:   this._switchToGunRequested,
+      /** One-shot: true on the frame 2 was pressed — switch to melee slot (t034). */
+      switchToMelee: this._switchToMeleeRequested,
     };
 
     // Reset one-shot inputs
-    this._fireRequested        = false;
-    this._meleeRequested       = false;
-    this._reloadRequested      = false;
-    this._exitVehicleRequested = false;
+    this._fireRequested          = false;
+    this._meleeRequested         = false;
+    this._reloadRequested        = false;
+    this._exitVehicleRequested   = false;
+    this._switchToGunRequested   = false;
+    this._switchToMeleeRequested = false;
 
     return state;
   }

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -1,3 +1,5 @@
+import { GunDefs, MeleeDefs } from '../data/WeaponDefs.js';
+
 export class HUD {
   constructor() {
     this.el = document.getElementById('hud');
@@ -11,6 +13,11 @@ export class HUD {
     this.statsDmgEl = document.getElementById('stat-damage');
     this.statsKillsEl = document.getElementById('stat-kills');
     this.statsAssistsEl = document.getElementById('stat-assists');
+
+    // Weapon slot indicator (t034) — shown only in soldier mode
+    this.weaponSlotsEl  = document.getElementById('weapon-slots');
+    this.slotGunEl      = document.getElementById('weapon-slot-gun');
+    this.slotMeleeEl    = document.getElementById('weapon-slot-melee');
   }
 
   /**
@@ -21,8 +28,22 @@ export class HUD {
    *                                     bar fills to 100 % at full soldier HP, not 30 %
    * @param {number|string|null} data.ammo — ammo count, null for soldiers (∞)
    * @param {import('../systems/StatsTracker.js').RoundStats} [data.stats]
+   * @param {boolean} [data.soldierMode=false]    — true when player is on foot (t034)
+   * @param {'gun'|'melee'} [data.activeWeaponSlot='gun'] — currently selected slot (t034)
+   * @param {string}  [data.soldierGunId]   — equipped gun id, used to look up name (t034)
+   * @param {string}  [data.soldierMeleeId] — equipped melee id, used to look up name (t034)
    */
-  update({ score, health, maxHealth = 100, ammo, stats }) {
+  update({
+    score,
+    health,
+    maxHealth = 100,
+    ammo,
+    stats,
+    soldierMode = false,
+    activeWeaponSlot = 'gun',
+    soldierGunId,
+    soldierMeleeId,
+  }) {
     this.scoreEl.textContent = score;
     this.ammoEl.textContent  = ammo ?? '∞';
 
@@ -42,6 +63,41 @@ export class HUD {
       if (this.statsDmgEl) this.statsDmgEl.textContent = stats.damageDealt;
       if (this.statsKillsEl) this.statsKillsEl.textContent = stats.kills;
       if (this.statsAssistsEl) this.statsAssistsEl.textContent = stats.assists;
+    }
+
+    // Weapon slot indicator (t034): visible only in soldier mode.
+    this._updateWeaponSlots(soldierMode, activeWeaponSlot, soldierGunId, soldierMeleeId);
+  }
+
+  /**
+   * Update the weapon slot indicator shown in soldier mode.
+   * Highlights the active slot and shows weapon names from WeaponDefs.
+   * @private
+   * @param {boolean}          soldierMode
+   * @param {'gun'|'melee'}    activeWeaponSlot
+   * @param {string|undefined} gunId
+   * @param {string|undefined} meleeId
+   */
+  _updateWeaponSlots(soldierMode, activeWeaponSlot, gunId, meleeId) {
+    if (!this.weaponSlotsEl) return;
+
+    if (!soldierMode) {
+      this.weaponSlotsEl.style.display = 'none';
+      return;
+    }
+
+    this.weaponSlotsEl.style.display = 'flex';
+
+    const gunName   = (gunId   && GunDefs[gunId])     ? GunDefs[gunId].name     : 'Gun';
+    const meleeName = (meleeId && MeleeDefs[meleeId])  ? MeleeDefs[meleeId].name : 'Melee';
+
+    if (this.slotGunEl) {
+      this.slotGunEl.textContent = `[1] ${gunName}`;
+      this.slotGunEl.classList.toggle('weapon-slot-active', activeWeaponSlot === 'gun');
+    }
+    if (this.slotMeleeEl) {
+      this.slotMeleeEl.textContent = `[2] ${meleeName}`;
+      this.slotMeleeEl.classList.toggle('weapon-slot-active', activeWeaponSlot === 'melee');
     }
   }
 


### PR DESCRIPTION
## Summary

Implements the on-foot weapon equip/switch system (t034): players can switch between their primary gun and melee weapon using number keys 1 and 2, with the fire button always using whichever slot is active.

## Changes

- **InputSystem**: Digit1 → `switchToGun` (one-shot), Digit2 → `switchToMelee` (one-shot)
- **PlayerController**:
  - `activeWeaponSlot` ('gun'|'melee') tracks selected slot; resets to 'gun' on round reset
  - `soldierMeleeId` propagated from loadout selection (was missing — only gun was applied)
  - `_spawnSoldierAt`: equips both gun and melee weapons from loadout
  - `_updateSoldierMode`: handles slot switching; suppresses gun fire when melee slot active
- **Game.js**:
  - Both `soldierGunId` and `soldierMeleeId` set from loadout in `start()` and `restart()`
  - `_updatePlayer`: fire button + active melee slot triggers melee swing (hit detection is here since it needs the full target list)
  - HUD.update: passes `soldierMode`, `activeWeaponSlot`, `soldierGunId`, `soldierMeleeId`
- **HUD.js**: `_updateWeaponSlots()` renders `[1] GunName` / `[2] MeleeName` indicator; active slot highlighted via `weapon-slot-active` class
- **index.html**: `#weapon-slots` element + CSS; desktop-hint updated with 1/2 key hint

## Controls (soldier/on-foot mode)

| Key | Action |
|-----|--------|
| `1` | Equip gun slot — fire button fires the gun |
| `2` | Equip melee slot — fire button swings melee |
| `F` / middle-click | Always swings melee (shortcut, ignores active slot) |

## Verification

1. Start game, exit tank (E), verify weapon slot indicator appears bottom-left
2. Press `1` → slot 1 highlighted; click/space fires gun
3. Press `2` → slot 2 highlighted; click/space swings melee at nearby enemy
4. Press `F` → melee swing regardless of active slot
5. Re-enter tank, bail out again → slot resets to gun

Resolves #50