### PR TITLE
t033: Melee weapon variety — knockback, Dash Strike ability, per-weapon visuals

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -503,30 +503,27 @@ export class Game {
         .filter(s => s.teamId === 1 && s.health > 0);
       const meleeTargets = [...this.teams.getEnemyTanks(), ...aiSoldiers];
       const hits = activeSoldier.melee(meleeTargets);
-      for (const { target, damage } of hits) {
-        // Record damage in the stats tracker so rewards are counted.
-        this.stats.recordPlayerDamage(target, damage);
-        const hitPos = target.mesh.position.clone();
-        if (target.health <= 0) {
-          this.killFeed.addMessage(
-            activeSoldier.name || 'Player',
-            target.name || 'Enemy'
-          );
-          if (target instanceof Soldier) {
-            // Melee killed an AI soldier — use t029 killSoldier for mesh removal
-            // and round-end check; remove from AIController tracking too.
-            this.teams.killSoldier(target);
-            this.aiController.removeSoldier(target);
-          } else {
-            // Melee killed a tank
-            this.stats.recordTankKilled(target, true);
-            this.teams.killTank(target);
-          }
-          this.particles.emitExplosion(hitPos, { count: 25, speed: 8 });
-        } else {
-          // Small impact burst for a non-lethal melee hit.
-          this.particles.emitExplosion(hitPos, { count: 8, speed: 4, lifetime: 0.3 });
-        }
+      this._processMeleeHits(activeSoldier, hits);
+    }
+
+    // ---- Melee weapon ability — Dash Strike (t033) ----
+    // Q key activates the equipped melee weapon's special ability.
+    if (activeSoldier && input.ability && activeSoldier.canActivateMeleeAbility()) {
+      // Include AI soldiers as ability targets (same set as regular melee).
+      const aiSoldiersAbility = this.aiController.getActiveSoldiers()
+        .filter(s => s.teamId === 1 && s.health > 0);
+      const abilityTargets = [...this.teams.getEnemyTanks(), ...aiSoldiersAbility];
+      const abilityHits = activeSoldier.activateMeleeAbility(abilityTargets);
+
+      // Snap the soldier's Y to terrain after the lunge repositions them.
+      const soldierPos = activeSoldier.mesh.position;
+      soldierPos.y = this.terrain.getHeightAt(soldierPos.x, soldierPos.z);
+
+      this._processMeleeHits(activeSoldier, abilityHits);
+
+      // Particle burst at landing position to signal the ability fired.
+      if (abilityHits.length === 0) {
+        this.particles.emitExplosion(soldierPos.clone(), { count: 12, speed: 6, lifetime: 0.4 });
       }
     }
 
@@ -652,6 +649,42 @@ export class Game {
         this.aiController.removeSoldier(soldier);
         this.particles.emitExplosion(deathPos, { count: 10, speed: 5, lifetime: 0.5 });
         console.info('[Game] AI soldier destroyed.');
+      }
+    }
+  }
+
+  /**
+   * Apply a batch of melee hit results: record stats, emit particles, kill targets.
+   * Shared by the regular melee swing and the Dash Strike ability (t033).
+   * Handles both Tank kills and Soldier kills (t028 AI soldiers).
+   *
+   * @param {import('../entities/Soldier.js').Soldier} attacker
+   * @param {Array<{target: object, damage: number}>} hits
+   * @private
+   */
+  _processMeleeHits(attacker, hits) {
+    for (const { target, damage } of hits) {
+      this.stats.recordPlayerDamage(target, damage);
+      const hitPos = target.mesh.position.clone();
+      if (target.health <= 0) {
+        this.killFeed.addMessage(
+          attacker.name || 'Player',
+          target.name || 'Enemy'
+        );
+        if (target instanceof Soldier) {
+          // Melee killed an AI soldier — use killSoldier for mesh removal and
+          // round-end check; remove from AIController tracking too.
+          this.teams.killSoldier(target);
+          this.aiController.removeSoldier(target);
+        } else {
+          // Melee killed a tank.
+          this.stats.recordTankKilled(target, true);
+          this.teams.killTank(target);
+        }
+        this.particles.emitExplosion(hitPos, { count: 25, speed: 8 });
+      } else {
+        // Small impact burst for a non-lethal hit.
+        this.particles.emitExplosion(hitPos, { count: 8, speed: 4, lifetime: 0.3 });
       }
     }
   }

--- a/src/entities/Soldier.js
+++ b/src/entities/Soldier.js
@@ -18,6 +18,52 @@ const SOLDIER_COLORS = {
 };
 
 /**
+ * Push `targetPos` away from `sourcePos` by `distance` world units on the XZ plane.
+ * Modifies `targetPos` in-place.  No-op if source and target are at the same XZ position.
+ *
+ * @param {THREE.Vector3} sourcePos  — attacker world position
+ * @param {THREE.Vector3} targetPos  — target world position (mutated)
+ * @param {number}        distance   — world-unit magnitude of the push
+ */
+function _applyKnockback(sourcePos, targetPos, distance) {
+  const dx = targetPos.x - sourcePos.x;
+  const dz = targetPos.z - sourcePos.z;
+  const len = Math.sqrt(dx * dx + dz * dz);
+  if (len < 0.001) return; // same position — skip to avoid NaN
+  const nx = dx / len;
+  const nz = dz / len;
+  targetPos.x += nx * distance;
+  targetPos.z += nz * distance;
+}
+
+/**
+ * Minimum distance from point `p` to the line segment `a`→`b` on the XZ plane.
+ *
+ * @param {THREE.Vector3} p — test point
+ * @param {THREE.Vector3} a — segment start
+ * @param {THREE.Vector3} b — segment end
+ * @returns {number} XZ-plane distance
+ */
+function _distanceToSegment(p, a, b) {
+  const abx = b.x - a.x;
+  const abz = b.z - a.z;
+  const ab2 = abx * abx + abz * abz;
+  if (ab2 < 0.0001) {
+    // Degenerate segment — return distance to a.
+    const dx = p.x - a.x;
+    const dz = p.z - a.z;
+    return Math.sqrt(dx * dx + dz * dz);
+  }
+  // Project p onto ab, clamped to [0, 1].
+  const t = Math.max(0, Math.min(1, ((p.x - a.x) * abx + (p.z - a.z) * abz) / ab2));
+  const closestX = a.x + t * abx;
+  const closestZ = a.z + t * abz;
+  const dx = p.x - closestX;
+  const dz = p.z - closestZ;
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+/**
  * Apply random spread to a normalised direction vector.
  *
  * Builds a random axis in the plane perpendicular to `dir` then rotates `dir`
@@ -103,7 +149,7 @@ export class Soldier {
     /** Seconds until the next shot is allowed. */
     this.fireCooldown = 0;
 
-    // ---- Melee weapon state (t026) ----
+    // ---- Melee weapon state (t026 / t033) ----
     /** Active melee weapon id. Defaults to starter combat knife. */
     this.meleeWeaponId = 'combatKnife';
     /** Seconds until next melee swing is allowed. */
@@ -117,6 +163,21 @@ export class Soldier {
     this._meleeRange    = _startMelee.range;
     /** Minimum seconds between swings = 1 / attackRate. */
     this._meleeInterval = 1 / _startMelee.attackRate;
+    /**
+     * World-unit push applied to targets on hit (War Hammer only).
+     * Direction is away from the attacker along the XZ plane.
+     * 0 = no knockback (all other weapons).
+     */
+    this._meleeKnockback = _startMelee.knockback ?? 0;
+    /**
+     * Special ability identifier for the equipped melee weapon, or null.
+     * e.g. 'dashStrike' for Energy Blade (t033).
+     */
+    this._meleeAbility = _startMelee.ability ?? null;
+    /** Seconds between ability activations. */
+    this._meleeAbilityCooldown = _startMelee.abilityCooldown ?? 0;
+    /** Countdown (seconds) until the next ability activation is allowed. */
+    this._meleeAbilityTimer = 0;
 
     // Per-round combat stats (mirrors Tank.js for scoreboard compatibility)
     this.kills       = 0;
@@ -125,6 +186,8 @@ export class Soldier {
     const palette = isPlayer ? SOLDIER_COLORS.player : SOLDIER_COLORS.enemy;
     this.mesh   = this._buildMesh(palette);
     this.muzzle = this.mesh.getObjectByName('muzzle');
+    /** Left-hand melee weapon group — swapped per weapon by _updateMeleeMesh(). */
+    this._meleeMeshGroup = this.mesh.getObjectByName('meleeGroup');
   }
 
   // ---------------------------------------------------------------------------
@@ -186,7 +249,119 @@ export class Soldier {
 
     group.add(gunGroup);
 
+    // Melee weapon — left hand, at waist height. Geometry swapped per weapon by
+    // _updateMeleeMesh(); starts as a combat knife (thin blade).
+    const meleeGroup = new THREE.Group();
+    meleeGroup.name = 'meleeGroup';
+    meleeGroup.position.set(-0.25, 1.1, 0); // left hand mirror of gun hand
+    // Default knife blade: thin box pointing forward (-Z)
+    const knifeGeo = new THREE.BoxGeometry(0.06, 0.04, 0.35);
+    const knifeMat = new THREE.MeshStandardMaterial({
+      color: 0x999999,
+      roughness: 0.3,
+      metalness: 0.8,
+    });
+    const knifeMesh = new THREE.Mesh(knifeGeo, knifeMat);
+    knifeMesh.position.z = -0.2;
+    knifeMesh.castShadow = true;
+    meleeGroup.add(knifeMesh);
+    group.add(meleeGroup);
+
     return group;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Melee visual update (t033)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Rebuild the left-hand melee weapon mesh to match `weaponId`.
+   * Called from setMeleeWeapon() after stat update.
+   * @param {string} weaponId
+   * @private
+   */
+  _updateMeleeMesh(weaponId) {
+    if (!this._meleeMeshGroup) return;
+
+    // Clear existing children.
+    while (this._meleeMeshGroup.children.length > 0) {
+      this._meleeMeshGroup.remove(this._meleeMeshGroup.children[0]);
+    }
+
+    switch (weaponId) {
+      case 'combatKnife': {
+        // Short thin blade, grey steel.
+        const geo = new THREE.BoxGeometry(0.06, 0.04, 0.35);
+        const mat = new THREE.MeshStandardMaterial({ color: 0x999999, roughness: 0.3, metalness: 0.8 });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.position.z = -0.2;
+        mesh.castShadow = true;
+        this._meleeMeshGroup.add(mesh);
+        break;
+      }
+      case 'machete': {
+        // Wider, longer blade, darker steel.
+        const geo = new THREE.BoxGeometry(0.10, 0.03, 0.55);
+        const mat = new THREE.MeshStandardMaterial({ color: 0x777766, roughness: 0.4, metalness: 0.7 });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.position.z = -0.3;
+        mesh.castShadow = true;
+        this._meleeMeshGroup.add(mesh);
+        break;
+      }
+      case 'warHammer': {
+        // Handle — thin long cylinder
+        const handleGeo = new THREE.CylinderGeometry(0.04, 0.04, 0.7, 6);
+        const handleMat = new THREE.MeshStandardMaterial({ color: 0x5c3a1e, roughness: 0.9, metalness: 0.1 });
+        const handle = new THREE.Mesh(handleGeo, handleMat);
+        handle.rotation.x = Math.PI / 2;   // point along -Z
+        handle.position.z = -0.35;
+        handle.castShadow = true;
+        this._meleeMeshGroup.add(handle);
+
+        // Head — large dark-iron box perpendicular to handle
+        const headGeo = new THREE.BoxGeometry(0.35, 0.22, 0.18);
+        const headMat = new THREE.MeshStandardMaterial({ color: 0x444455, roughness: 0.6, metalness: 0.5 });
+        const head = new THREE.Mesh(headGeo, headMat);
+        head.position.z = -0.68;
+        head.castShadow = true;
+        this._meleeMeshGroup.add(head);
+        break;
+      }
+      case 'energyBlade': {
+        // Blade — thin, glowing cyan.
+        const geo = new THREE.BoxGeometry(0.05, 0.03, 0.75);
+        const mat = new THREE.MeshStandardMaterial({
+          color: 0x00ffee,
+          emissive: 0x00ccdd,
+          emissiveIntensity: 1.5,
+          roughness: 0.1,
+          metalness: 0.9,
+        });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.position.z = -0.4;
+        mesh.castShadow = true;
+        this._meleeMeshGroup.add(mesh);
+
+        // Guard — small bright crosspiece
+        const guardGeo = new THREE.BoxGeometry(0.22, 0.06, 0.05);
+        const guardMat = new THREE.MeshStandardMaterial({
+          color: 0x0088aa,
+          emissive: 0x004455,
+          emissiveIntensity: 0.8,
+          roughness: 0.2,
+          metalness: 0.8,
+        });
+        const guard = new THREE.Mesh(guardGeo, guardMat);
+        guard.position.z = -0.06;
+        guard.castShadow = true;
+        this._meleeMeshGroup.add(guard);
+        break;
+      }
+      default:
+        // Unknown weapon id — show nothing.
+        break;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -316,10 +491,16 @@ export class Soldier {
    */
   setMeleeWeapon(weaponId) {
     const def = getMeleeDef(weaponId);
-    this.meleeWeaponId  = weaponId;
-    this._meleeDamage   = def.damage;
-    this._meleeRange    = def.range;
-    this._meleeInterval = 1 / def.attackRate;
+    this.meleeWeaponId        = weaponId;
+    this._meleeDamage         = def.damage;
+    this._meleeRange          = def.range;
+    this._meleeInterval       = 1 / def.attackRate;
+    this._meleeKnockback      = def.knockback ?? 0;
+    this._meleeAbility        = def.ability ?? null;
+    this._meleeAbilityCooldown = def.abilityCooldown ?? 0;
+    // Don't reset the ability timer — cooldown carries over if switching mid-combat.
+    this._updateMeleeMesh(weaponId);
+    return this;
   }
 
   /**
@@ -348,9 +529,10 @@ export class Soldier {
 
     this.meleeCooldown = this._meleeInterval;
 
-    const pos   = this.mesh.position;
-    const range = this._meleeRange;
-    const hits  = [];
+    const pos       = this.mesh.position;
+    const range     = this._meleeRange;
+    const knockback = this._meleeKnockback;
+    const hits      = [];
 
     for (const target of targets) {
       if (!target || target.health <= 0) continue;
@@ -365,6 +547,96 @@ export class Soldier {
       if (target.health <= 0) {
         this.recordKill();
       }
+
+      // War Hammer knockback — push target away from attacker on the XZ plane.
+      if (knockback > 0 && target.mesh) {
+        _applyKnockback(pos, target.mesh.position, knockback);
+      }
+
+      hits.push({ target, damage: actualDamage });
+    }
+
+    return hits;
+  }
+
+  /**
+   * @returns {boolean} True when this soldier has a melee weapon with an ability
+   *   and the ability cooldown has elapsed.
+   */
+  canActivateMeleeAbility() {
+    return this._meleeAbility !== null && this._meleeAbilityTimer <= 0;
+  }
+
+  /**
+   * Activate the equipped melee weapon's special ability.
+   *
+   * **dashStrike (Energy Blade):** Lunge forward 10 world units and slash every
+   * target within 2.5 units of the lunge path.  Applies melee damage and
+   * knockback to each entity hit.  Returns an empty array if the ability is not
+   * ready or no melee ability is equipped.
+   *
+   * Movement side-effect: modifies `this.mesh.position` directly.  The caller
+   * (Game.js) is responsible for snapping the y-coordinate back to terrain
+   * height after this call.
+   *
+   * @param {Array<{mesh: import('three').Object3D, health: number, takeDamage: (n:number)=>void}>} targets
+   * @returns {Array<{target: object, damage: number}>} Entities hit (may be empty).
+   */
+  activateMeleeAbility(targets = []) {
+    if (!this.canActivateMeleeAbility()) return [];
+
+    this._meleeAbilityTimer = this._meleeAbilityCooldown;
+
+    if (this._meleeAbility === 'dashStrike') {
+      return this._performDashStrike(targets);
+    }
+
+    return [];
+  }
+
+  /**
+   * Lunge forward 10 units along the soldier's facing direction, dealing melee
+   * damage to every target whose mesh centre is within 2.5 units of the path.
+   * @param {Array} targets
+   * @returns {Array<{target, damage}>}
+   * @private
+   */
+  _performDashStrike(targets) {
+    const LUNGE_DISTANCE  = 10;
+    const PATH_HALF_WIDTH = 2.5;
+
+    const startPos = this.mesh.position.clone();
+
+    // Forward direction = -Z of the soldier's local axes.
+    const forward = new THREE.Vector3(0, 0, -1)
+      .applyEuler(this.mesh.rotation)
+      .normalize();
+
+    // Move soldier to end position (y-snap to terrain handled by caller).
+    this.mesh.position.addScaledVector(forward, LUNGE_DISTANCE);
+
+    const endPos = this.mesh.position.clone();
+    const hits   = [];
+
+    for (const target of targets) {
+      if (!target || target.health <= 0) continue;
+
+      // Distance from target to the lunge line segment (startPos → endPos).
+      const dist = _distanceToSegment(target.mesh.position, startPos, endPos);
+      if (dist > PATH_HALF_WIDTH) continue;
+
+      const actualDamage = Math.min(this._meleeDamage, target.health);
+      target.takeDamage(this._meleeDamage);
+      this.recordDamage(actualDamage);
+      if (target.health <= 0) {
+        this.recordKill();
+      }
+
+      // Apply knockback perpendicular to the lunge path (push targets sideways).
+      if (this._meleeKnockback > 0 && target.mesh) {
+        _applyKnockback(endPos, target.mesh.position, this._meleeKnockback);
+      }
+
       hits.push({ target, damage: actualDamage });
     }
 
@@ -404,6 +676,9 @@ export class Soldier {
     if (this.meleeCooldown > 0) {
       this.meleeCooldown -= dt;
     }
+    if (this._meleeAbilityTimer > 0) {
+      this._meleeAbilityTimer -= dt;
+    }
     // Advance reload timer — completes when _reloadTimer reaches 0.
     if (this.isReloading) {
       this._reloadTimer -= dt;
@@ -417,11 +692,12 @@ export class Soldier {
 
   /** Reset to full health / stats for round start. */
   reset() {
-    this.health        = this.maxHealth;
-    this.fireCooldown  = 0;
-    this.meleeCooldown = 0;
-    this.kills         = 0;
-    this.damageDealt   = 0;
+    this.health             = this.maxHealth;
+    this.fireCooldown       = 0;
+    this.meleeCooldown      = 0;
+    this._meleeAbilityTimer = 0;
+    this.kills              = 0;
+    this.damageDealt        = 0;
     // Refill clip and cancel any in-progress reload.
     this.clipCurrent  = this._gunClipSize;
     this.isReloading  = false;

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -25,6 +25,8 @@ export class InputSystem {
     this._switchToGunRequested   = false;
     /** One-shot: true on the frame 2 is pressed — switch to melee slot (t034). */
     this._switchToMeleeRequested = false;
+    /** One-shot: Q key activates the equipped melee weapon's special ability (t033). */
+    this._abilityRequested = false;
 
     // Mouse aim
     this._mouseAim = { active: false, x: 0, y: 0 };
@@ -46,6 +48,8 @@ export class InputSystem {
       // 1/2 — weapon slot switching: 1 = gun, 2 = melee (t034)
       if (e.code === 'Digit1') this._switchToGunRequested   = true;
       if (e.code === 'Digit2') this._switchToMeleeRequested = true;
+      // Q key — activate melee/weapon ability (dashStrike for energyBlade, t033)
+      if (e.code === 'KeyQ') this._abilityRequested = true;
       // Prevent Tab from shifting browser focus while held for the scoreboard
       if (e.code === 'Tab') e.preventDefault();
     });
@@ -168,6 +172,8 @@ export class InputSystem {
       melee: this._meleeRequested,
       /** One-shot: R key triggers a manual reload for the on-foot gun (t030). */
       reload: this._reloadRequested,
+      /** One-shot: Q key triggers the equipped melee weapon's special ability (t033). */
+      ability: this._abilityRequested,
       turretAngle: this._turretAngle,
       /** true while Tab is held — shows/hides the scoreboard overlay */
       tabHeld: !!this._keys['Tab'],
@@ -186,6 +192,7 @@ export class InputSystem {
     this._exitVehicleRequested   = false;
     this._switchToGunRequested   = false;
     this._switchToMeleeRequested = false;
+    this._abilityRequested       = false;
 
     return state;
   }


### PR DESCRIPTION
## Summary

Implements t033: distinct behaviours and visuals for all four melee weapons. Cleanly layered on top of t034 (weapon slot switching).

- **War Hammer knockback**: `melee()` reads `_meleeKnockback` (3 wu for War Hammer, 0 for others) and calls `_applyKnockback()` to push hit targets away on the XZ plane after dealing damage.
- **Energy Blade Dash Strike ability** (Q key, 12 s cooldown): `activateMeleeAbility()` → `_performDashStrike()` lunges the soldier 10 units forward, hitting all targets within 2.5 units of the path. AI soldiers are included. Terrain y-snap applied by Game.js after lunge.
- **Per-weapon left-hand mesh**: `_buildMesh()` creates a named `meleeGroup` in the left hand. `_updateMeleeMesh(weaponId)` rebuilds it per weapon on every `setMeleeWeapon()` call:
  - `combatKnife` — short grey blade
  - `machete` — wider, longer darker blade
  - `warHammer` — wooden handle + dark iron box head (T-shape)
  - `energyBlade` — glowing cyan blade + crossguard (emissive `MeshStandardMaterial`, intensity 1.5)
- **Q key input**: `InputSystem` adds `_abilityRequested` (Q key one-shot) and `ability` in `getState()`, alongside t034's existing 1/2 slot-switch inputs.
- **`_processMeleeHits()` helper**: Extracts shared kill/particle logic from the melee block. Handles both AI Soldier kills (`teams.killSoldier` + `aiController.removeSoldier`) and Tank kills (`stats.recordTankKilled` + `teams.killTank`). Used by both regular swing and dash strike.

## Testing

Node.js module tests — all passing:
- War Hammer: target pushed away from attacker on XZ plane ✓
- Energy Blade dash: soldier moves 10 units forward, hits target in 2.5-unit path, misses target 5 units off-axis ✓
- Cooldown (12 s) set after use; `canActivateMeleeAbility()` false while cooling ✓
- Machete: no knockback (`_meleeKnockback === 0`) ✓

Resolves #49