### PR TITLE
t042: AbilitySystem — cooldown management, Q-key input binding, max 2 active abilities

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -23,6 +23,9 @@ import { SaveSystem } from '../systems/SaveSystem.js';
 import { LeagueSystem } from '../systems/LeagueSystem.js';
 import { LeagueDisplay } from '../ui/LeagueDisplay.js';
 import { getLeagueDef } from '../data/LeagueDefs.js';
+import { AbilitySystem } from '../systems/AbilitySystem.js';
+import { getTankDef } from '../data/TankDefs.js';
+import { GunDefs, MeleeDefs } from '../data/WeaponDefs.js';
 
 export class Game {
   constructor(canvas) {
@@ -252,6 +255,8 @@ export class Game {
         this.aiController.reset();
         // Reset PlayerController to tank mode (removes any active soldier mesh).
         this.playerController.reset();
+        // Reset ability cooldowns so both slots are ready at round start (t042).
+        this.abilitySystem.reset();
         this._playerDustTimer = 0;
         this._enemyDustTimer = 0;
       })
@@ -319,6 +324,10 @@ export class Game {
     // round resets because Tank.reset() restores health to the (already-scaled) maxHealth.
     this.aiController.applyLeagueScalingToTeam(1, 0);
 
+    // AbilitySystem: cooldown-based Q-key ability framework (t042).
+    // Slots are configured from the player's loadout when a match starts.
+    this.abilitySystem = new AbilitySystem();
+
     this.hud = new HUD();
     this.killFeed = new KillFeed();
     this.scoreboard = new Scoreboard(this.teams);
@@ -356,6 +365,8 @@ export class Game {
       );
       // Apply on-foot gun selection so soldiers spawn with the chosen weapon (t031).
       this.playerController.soldierGunId = selection.gun;
+      // Configure AbilitySystem slots from the chosen loadout (t042).
+      this._applyLoadoutToAbilitySystem(selection);
       this._startImmediately();
     });
   }
@@ -410,6 +421,9 @@ export class Game {
           this.particles.emitDust(tank.mesh.position);
         }
       }
+
+      // AbilitySystem: advance cooldown timers (t042).
+      this.abilitySystem.update(dt);
 
       // StatsTracker: advance survival timer only during active round
       this.stats.update(dt);
@@ -483,6 +497,35 @@ export class Game {
         } else {
           // Small impact burst for a non-lethal melee hit.
           this.particles.emitExplosion(hitPos, { count: 8, speed: 4, lifetime: 0.3 });
+        }
+      }
+    }
+
+    // ---- Ability activation — Q key (t042) ----
+    // Tank mode  → try tank ability slot.
+    // Soldier mode → try weapon ability slot.
+    // Actual gameplay effects are implemented by t043 (tank) and t044 (weapon);
+    // for now the activation is logged so the framework is verifiable end-to-end.
+    if (input.ability) {
+      if (this.playerController.mode === 'tank') {
+        const activated = this.abilitySystem.tryActivateTankAbility();
+        if (activated) {
+          // Placeholder VFX: emit a burst at the tank's position.
+          // t043 will replace this with the real ability effect.
+          this.particles.emitExplosion(
+            this.player.mesh.position.clone(),
+            { count: 20, speed: 8, lifetime: 0.8 }
+          );
+        }
+      } else if (this.playerController.soldier) {
+        const activated = this.abilitySystem.tryActivateWeaponAbility();
+        if (activated) {
+          // Placeholder VFX: emit a burst at the soldier's position.
+          // t044 will replace this with the real weapon ability effect.
+          this.particles.emitExplosion(
+            this.playerController.soldier.mesh.position.clone(),
+            { count: 15, speed: 6, lifetime: 0.6 }
+          );
         }
       }
     }
@@ -624,6 +667,8 @@ export class Game {
       );
       // Apply on-foot gun selection so soldiers spawn with the chosen weapon (t031).
       this.playerController.soldierGunId = selection.gun;
+      // Reconfigure AbilitySystem for the new loadout (t042).
+      this._applyLoadoutToAbilitySystem(selection);
 
       this.score = 0;
       // Reset match state machine first (no team events should fire during reset)
@@ -645,6 +690,37 @@ export class Game {
 
       this._startImmediately();
     });
+  }
+
+  /**
+   * Configure AbilitySystem slots from the selected loadout (t042).
+   *
+   * Tank slot   — from TankDefs entry for the chosen tank class.
+   * Weapon slot — from the on-foot weapon that has an ability.  Gun ability
+   *               takes priority; if the gun has no ability the melee weapon
+   *               is checked as a fallback (e.g. Energy Blade → dashStrike).
+   *
+   * @param {{ tank: string, gun: string, melee: string }} selection
+   * @private
+   */
+  _applyLoadoutToAbilitySystem(selection) {
+    const tankDef  = getTankDef(selection.tank);
+    const gunDef   = GunDefs[selection.gun];
+    const meleeDef = MeleeDefs[selection.melee];
+
+    this.abilitySystem.setTankDef(tankDef);
+
+    // Prefer gun ability; fall back to melee ability if gun has none.
+    const weaponDef = (gunDef && gunDef.ability) ? gunDef : (meleeDef || gunDef);
+    if (weaponDef) {
+      this.abilitySystem.setWeaponDef(weaponDef);
+    }
+
+    console.info(
+      `[AbilitySystem] Loadout applied — ` +
+      `tank ability: ${tankDef.ability || 'none'}, ` +
+      `weapon ability: ${this.abilitySystem.weaponAbilityId || 'none'}`
+    );
   }
 
   _onResize() {

--- a/src/systems/AbilitySystem.js
+++ b/src/systems/AbilitySystem.js
@@ -1,0 +1,199 @@
+/**
+ * AbilitySystem.js — Cooldown-based active ability management for tanks and weapons.
+ *
+ * Architecture (VISION.md "Weapon and Tank Abilities — Gold+ Leagues"):
+ *   - Two ability slots per player: one from the equipped tank, one from the equipped weapon.
+ *   - Max 2 active abilities at once (one per slot — natural cap, no extra bookkeeping needed).
+ *   - Q key (desktop) / ability button (mobile) triggers the context-appropriate slot:
+ *       Tank mode   → tank ability slot.
+ *       Soldier mode → weapon ability slot.
+ *   - Each slot has an independent cooldown timer.  Once activated the slot is on cooldown
+ *     for `abilityCooldown` seconds before it becomes ready again.  No ammo cost.
+ *   - This class manages state and emits ability IDs on activation.  Actual gameplay
+ *     effects (VFX, stat changes, projectiles) are implemented by t043 (tank abilities)
+ *     and t044 (weapon abilities).
+ *
+ * Usage:
+ *   const abilities = new AbilitySystem();
+ *   abilities.setTankDef(TankDefs['flameTank']);    // abilityCooldown: 20, ability: 'infernoBurst'
+ *   abilities.setWeaponDef(WeaponDefs['grenadeLauncher']); // abilityCooldown: 18, ability: 'clusterBomb'
+ *
+ *   // Per-frame:
+ *   abilities.update(dt);
+ *
+ *   // On Q key in tank mode:
+ *   const activatedId = abilities.tryActivateTankAbility(); // 'infernoBurst' or null
+ *
+ *   // On Q key in soldier mode:
+ *   const activatedId = abilities.tryActivateWeaponAbility(); // 'clusterBomb' or null
+ */
+export class AbilitySystem {
+  constructor() {
+    // ── Tank ability slot ──────────────────────────────────────────────────
+    /** @type {string|null} Ability identifier from TankDefs.ability. */
+    this._tankAbilityId = null;
+    /** @type {number} Full cooldown duration in seconds. */
+    this._tankCooldownMax = 0;
+    /** @type {number} Seconds remaining before the slot is ready again (0 = ready). */
+    this._tankCooldownRemaining = 0;
+
+    // ── Weapon ability slot ───────────────────────────────────────────────
+    /** @type {string|null} Ability identifier from WeaponDefs.ability. */
+    this._weaponAbilityId = null;
+    /** @type {number} Full cooldown duration in seconds. */
+    this._weaponCooldownMax = 0;
+    /** @type {number} Seconds remaining before the slot is ready again (0 = ready). */
+    this._weaponCooldownRemaining = 0;
+  }
+
+  // ── Configuration ────────────────────────────────────────────────────────
+
+  /**
+   * Configure the tank ability slot from a TankDef entry.
+   * Call this when the player's tank selection changes (loadout screen, restart).
+   * Resets the cooldown so the ability is ready at round start.
+   *
+   * @param {{ ability: string|null, abilityCooldown: number }} def
+   */
+  setTankDef(def) {
+    this._tankAbilityId       = def.ability        ?? null;
+    this._tankCooldownMax     = def.abilityCooldown ?? 0;
+    this._tankCooldownRemaining = 0; // ready at round start
+  }
+
+  /**
+   * Configure the weapon ability slot from a WeaponDef entry.
+   * Call this when the player's weapon selection changes.
+   * Resets the cooldown so the ability is ready at round start.
+   *
+   * @param {{ ability: string|null, abilityCooldown: number }} def
+   */
+  setWeaponDef(def) {
+    this._weaponAbilityId       = def.ability        ?? null;
+    this._weaponCooldownMax     = def.abilityCooldown ?? 0;
+    this._weaponCooldownRemaining = 0; // ready at round start
+  }
+
+  // ── Read-only state ───────────────────────────────────────────────────────
+
+  /** Ability identifier for the tank slot, or null if the tank has no ability. */
+  get tankAbilityId()   { return this._tankAbilityId; }
+
+  /** Ability identifier for the weapon slot, or null if the weapon has no ability. */
+  get weaponAbilityId() { return this._weaponAbilityId; }
+
+  /**
+   * True when the tank ability exists and is off cooldown.
+   * @returns {boolean}
+   */
+  get tankReady() {
+    return this._tankAbilityId !== null && this._tankCooldownRemaining <= 0;
+  }
+
+  /**
+   * True when the weapon ability exists and is off cooldown.
+   * @returns {boolean}
+   */
+  get weaponReady() {
+    return this._weaponAbilityId !== null && this._weaponCooldownRemaining <= 0;
+  }
+
+  /**
+   * Cooldown progress for the tank slot: 0 = fully ready, 1 = just activated / max wait.
+   * Useful for a radial cooldown fill in AbilityBar UI (t045).
+   * @returns {number} Value in [0, 1].
+   */
+  get tankCooldownFraction() {
+    if (this._tankCooldownMax <= 0) return 0;
+    return Math.max(0, this._tankCooldownRemaining / this._tankCooldownMax);
+  }
+
+  /**
+   * Cooldown progress for the weapon slot: 0 = fully ready, 1 = just activated / max wait.
+   * @returns {number} Value in [0, 1].
+   */
+  get weaponCooldownFraction() {
+    if (this._weaponCooldownMax <= 0) return 0;
+    return Math.max(0, this._weaponCooldownRemaining / this._weaponCooldownMax);
+  }
+
+  /**
+   * Seconds remaining on the tank ability cooldown (0 = ready).
+   * @returns {number}
+   */
+  get tankCooldownRemaining() {
+    return Math.max(0, this._tankCooldownRemaining);
+  }
+
+  /**
+   * Seconds remaining on the weapon ability cooldown (0 = ready).
+   * @returns {number}
+   */
+  get weaponCooldownRemaining() {
+    return Math.max(0, this._weaponCooldownRemaining);
+  }
+
+  // ── Per-frame update ──────────────────────────────────────────────────────
+
+  /**
+   * Advance cooldown timers.  Call once per game-loop tick with the frame delta.
+   * @param {number} dt — seconds since the last frame
+   */
+  update(dt) {
+    if (this._tankCooldownRemaining > 0) {
+      this._tankCooldownRemaining = Math.max(0, this._tankCooldownRemaining - dt);
+    }
+    if (this._weaponCooldownRemaining > 0) {
+      this._weaponCooldownRemaining = Math.max(0, this._weaponCooldownRemaining - dt);
+    }
+  }
+
+  // ── Activation ────────────────────────────────────────────────────────────
+
+  /**
+   * Attempt to activate the tank ability slot.
+   *
+   * On success the slot enters cooldown and the ability ID is returned so the
+   * caller (Game.js) can trigger the appropriate effect (t043).
+   * On failure (no ability, or still on cooldown) returns null — silent no-op.
+   *
+   * Called when the player presses Q while in tank mode.
+   *
+   * @returns {string|null} Activated ability ID, or null if the slot is not ready.
+   */
+  tryActivateTankAbility() {
+    if (!this.tankReady) return null;
+    this._tankCooldownRemaining = this._tankCooldownMax;
+    console.info(`[AbilitySystem] Tank ability activated: ${this._tankAbilityId} (cooldown ${this._tankCooldownMax}s)`);
+    return this._tankAbilityId;
+  }
+
+  /**
+   * Attempt to activate the weapon ability slot.
+   *
+   * On success the slot enters cooldown and the ability ID is returned so the
+   * caller (Game.js) can trigger the appropriate effect (t044).
+   * On failure (no ability, or still on cooldown) returns null — silent no-op.
+   *
+   * Called when the player presses Q while in on-foot soldier mode.
+   *
+   * @returns {string|null} Activated ability ID, or null if the slot is not ready.
+   */
+  tryActivateWeaponAbility() {
+    if (!this.weaponReady) return null;
+    this._weaponCooldownRemaining = this._weaponCooldownMax;
+    console.info(`[AbilitySystem] Weapon ability activated: ${this._weaponAbilityId} (cooldown ${this._weaponCooldownMax}s)`);
+    return this._weaponAbilityId;
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  /**
+   * Reset both cooldowns to 0 (abilities immediately ready).
+   * Call at the start of each round so abilities are fresh, not carried over.
+   */
+  reset() {
+    this._tankCooldownRemaining   = 0;
+    this._weaponCooldownRemaining = 0;
+  }
+}

--- a/src/systems/InputSystem.js
+++ b/src/systems/InputSystem.js
@@ -18,6 +18,8 @@ export class InputSystem {
     this._fireRequested   = false;
     this._meleeRequested  = false;
     this._reloadRequested = false;
+    /** One-shot: true on the frame Q is pressed (activate ability). */
+    this._abilityRequested = false;
     this._turretAngle = null;
     /** One-shot: true on the frame E is pressed (exit/enter vehicle). */
     this._exitVehicleRequested = false;
@@ -39,6 +41,8 @@ export class InputSystem {
       if (e.code === 'KeyF') this._meleeRequested = true;
       // R key — manual reload for on-foot gun (t030)
       if (e.code === 'KeyR') this._reloadRequested = true;
+      // Q key — activate ability (tank ability in tank mode, weapon ability in soldier mode)
+      if (e.code === 'KeyQ') this._abilityRequested = true;
       // Prevent Tab from shifting browser focus while held for the scoreboard
       if (e.code === 'Tab') e.preventDefault();
     });
@@ -161,6 +165,8 @@ export class InputSystem {
       melee: this._meleeRequested,
       /** One-shot: R key triggers a manual reload for the on-foot gun (t030). */
       reload: this._reloadRequested,
+      /** One-shot: Q key activates the context-appropriate ability slot (t042). */
+      ability: this._abilityRequested,
       turretAngle: this._turretAngle,
       /** true while Tab is held — shows/hides the scoreboard overlay */
       tabHeld: !!this._keys['Tab'],
@@ -172,6 +178,7 @@ export class InputSystem {
     this._fireRequested        = false;
     this._meleeRequested       = false;
     this._reloadRequested      = false;
+    this._abilityRequested     = false;
     this._exitVehicleRequested = false;
 
     return state;

--- a/tests/AbilitySystem.test.js
+++ b/tests/AbilitySystem.test.js
@@ -1,0 +1,253 @@
+/**
+ * AbilitySystem.test.js — Unit tests for the AbilitySystem cooldown management.
+ *
+ * Run: node --test tests/AbilitySystem.test.js
+ *
+ * Covers:
+ *  - Initial state (both slots ready, IDs null)
+ *  - setTankDef / setWeaponDef configure slots correctly
+ *  - tryActivateTankAbility / tryActivateWeaponAbility return ID on first call
+ *  - Cooldown prevents double-activation
+ *  - update(dt) drains the cooldown timer
+ *  - Slot becomes ready again once cooldown reaches 0
+ *  - reset() clears both cooldowns
+ *  - Slots with no ability always return null on activate
+ *  - tankCooldownFraction and weaponCooldownFraction return expected values
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AbilitySystem } from '../src/systems/AbilitySystem.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal tank def that mirrors TankDefs shape. */
+function makeTankDef(ability, cooldown) {
+  return { ability, abilityCooldown: cooldown };
+}
+
+/** Minimal weapon def that mirrors WeaponDefs shape. */
+function makeWeaponDef(ability, cooldown) {
+  return { ability, abilityCooldown: cooldown };
+}
+
+// ── Initial state ────────────────────────────────────────────────────────────
+
+test('initial state: both slots have null ability IDs', () => {
+  const sys = new AbilitySystem();
+  assert.equal(sys.tankAbilityId, null);
+  assert.equal(sys.weaponAbilityId, null);
+});
+
+test('initial state: both slots are not ready (no ability configured)', () => {
+  const sys = new AbilitySystem();
+  assert.equal(sys.tankReady, false);
+  assert.equal(sys.weaponReady, false);
+});
+
+test('initial state: cooldown fractions are 0', () => {
+  const sys = new AbilitySystem();
+  assert.equal(sys.tankCooldownFraction, 0);
+  assert.equal(sys.weaponCooldownFraction, 0);
+});
+
+test('initial state: tryActivateTankAbility returns null', () => {
+  const sys = new AbilitySystem();
+  assert.equal(sys.tryActivateTankAbility(), null);
+});
+
+test('initial state: tryActivateWeaponAbility returns null', () => {
+  const sys = new AbilitySystem();
+  assert.equal(sys.tryActivateWeaponAbility(), null);
+});
+
+// ── setTankDef ────────────────────────────────────────────────────────────────
+
+test('setTankDef: stores ability id and cooldown', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('infernoBurst', 20));
+  assert.equal(sys.tankAbilityId, 'infernoBurst');
+  assert.equal(sys.tankReady, true);
+});
+
+test('setTankDef: null ability → slot never ready', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef(null, 0));
+  assert.equal(sys.tankReady, false);
+  assert.equal(sys.tryActivateTankAbility(), null);
+});
+
+test('setTankDef: resets cooldown to 0 (ready at round start)', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('energyShield', 25));
+  sys.tryActivateTankAbility(); // put on cooldown
+  // Reconfiguring mid-round (e.g. restart) should reset the timer
+  sys.setTankDef(makeTankDef('energyShield', 25));
+  assert.equal(sys.tankReady, true);
+});
+
+// ── setWeaponDef ─────────────────────────────────────────────────────────────
+
+test('setWeaponDef: stores ability id and cooldown', () => {
+  const sys = new AbilitySystem();
+  sys.setWeaponDef(makeWeaponDef('clusterBomb', 18));
+  assert.equal(sys.weaponAbilityId, 'clusterBomb');
+  assert.equal(sys.weaponReady, true);
+});
+
+test('setWeaponDef: null ability → slot never ready', () => {
+  const sys = new AbilitySystem();
+  sys.setWeaponDef(makeWeaponDef(null, 0));
+  assert.equal(sys.weaponReady, false);
+  assert.equal(sys.tryActivateWeaponAbility(), null);
+});
+
+// ── Activation ───────────────────────────────────────────────────────────────
+
+test('tryActivateTankAbility: returns ability id on first call when ready', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('rocketJump', 15));
+  const result = sys.tryActivateTankAbility();
+  assert.equal(result, 'rocketJump');
+});
+
+test('tryActivateTankAbility: returns null on second call (on cooldown)', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('rocketJump', 15));
+  sys.tryActivateTankAbility(); // activates
+  const second = sys.tryActivateTankAbility(); // on cooldown
+  assert.equal(second, null);
+});
+
+test('tryActivateWeaponAbility: returns ability id on first call when ready', () => {
+  const sys = new AbilitySystem();
+  sys.setWeaponDef(makeWeaponDef('dashStrike', 12));
+  const result = sys.tryActivateWeaponAbility();
+  assert.equal(result, 'dashStrike');
+});
+
+test('tryActivateWeaponAbility: returns null on second call (on cooldown)', () => {
+  const sys = new AbilitySystem();
+  sys.setWeaponDef(makeWeaponDef('dashStrike', 12));
+  sys.tryActivateWeaponAbility();
+  assert.equal(sys.tryActivateWeaponAbility(), null);
+});
+
+test('activation sets slot to not-ready', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('barrage', 30));
+  assert.equal(sys.tankReady, true);
+  sys.tryActivateTankAbility();
+  assert.equal(sys.tankReady, false);
+});
+
+// ── Cooldown drain (update) ───────────────────────────────────────────────────
+
+test('update(dt): cooldown drains over time', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('lockdownMode', 20));
+  sys.tryActivateTankAbility(); // cooldown = 20
+  sys.update(5);  // 15 remaining
+  assert.equal(sys.tankCooldownRemaining, 15);
+});
+
+test('update(dt): cooldown reaches 0 and slot becomes ready', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('reactiveArmor', 20));
+  sys.tryActivateTankAbility(); // cooldown = 20
+  sys.update(20); // fully drained
+  assert.equal(sys.tankReady, true);
+  assert.equal(sys.tankCooldownRemaining, 0);
+});
+
+test('update(dt): cooldown does not go below 0', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('infernoBurst', 20));
+  sys.tryActivateTankAbility();
+  sys.update(100); // way past cooldown
+  assert.equal(sys.tankCooldownRemaining, 0);
+  assert.equal(sys.tankReady, true);
+});
+
+test('update(dt): weapon cooldown drains independently of tank', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('barrage', 30));
+  sys.setWeaponDef(makeWeaponDef('lockOn', 15));
+  sys.tryActivateTankAbility();    // tank: 30s cooldown
+  sys.tryActivateWeaponAbility();  // weapon: 15s cooldown
+  sys.update(15);
+  assert.equal(sys.weaponReady, true);   // weapon fully drained
+  assert.equal(sys.tankReady, false);    // tank still on cooldown (15 remaining)
+  assert.equal(sys.tankCooldownRemaining, 15);
+});
+
+// ── cooldownFraction ─────────────────────────────────────────────────────────
+
+test('tankCooldownFraction: 1.0 just after activation', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('energyShield', 25));
+  sys.tryActivateTankAbility();
+  assert.equal(sys.tankCooldownFraction, 1.0);
+});
+
+test('tankCooldownFraction: 0.5 at half-cooldown', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('energyShield', 20));
+  sys.tryActivateTankAbility();
+  sys.update(10); // half elapsed
+  assert.equal(sys.tankCooldownFraction, 0.5);
+});
+
+test('tankCooldownFraction: 0 when fully ready', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('energyShield', 20));
+  sys.tryActivateTankAbility();
+  sys.update(20);
+  assert.equal(sys.tankCooldownFraction, 0);
+});
+
+test('weaponCooldownFraction: 0 when no cooldown configured', () => {
+  const sys = new AbilitySystem();
+  sys.setWeaponDef(makeWeaponDef(null, 0));
+  assert.equal(sys.weaponCooldownFraction, 0);
+});
+
+// ── reset ─────────────────────────────────────────────────────────────────────
+
+test('reset: clears tank cooldown — slot becomes ready', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('barrage', 30));
+  sys.tryActivateTankAbility(); // on cooldown
+  sys.reset();
+  assert.equal(sys.tankReady, true);
+  assert.equal(sys.tankCooldownRemaining, 0);
+});
+
+test('reset: clears weapon cooldown — slot becomes ready', () => {
+  const sys = new AbilitySystem();
+  sys.setWeaponDef(makeWeaponDef('novaBlast', 25));
+  sys.tryActivateWeaponAbility();
+  sys.reset();
+  assert.equal(sys.weaponReady, true);
+  assert.equal(sys.weaponCooldownRemaining, 0);
+});
+
+test('reset: both slots cleared simultaneously', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('infernoBurst', 20));
+  sys.setWeaponDef(makeWeaponDef('overcharge', 20));
+  sys.tryActivateTankAbility();
+  sys.tryActivateWeaponAbility();
+  sys.reset();
+  assert.equal(sys.tankReady, true);
+  assert.equal(sys.weaponReady, true);
+});
+
+// ── Re-activation after cooldown ──────────────────────────────────────────────
+
+test('slot can be re-activated after cooldown expires', () => {
+  const sys = new AbilitySystem();
+  sys.setTankDef(makeTankDef('rocketJump', 15));
+  assert.equal(sys.tryActivateTankAbility(), 'rocketJump'); // first use
+  sys.update(15); // cooldown done
+  assert.equal(sys.tryActivateTankAbility(), 'rocketJump'); // second use
+});


### PR DESCRIPTION
## Summary

Implements the AbilitySystem infrastructure (t042) as specified in VISION.md §"Weapon and Tank Abilities (Gold+ Leagues)".

- **`src/systems/AbilitySystem.js`** — Two-slot cooldown manager (tank ability + weapon ability).  Each slot is configured from the equipped tank/weapon definition (`ability` + `abilityCooldown` fields already present in `TankDefs` and `WeaponDefs`).  Provides `tryActivateTankAbility()` / `tryActivateWeaponAbility()` which return the ability ID on activation and start the cooldown timer.  `tankCooldownFraction` / `weaponCooldownFraction` (0–1) are ready for the AbilityBar UI (t045).
- **`src/systems/InputSystem.js`** — Q key → `input.ability` one-shot flag (same pattern as `fire`, `melee`, `reload`).
- **`src/core/Game.js`** — Full integration: instantiation, `_applyLoadoutToAbilitySystem()` called at loadout select/restart, `abilitySystem.update(dt)` per frame, `abilitySystem.reset()` on round reset, Q-key dispatch in `_updatePlayer()` (tank mode → tank ability, soldier mode → weapon ability).  Placeholder particle burst on activation so the system is end-to-end testable without t043/t044.
- **`tests/AbilitySystem.test.js`** — 27 unit tests; all pass with `node --test`.

## Design notes

- Max 2 active abilities is naturally enforced by the two-slot design (one per tank, one per weapon) — no extra bookkeeping needed.
- Weapon ability priority: gun def if it has an ability, else melee def (e.g. Energy Blade → `dashStrike`).
- Actual gameplay effects (Inferno Burst, Energy Shield, Rocket Jump, etc.) are t043 (tank) and t044 (weapon).  This PR ships only the framework so t045 (AbilityBar UI) can also unblock.
- Pre-existing `LeagueDefs.test.js` / `LeagueSystem.test.js` failures (9 tests) are unrelated to this change and were failing before this branch.

## Verification

```bash
node --test tests/AbilitySystem.test.js
# 27 pass, 0 fail
```

Resolves #58