### PR TITLE
t036: Tank visual differentiation — distinct mesh per class

### DIFF
--- a/src/core/TeamManager.js
+++ b/src/core/TeamManager.js
@@ -265,6 +265,21 @@ export class TeamManager {
   // Private helpers
   // ---------------------------------------------------------------------------
 
+  /**
+   * Tank class IDs assigned to each slot in a 6-tank team.
+   * Slot 0 is always the player (their chosen class — overridden at runtime when
+   * the loadout system is in place; 'standard' is the placeholder until t040).
+   * Slots 1-5 are AI teammates; varied classes make team composition visible on the
+   * field.  Full league-based composition tables land in t038.
+   */
+  static get AI_ALLY_CLASSES() {
+    return ['standard', 'scout', 'heavy', 'artillery', 'standard'];
+  }
+
+  static get AI_ENEMY_CLASSES() {
+    return ['standard', 'scout', 'heavy', 'artillery', 'standard', 'heavy'];
+  }
+
   _buildTeams() {
     // Team 0 — player side
     const playerTeam = {
@@ -275,12 +290,19 @@ export class TeamManager {
 
     for (let i = 0; i < TEAM_SIZE; i++) {
       const isPlayer = i === 0;
+      // Slot 0 = player (defaults to 'standard' until the loadout system from t040
+      // sets a real selection).  Slots 1-5 = AI allies with varied classes.
+      const tankClassId = isPlayer
+        ? 'standard'
+        : TeamManager.AI_ALLY_CLASSES[i - 1] || 'standard';
+
       const tank = new Tank({
         isPlayer,
         color: TEAM_COLORS[0].body,
         turretColor: TEAM_COLORS[0].turret,
         teamId: 0,
         name: isPlayer ? 'Player' : `Ally ${i}`,
+        tankClassId,
       });
 
       const pos = this._spawnPosition(i, 0);
@@ -299,12 +321,15 @@ export class TeamManager {
     };
 
     for (let i = 0; i < TEAM_SIZE; i++) {
+      const tankClassId = TeamManager.AI_ENEMY_CLASSES[i] || 'standard';
+
       const tank = new Tank({
         isPlayer: false,
         color: TEAM_COLORS[1].body,
         turretColor: TEAM_COLORS[1].turret,
         teamId: 1,
         name: `Enemy #${i + 1}`,
+        tankClassId,
       });
 
       const pos = this._spawnPosition(i, 1);

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -6,20 +6,122 @@ const TANK_COLORS = {
   enemy: { body: 0x8b2500, turret: 0xb03000 },
 };
 
+/**
+ * Per-class geometry parameters — distinct visual identity for each tank class.
+ * Dimensions are in world units (unscaled). Deviations from 'standard' make each
+ * class visually distinct at a glance: Scout is narrow and low, Siege is massive, etc.
+ *
+ * hullW/H/L  : BoxGeometry extents for the main hull.
+ * trackW/H   : BoxGeometry extents for each track.
+ * turretTopR/BotR/H/Segs : CylinderGeometry for the turret dome.
+ * barrelTopR/BotR/L : CylinderGeometry for the barrel.
+ * barrelPitch: radians — negative rotates barrel upward (artillery elevation).
+ * extras     : optional detail geometry key ('jumpJets', 'sideArmor', or null).
+ */
+const CLASS_MESH_PARAMS = {
+  standard: {
+    hullW: 3.0, hullH: 1.2, hullL: 4.5,
+    trackW: 0.60, trackH: 0.80,
+    turretTopR: 1.10, turretBotR: 1.30, turretH: 0.80, turretSegs: 8,
+    barrelTopR: 0.15, barrelBotR: 0.18, barrelL: 3.5,
+    barrelPitch: 0,
+    extras: null,
+  },
+  scout: {
+    // Narrow, low silhouette — fast flanker with reduced cross-section
+    hullW: 2.4, hullH: 0.90, hullL: 3.8,
+    trackW: 0.48, trackH: 0.65,
+    turretTopR: 0.82, turretBotR: 0.98, turretH: 0.55, turretSegs: 6,
+    barrelTopR: 0.10, barrelBotR: 0.12, barrelL: 2.8,
+    barrelPitch: 0,
+    extras: null,
+  },
+  heavy: {
+    // Wide, tall, heavily-armored — unmistakable bulk on the field
+    hullW: 4.2, hullH: 1.50, hullL: 5.5,
+    trackW: 0.80, trackH: 1.00,
+    turretTopR: 1.35, turretBotR: 1.60, turretH: 1.00, turretSegs: 8,
+    barrelTopR: 0.22, barrelBotR: 0.26, barrelL: 4.0,
+    barrelPitch: 0,
+    extras: null,
+  },
+  artillery: {
+    // Standard hull but with an extremely long, thin barrel; elevated pitch
+    hullW: 3.0, hullH: 1.20, hullL: 5.0,
+    trackW: 0.60, trackH: 0.80,
+    turretTopR: 0.90, turretBotR: 1.10, turretH: 0.70, turretSegs: 8,
+    barrelTopR: 0.10, barrelBotR: 0.13, barrelL: 6.0,
+    barrelPitch: -0.22, // ~13° upward elevation (artillery arc)
+    extras: null,
+  },
+  flameTank: {
+    // Stubby wide nozzle instead of a cannon barrel
+    hullW: 3.2, hullH: 1.30, hullL: 4.5,
+    trackW: 0.64, trackH: 0.85,
+    turretTopR: 1.10, turretBotR: 1.30, turretH: 0.80, turretSegs: 8,
+    barrelTopR: 0.32, barrelBotR: 0.40, barrelL: 1.8,
+    barrelPitch: 0,
+    extras: null,
+  },
+  shieldTank: {
+    // Dome-shaped turret (steep taper, many segments) distinguishes it visually
+    hullW: 3.4, hullH: 1.30, hullL: 4.8,
+    trackW: 0.65, trackH: 0.85,
+    turretTopR: 0.60, turretBotR: 1.50, turretH: 1.10, turretSegs: 12,
+    barrelTopR: 0.14, barrelBotR: 0.17, barrelL: 3.5,
+    barrelPitch: 0,
+    extras: null,
+  },
+  jumpTank: {
+    // Slightly smaller hull; rocket-booster pods on the hull sides
+    hullW: 2.8, hullH: 1.10, hullL: 4.2,
+    trackW: 0.58, trackH: 0.75,
+    turretTopR: 1.00, turretBotR: 1.20, turretH: 0.70, turretSegs: 8,
+    barrelTopR: 0.14, barrelBotR: 0.17, barrelL: 3.2,
+    barrelPitch: 0,
+    extras: 'jumpJets',
+  },
+  siegeTank: {
+    // Massive hull and turret — the largest tank on the field
+    hullW: 5.0, hullH: 1.80, hullL: 6.5,
+    trackW: 0.90, trackH: 1.20,
+    turretTopR: 1.50, turretBotR: 1.85, turretH: 1.30, turretSegs: 8,
+    barrelTopR: 0.28, barrelBotR: 0.34, barrelL: 4.5,
+    barrelPitch: 0,
+    extras: 'sideArmor',
+  },
+};
+
 export class Tank {
   /**
    * @param {object} [opts]
    * @param {boolean} [opts.isPlayer=false]
-   * @param {number|null} [opts.color=null]       — override hull color (hex int)
-   * @param {number|null} [opts.turretColor=null] — override turret color (hex int)
-   * @param {number} [opts.teamId=1]              — 0 = player team, 1 = enemy team
-   * @param {string} [opts.name='']               — display name shown in kill feed
+   * @param {number|null} [opts.color=null]          — override hull color (hex int)
+   * @param {number|null} [opts.turretColor=null]    — override turret color (hex int)
+   * @param {number} [opts.teamId=1]                 — 0 = player team, 1 = enemy team
+   * @param {string} [opts.name='']                  — display name shown in kill feed
+   * @param {string} [opts.tankClassId='standard']   — tank class key (controls mesh shape)
    */
-  constructor({ isPlayer = false, color = null, turretColor = null, teamId = 1, name = '' } = {}) {
+  constructor({
+    isPlayer = false,
+    color = null,
+    turretColor = null,
+    teamId = 1,
+    name = '',
+    tankClassId = 'standard',
+  } = {}) {
     this.isPlayer = isPlayer;
     this.teamId = teamId;
     /** @type {string} Display name for kill feed messages (e.g. 'Player', 'Enemy #2'). */
     this.name = name || (isPlayer ? 'Player' : 'Enemy');
+
+    /**
+     * Tank class identifier — controls mesh geometry.
+     * Stats from the class definition are applied separately by t037.
+     * Falls back to 'standard' for any unknown id.
+     */
+    this.tankClassId = CLASS_MESH_PARAMS[tankClassId] ? tankClassId : 'standard';
+
     this.health = 100;
     this.maxHealth = 100;
     this.ammo = 30;
@@ -45,49 +147,71 @@ export class Tank {
       turret: turretColor !== null ? turretColor : (color !== null ? color : base.turret),
     };
 
-    this.mesh = this._buildMesh(palette);
+    this.mesh = this._buildMesh(palette, this.tankClassId);
     this.turret = this.mesh.getObjectByName('turret');
     this.barrel = this.mesh.getObjectByName('barrel');
     this.muzzle = this.mesh.getObjectByName('muzzle');
   }
 
-  _buildMesh(palette) {
+  /**
+   * Build the tank mesh using class-specific geometry parameters.
+   *
+   * Hull/track/turret/barrel dimensions are read from CLASS_MESH_PARAMS so that
+   * each class has a distinct silhouette.  Team palette colors are still applied
+   * for team identification.
+   *
+   * @param {{body: number, turret: number}} palette — team-tinted colors
+   * @param {string} classId — key into CLASS_MESH_PARAMS
+   * @returns {THREE.Group}
+   */
+  _buildMesh(palette, classId) {
+    const p = CLASS_MESH_PARAMS[classId] || CLASS_MESH_PARAMS.standard;
     const group = new THREE.Group();
 
-    // Hull (body)
-    const hullGeo = new THREE.BoxGeometry(3, 1.2, 4.5);
+    // ── Ground clearance and derived Y positions ──────────────────────────────
+    const groundClearance = 0.20;
+    const hullCenterY = groundClearance + p.hullH / 2;
+    const turretBaseY  = groundClearance + p.hullH + 0.05; // sit on hull top
+
+    // ── Hull ─────────────────────────────────────────────────────────────────
+    const hullGeo = new THREE.BoxGeometry(p.hullW, p.hullH, p.hullL);
     const hullMat = new THREE.MeshStandardMaterial({
       color: palette.body,
       roughness: 0.7,
       metalness: 0.3,
     });
     const hull = new THREE.Mesh(hullGeo, hullMat);
-    hull.position.y = 0.8;
+    hull.position.y = hullCenterY;
     hull.castShadow = true;
     hull.receiveShadow = true;
     group.add(hull);
 
-    // Track left
-    const trackGeo = new THREE.BoxGeometry(0.6, 0.8, 4.8);
+    // ── Tracks (left & right) ────────────────────────────────────────────────
+    const trackGeo = new THREE.BoxGeometry(p.trackW, p.trackH, p.hullL + 0.3);
     const trackMat = new THREE.MeshStandardMaterial({
       color: 0x222222,
       roughness: 0.9,
     });
+    const trackCenterY = groundClearance / 2 + p.trackH / 2;
+    const trackOffsetX  = p.hullW / 2 + p.trackW / 2;
+
     const trackL = new THREE.Mesh(trackGeo, trackMat);
-    trackL.position.set(-1.6, 0.5, 0);
+    trackL.position.set(-trackOffsetX, trackCenterY, 0);
     trackL.castShadow = true;
     group.add(trackL);
 
     const trackR = trackL.clone();
-    trackR.position.x = 1.6;
+    trackR.position.x = trackOffsetX;
     group.add(trackR);
 
-    // Turret base
+    // ── Turret ───────────────────────────────────────────────────────────────
     const turretGroup = new THREE.Group();
     turretGroup.name = 'turret';
-    turretGroup.position.y = 1.5;
+    turretGroup.position.y = turretBaseY;
 
-    const turretGeo = new THREE.CylinderGeometry(1.1, 1.3, 0.8, 8);
+    const turretGeo = new THREE.CylinderGeometry(
+      p.turretTopR, p.turretBotR, p.turretH, p.turretSegs,
+    );
     const turretMat = new THREE.MeshStandardMaterial({
       color: palette.turret,
       roughness: 0.6,
@@ -97,8 +221,16 @@ export class Tank {
     turretMesh.castShadow = true;
     turretGroup.add(turretMesh);
 
-    // Barrel
-    const barrelGeo = new THREE.CylinderGeometry(0.15, 0.18, 3.5, 8);
+    // ── Barrel ───────────────────────────────────────────────────────────────
+    // Barrel is embedded slightly inside the turret for a realistic gun mount.
+    // Formula: barrel back-end is 0.15 units inside the turret centre, giving
+    // a believable mounting point regardless of barrel length.
+    const barrelCenterZ = -(p.barrelL / 2 + 0.15);
+    const muzzleZ       = -(p.barrelL + 0.20);
+
+    const barrelGeo = new THREE.CylinderGeometry(
+      p.barrelTopR, p.barrelBotR, p.barrelL, 8,
+    );
     const barrelMat = new THREE.MeshStandardMaterial({
       color: 0x333333,
       roughness: 0.5,
@@ -106,20 +238,74 @@ export class Tank {
     });
     const barrel = new THREE.Mesh(barrelGeo, barrelMat);
     barrel.name = 'barrel';
-    barrel.rotation.x = Math.PI / 2;
-    barrel.position.set(0, 0.1, -1.9);
+    // Rotate to horizontal first (default CylinderGeometry is vertical),
+    // then add elevation pitch (negative value = upward tilt, e.g. artillery).
+    barrel.rotation.x = Math.PI / 2 + p.barrelPitch;
+    barrel.position.set(0, 0.1, barrelCenterZ);
     barrel.castShadow = true;
     turretGroup.add(barrel);
 
-    // Muzzle point (for spawning projectiles)
+    // Muzzle — world-space reference point for projectile spawn & muzzle flash
     const muzzle = new THREE.Object3D();
     muzzle.name = 'muzzle';
-    muzzle.position.set(0, 0.1, -3.6);
+    muzzle.position.set(0, 0.1, muzzleZ);
     turretGroup.add(muzzle);
 
     group.add(turretGroup);
 
+    // ── Class-specific extras ─────────────────────────────────────────────────
+    if (p.extras === 'jumpJets') {
+      this._addJumpJets(group, p, hullCenterY);
+    } else if (p.extras === 'sideArmor') {
+      this._addSideArmor(group, p, hullCenterY, palette.body);
+    }
+
     return group;
+  }
+
+  /**
+   * Jump Tank detail: two rocket-booster pods on the rear hull sides.
+   * @private
+   */
+  _addJumpJets(group, p, hullCenterY) {
+    const podGeo = new THREE.CylinderGeometry(0.28, 0.35, 1.2, 6);
+    const podMat = new THREE.MeshStandardMaterial({
+      color: 0x555566,
+      roughness: 0.5,
+      metalness: 0.5,
+    });
+    const offsetX = p.hullW / 2 + 0.55;
+    const offsetZ = p.hullL / 2 - 0.6; // rear quarter of hull
+
+    for (const side of [-1, 1]) {
+      const pod = new THREE.Mesh(podGeo, podMat);
+      pod.rotation.z = Math.PI / 2; // cylinders horizontal, pointing outward
+      pod.position.set(side * offsetX, hullCenterY + 0.2, offsetZ);
+      pod.castShadow = true;
+      group.add(pod);
+    }
+  }
+
+  /**
+   * Siege Tank detail: thick side-armor slabs on each hull flank.
+   * @private
+   */
+  _addSideArmor(group, p, hullCenterY, color) {
+    const slabGeo = new THREE.BoxGeometry(0.35, p.hullH * 0.85, p.hullL * 0.80);
+    const slabMat = new THREE.MeshStandardMaterial({
+      color,
+      roughness: 0.8,
+      metalness: 0.2,
+    });
+    const offsetX = p.hullW / 2 + 0.18;
+
+    for (const side of [-1, 1]) {
+      const slab = new THREE.Mesh(slabGeo, slabMat);
+      slab.position.set(side * offsetX, hullCenterY, 0);
+      slab.castShadow = true;
+      slab.receiveShadow = true;
+      group.add(slab);
+    }
   }
 
   setTurretAngle(angle) {


### PR DESCRIPTION
## Summary

Implements t036: each of the 8 tank classes now has a unique visual mesh so players can identify class at a glance on the field.

### What changed

**`src/entities/Tank.js`**
- Added `CLASS_MESH_PARAMS` table — per-class hull/track/turret/barrel geometry.
- `Tank` constructor now accepts `tankClassId` (default `'standard'`). Stores it for future stat wiring (t037).
- `_buildMesh(palette, classId)` uses class params for all geometry; derived Y positions keep all classes properly grounded.
- Added `_addJumpJets()` (Jump Tank) and `_addSideArmor()` (Siege Tank) for class-specific detail geometry.
- Stats (`health`, `fireRate`, `damage`) are unchanged — stat wiring is t037's scope.

**`src/core/TeamManager.js`**
- Added `AI_ALLY_CLASSES` / `AI_ENEMY_CLASSES` static getters with varied class rosters.
- Both `_buildTeams()` loops pass `tankClassId` to `new Tank(...)`.

### Per-class visual identity

| Class | Hull W×H×L | Turret | Barrel | Extra |
|-------|-----------|--------|--------|-------|
| Standard | 3.0×1.2×4.5 | cylinder r1.1→1.3 | 3.5 long | — |
| Scout | 2.4×0.9×3.8 | flat r0.82→0.98, 6 segs | 2.8 thin | — |
| Heavy | 4.2×1.5×5.5 | r1.35→1.60 | 4.0 thick | — |
| Artillery | 3.0×1.2×5.0 | r0.90→1.10 | 6.0 thin, 13° elev. | — |
| Flame Tank | 3.2×1.3×4.5 | standard | 1.8 wide nozzle | — |
| Shield Tank | 3.4×1.3×4.8 | dome r0.60→1.50, 12 segs | 3.5 | — |
| Jump Tank | 2.8×1.1×4.2 | r1.00→1.20 | 3.2 | booster pods |
| Siege Tank | 5.0×1.8×6.5 | r1.50→1.85 | 4.5 thick | side armor slabs |

### Verification

`npm run build` — passes with 0 errors (build output 595 kB). Both modified files pass `node --input-type=module` import checks.

Resolves #52