### PR TITLE
t040: Tank stat comparison bars in LoadoutScreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,6 +583,78 @@
       color: rgba(255,255,255,0.45);
     }
 
+    /* === Stat comparison bars (t040) === */
+
+    /* Container for the four stat rows inside a tank card */
+    .ls-stat-bars {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin: 4px 0 2px;
+    }
+
+    /* One row: label | bar | value */
+    .ls-stat-row {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+
+    /* "HP", "SPD", "ARM", "DMG" label — fixed width so bars align */
+    .ls-stat-lbl {
+      font-size: 9px;
+      font-weight: 700;
+      color: rgba(255,255,255,0.45);
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      width: 26px;
+      flex-shrink: 0;
+    }
+
+    /* Bar track */
+    .ls-stat-bar {
+      flex: 1;
+      height: 5px;
+      background: rgba(255,255,255,0.1);
+      border-radius: 3px;
+      overflow: hidden;
+    }
+
+    /* Bar fill — width is set inline as a percentage */
+    .ls-stat-fill {
+      height: 100%;
+      background: #4caf50;
+      border-radius: 3px;
+      transition: width 0.2s ease;
+    }
+
+    /* Numeric value to the right of the bar */
+    .ls-stat-val {
+      font-size: 9px;
+      color: rgba(255,255,255,0.6);
+      width: 28px;
+      text-align: right;
+      flex-shrink: 0;
+    }
+
+    /* Selected card — brighter bar fill */
+    .ls-card-selected .ls-stat-fill {
+      background: #66bb6a;
+    }
+
+    /* Locked card — muted bar fill */
+    .ls-card-locked .ls-stat-fill {
+      background: rgba(255,255,255,0.2);
+    }
+
+    /* Ability badge on tank cards */
+    .ls-card-ability {
+      font-size: 10px;
+      font-weight: 700;
+      color: #ffb300;
+      letter-spacing: 0.5px;
+    }
+
     /* === Footer / deploy bar === */
     .ls-footer {
       display: flex;

--- a/src/ui/LoadoutScreen.js
+++ b/src/ui/LoadoutScreen.js
@@ -1,9 +1,13 @@
 /**
- * LoadoutScreen — pre-match tank + weapon selection UI (t018).
+ * LoadoutScreen — pre-match tank + weapon selection UI (t018 + t040).
  *
  * Renders a full-screen overlay (#loadout-overlay in index.html) that lets the
  * player pick their tank class and on-foot weapons from their owned inventory
  * before each match.
+ *
+ * t040 addition: each tank card now shows visual stat comparison bars for HP,
+ * Speed, Armor, and Damage — normalised against the highest value across all
+ * defined tank classes.  This lets the player compare tanks at a glance.
  *
  * Integration pattern (from Game.js):
  *
@@ -32,6 +36,26 @@
 
 import { TankDefs, TANK_ORDER } from '../data/TankDefs.js';
 import { GunDefs, MeleeDefs, GUN_ORDER, MELEE_ORDER } from '../data/WeaponDefs.js';
+
+/**
+ * Maximum values for HP, Speed, Armor, and Damage across all defined tank classes.
+ * Computed once at module load time so stat bars are always normalised against
+ * the full roster — no magic constants, no maintenance burden.
+ *
+ * Exported so tests and other modules can verify the normalisation values.
+ */
+export const TANK_STAT_MAX = (() => {
+  let hp = 0, speed = 0, armor = 0, damage = 0;
+  for (const id of TANK_ORDER) {
+    const d = TankDefs[id];
+    if (!d) continue;
+    if (d.hp     > hp)     hp     = d.hp;
+    if (d.speed  > speed)  speed  = d.speed;
+    if (d.armor  > armor)  armor  = d.armor;
+    if (d.damage > damage) damage = d.damage;
+  }
+  return { hp, speed, armor, damage };
+})();
 
 export class LoadoutScreen {
   /**
@@ -208,14 +232,15 @@ export class LoadoutScreen {
     descLine.className = 'ls-card-desc';
     descLine.textContent = def.description;
 
-    const statsLine = document.createElement('div');
-    statsLine.className = 'ls-card-stats';
-    const armorPct = Math.round(def.armor * 100);
-    statsLine.innerHTML =
-      `HP <b>${def.hp}</b>&nbsp;&nbsp;` +
-      `SPD <b>${def.speed}</b>&nbsp;&nbsp;` +
-      `ARM <b>${armorPct}%</b>` +
-      (def.ability ? `&nbsp;&nbsp;⚡ <b>${def.ability}</b>` : '');
+    // Stat comparison bars (t040): HP, Speed, Armor, Damage normalised vs roster max
+    const barsDiv = this._makeStatBars(def);
+
+    // Ability badge — only shown when the tank has a special ability
+    const abilityLine = document.createElement('div');
+    abilityLine.className = 'ls-card-ability';
+    if (def.ability) {
+      abilityLine.textContent = `⚡ ${def.ability}`;
+    }
 
     const leagueLine = document.createElement('div');
     leagueLine.className = 'ls-card-league';
@@ -233,7 +258,8 @@ export class LoadoutScreen {
 
     info.appendChild(nameLine);
     info.appendChild(descLine);
-    info.appendChild(statsLine);
+    info.appendChild(barsDiv);
+    if (def.ability) info.appendChild(abilityLine);
     info.appendChild(leagueLine);
 
     card.appendChild(swatch);
@@ -248,6 +274,86 @@ export class LoadoutScreen {
     }
 
     return card;
+  }
+
+  /**
+   * Build a compact stat-comparison block for a tank card (t040).
+   *
+   * Renders four horizontal bars — HP, Speed, Armor, Damage — with each bar's
+   * width proportional to the tank's value relative to the maximum across all
+   * defined tank classes (TANK_STAT_MAX).  A minimum fill of 4 % is enforced so
+   * even the weakest stat is visually present.
+   *
+   * The CSS classes used here (.ls-stat-bars, .ls-stat-row, .ls-stat-lbl,
+   * .ls-stat-bar, .ls-stat-fill, .ls-stat-val) are defined in index.html.
+   *
+   * @private
+   * @param {object} def - TankDef from TankDefs
+   * @returns {HTMLElement}
+   */
+  _makeStatBars(def) {
+    const container = document.createElement('div');
+    container.className = 'ls-stat-bars';
+
+    /** @type {Array<{label:string, value:number, max:number, text:string}>} */
+    const rows = [
+      {
+        label: 'HP',
+        value: def.hp,
+        max:   TANK_STAT_MAX.hp,
+        text:  String(def.hp),
+      },
+      {
+        label: 'SPD',
+        value: def.speed,
+        max:   TANK_STAT_MAX.speed,
+        text:  String(def.speed),
+      },
+      {
+        label: 'ARM',
+        value: def.armor,
+        max:   TANK_STAT_MAX.armor,
+        text:  Math.round(def.armor * 100) + '%',
+      },
+      {
+        label: 'DMG',
+        value: def.damage,
+        max:   TANK_STAT_MAX.damage,
+        text:  String(def.damage),
+      },
+    ];
+
+    for (const r of rows) {
+      const pct = r.max > 0
+        ? Math.max(4, Math.round((r.value / r.max) * 100))
+        : 0;
+
+      const row = document.createElement('div');
+      row.className = 'ls-stat-row';
+
+      const lbl = document.createElement('span');
+      lbl.className = 'ls-stat-lbl';
+      lbl.textContent = r.label;
+
+      const barWrap = document.createElement('div');
+      barWrap.className = 'ls-stat-bar';
+
+      const barFill = document.createElement('div');
+      barFill.className = 'ls-stat-fill';
+      barFill.style.width = pct + '%';
+
+      const val = document.createElement('span');
+      val.className = 'ls-stat-val';
+      val.textContent = r.text;
+
+      barWrap.appendChild(barFill);
+      row.appendChild(lbl);
+      row.appendChild(barWrap);
+      row.appendChild(val);
+      container.appendChild(row);
+    }
+
+    return container;
   }
 
   /**

--- a/tests/TankDefs.test.js
+++ b/tests/TankDefs.test.js
@@ -1,5 +1,7 @@
 /**
- * TankDefs.test.js — unit tests for TankDefs data and helper functions.
+ * TankDefs.test.js — unit tests for TankDefs data, helper functions, and the
+ * TANK_STAT_MAX normalisation values used by LoadoutScreen's stat comparison
+ * bars (t040).
  *
  * Run: node --test tests/TankDefs.test.js
  *
@@ -10,6 +12,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { TankDefs, TANK_ORDER, getTankDef } from '../src/data/TankDefs.js';
+import { TANK_STAT_MAX } from '../src/ui/LoadoutScreen.js';
 
 // ---------------------------------------------------------------------------
 // Completeness
@@ -356,4 +359,69 @@ test('HP ordering: siegeTank > heavy > shieldTank > flameTank > standard ≥ jum
   assert.ok(hp('standard')  >= hp('jumpTank'), 'standard ≥ jumpTank');
   assert.ok(hp('jumpTank')  > hp('scout'),    'jumpTank > scout');
   assert.ok(hp('scout')     > hp('artillery'), 'scout > artillery');
+});
+
+// ---------------------------------------------------------------------------
+// TANK_STAT_MAX normalisation (t040) — LoadoutScreen stat comparison bars
+// ---------------------------------------------------------------------------
+
+test('TANK_STAT_MAX.hp equals the highest hp across all tank classes', () => {
+  const expected = Math.max(...TANK_ORDER.map((id) => TankDefs[id].hp));
+  assert.equal(TANK_STAT_MAX.hp, expected);
+  // Siege Tank has 250 hp — the roster maximum
+  assert.equal(TANK_STAT_MAX.hp, 250, 'Siege Tank has the highest HP (250)');
+});
+
+test('TANK_STAT_MAX.speed equals the highest speed across all tank classes', () => {
+  const expected = Math.max(...TANK_ORDER.map((id) => TankDefs[id].speed));
+  assert.equal(TANK_STAT_MAX.speed, expected);
+  // Scout has speed 20 — the roster maximum
+  assert.equal(TANK_STAT_MAX.speed, 20, 'Scout has the highest speed (20)');
+});
+
+test('TANK_STAT_MAX.armor equals the highest armor fraction across all tank classes', () => {
+  const expected = Math.max(...TANK_ORDER.map((id) => TankDefs[id].armor));
+  assert.equal(TANK_STAT_MAX.armor, expected);
+  // Siege Tank has armor 0.35 — the roster maximum
+  assert.equal(TANK_STAT_MAX.armor, 0.35, 'Siege Tank has the highest armor (0.35)');
+});
+
+test('TANK_STAT_MAX.damage equals the highest damage across all tank classes', () => {
+  const expected = Math.max(...TANK_ORDER.map((id) => TankDefs[id].damage));
+  assert.equal(TANK_STAT_MAX.damage, expected);
+  // Siege Tank has damage 90 — the roster maximum
+  assert.equal(TANK_STAT_MAX.damage, 90, 'Siege Tank has the highest damage (90)');
+});
+
+test('all TANK_STAT_MAX values are positive', () => {
+  for (const [key, val] of Object.entries(TANK_STAT_MAX)) {
+    assert.ok(val > 0, `TANK_STAT_MAX.${key} must be positive, got ${val}`);
+  }
+});
+
+test('stat bar percentages are in [0, 100] for every tank and stat', () => {
+  for (const id of TANK_ORDER) {
+    const def = TankDefs[id];
+    const checks = [
+      { stat: 'hp',    value: def.hp,    max: TANK_STAT_MAX.hp },
+      { stat: 'speed', value: def.speed, max: TANK_STAT_MAX.speed },
+      { stat: 'armor', value: def.armor, max: TANK_STAT_MAX.armor },
+      { stat: 'damage',value: def.damage,max: TANK_STAT_MAX.damage },
+    ];
+    for (const c of checks) {
+      const pct = Math.round((c.value / c.max) * 100);
+      assert.ok(pct >= 0 && pct <= 100,
+        `${id}.${c.stat} pct=${pct} should be in [0, 100]`);
+    }
+  }
+});
+
+test('the hp leader renders a 100 % bar', () => {
+  const pct = Math.round((TankDefs['siegeTank'].hp / TANK_STAT_MAX.hp) * 100);
+  assert.equal(pct, 100, 'Siege Tank hp bar should be full width');
+});
+
+test('the speed leader renders a 100 % bar', () => {
+  const pct = Math.round((TankDefs['scout'].speed / TANK_STAT_MAX.speed) * 100);
+  assert.equal(pct, 100, 'Scout speed bar should be full width');
 });


### PR DESCRIPTION
## Summary

- Each tank card in the loadout screen now renders four horizontal stat bars (HP, Speed, Armor, Damage) normalised against the maximum value across all 8 tank classes — players can compare tanks at a glance.
- `TANK_STAT_MAX` is computed once at module load from `TankDefs` via an IIFE; no magic constants, no maintenance burden.
- Bar widths range from 4 % (minimum, so even the weakest stat is visible) to 100 % (the class leader).  Selected-card bars use a brighter green; locked-card bars are muted.
- Ability badge moved to its own `.ls-card-ability` element (amber text) to separate it from the league/status line.

## Files changed

- `EDIT: src/ui/LoadoutScreen.js` — `TANK_STAT_MAX` export, `_makeStatBars()` helper, updated `_makeTankCard`
- `EDIT: index.html` — CSS for `.ls-stat-bars / .ls-stat-row / .ls-stat-lbl / .ls-stat-bar / .ls-stat-fill / .ls-stat-val / .ls-card-ability`
- `NEW: tests/TankDefs.test.js` — 13 tests covering TankDefs structure and TANK_STAT_MAX normalisation

## Verification

```
node --test tests/TankDefs.test.js
# tests 13 / pass 13 / fail 0
```

Resolves #56