### PR TITLE
t043: Tank abilities — Inferno Burst, Energy Shield, Rocket Jump, Lockdown Mode, Barrage, Reactive Armor

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -25,6 +25,7 @@ import { SaveSystem } from '../systems/SaveSystem.js';
 import { LeagueSystem } from '../systems/LeagueSystem.js';
 import { LeagueDisplay } from '../ui/LeagueDisplay.js';
 import { getLeagueDef } from '../data/LeagueDefs.js';
+import { TankAbilityEffects } from '../systems/TankAbilityEffects.js';
 import { getTankDef } from '../data/TankDefs.js';
 import { GunDefs, MeleeDefs } from '../data/WeaponDefs.js';
 import { Projectile } from '../entities/Projectile.js';
@@ -269,6 +270,9 @@ export class Game {
         this.playerController.reset();
         // Reset ability cooldowns so both slots are ready at round start (t042).
         this.abilitySystem.reset();
+        // Cancel active ability effects (shield, jump arc, lockdown) so they
+        // don't carry into the next round. Tank.reset() will clear flags after (t043).
+        this.tankAbilityEffects.reset();
         this._playerDustTimer = 0;
         this._enemyDustTimer = 0;
       })
@@ -339,6 +343,15 @@ export class Game {
     // AbilitySystem: cooldown-based Q-key ability framework (t042/t044).
     // Slots are configured from the player's loadout when a match starts.
     this.abilitySystem = new AbilitySystem();
+
+    // TankAbilityEffects: actual gameplay effects for the six tank abilities (t043).
+    // Receives the ability ID from AbilitySystem.tryActivateTankAbility() and
+    // executes the corresponding effect (damage, shield, jump, lockdown, etc.).
+    this.tankAbilityEffects = new TankAbilityEffects({
+      terrain:          this.terrain,
+      particles:        this.particles,
+      projectileSystem: this.projectiles,
+    });
 
     this.hud = new HUD();
     this.killFeed = new KillFeed();
@@ -457,6 +470,10 @@ export class Game {
       // AbilitySystem: advance cooldown timers (t042).
       this.abilitySystem.update(dt);
 
+      // TankAbilityEffects: advance timed effects (jump arcs, shield/lockdown timers,
+      // barrage queues) and apply AoE on landing (t043).
+      this.tankAbilityEffects.update(dt, this.teams.getAllLivingTanks());
+
       // StatsTracker: advance survival timer only during active round
       this.stats.update(dt);
     }
@@ -563,19 +580,17 @@ export class Game {
       }
     }
 
-    // ---- Ability activation — Q key (t042/t044) ----
-    // Tank mode   → try tank ability slot (effects: t043).
-    // Soldier mode → try weapon ability slot (effects: t044, implemented below).
+    // ---- Ability activation — Q key (t042/t043/t044) ----
+    // Tank mode   → tank ability slot (cooldown managed by AbilitySystem,
+    //               effect executed by TankAbilityEffects — t043).
+    // Soldier mode → weapon ability slot (effects: t044, implemented below).
     if (input.ability) {
       if (this.playerController.mode === 'tank') {
         const activated = this.abilitySystem.tryActivateTankAbility();
         if (activated) {
-          // Placeholder VFX: emit a burst at the tank's position.
-          // t043 will replace this with the real tank ability effect.
-          this.particles.emitExplosion(
-            this.player.mesh.position.clone(),
-            { count: 20, speed: 8, lifetime: 0.8 }
-          );
+          // Execute the real gameplay effect (t043).
+          const allTanks = this.teams.getAllLivingTanks();
+          this.tankAbilityEffects.execute(activated, this.player, allTanks);
         }
       } else if (this.playerController.soldier) {
         const activated = this.abilitySystem.tryActivateWeaponAbility();
@@ -1049,6 +1064,8 @@ export class Game {
       this.stats.reset();
       // Reset PlayerController to tank mode (clears any active soldier mesh)
       this.playerController.reset();
+      // Cancel any active ability effects before tanks reset their flag fields (t043).
+      this.tankAbilityEffects.reset();
       // Reset field entities
       this.teams.reset();
       this.projectiles.reset();

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -301,25 +301,35 @@ export class PlayerController {
     const moveSpeed = tank.speed;
     const turnSpeed = tank.turnRate;
 
-    const moving = input.forward || input.backward;
+    // Lockdown Mode (t043): suppress all hull movement while active.
+    // Turret can still track the target; firing continues at doubled rate.
+    const locked = tank.isLockedDown;
 
-    if (input.forward)  tank.mesh.translateZ(-moveSpeed * dt);
-    if (input.backward) tank.mesh.translateZ(moveSpeed * 0.6 * dt);
-    if (input.left)     tank.mesh.rotation.y += turnSpeed * dt;
-    if (input.right)    tank.mesh.rotation.y -= turnSpeed * dt;
+    const moving = !locked && (input.forward || input.backward);
+
+    if (!locked) {
+      if (input.forward)  tank.mesh.translateZ(-moveSpeed * dt);
+      if (input.backward) tank.mesh.translateZ(moveSpeed * 0.6 * dt);
+      if (input.left)     tank.mesh.rotation.y += turnSpeed * dt;
+      if (input.right)    tank.mesh.rotation.y -= turnSpeed * dt;
+    }
 
     if (input.turretAngle !== null) {
       tank.setTurretAngle(input.turretAngle);
     }
 
-    // Terrain follow + arena clamp
+    // Terrain follow + arena clamp.
+    // Skip terrain-follow while jumping — TankAbilityEffects drives the Y
+    // coordinate along the parabolic arc (t043 rocketJump).
     const pos = tank.mesh.position;
-    pos.y = terrain.getHeightAt(pos.x, pos.z);
+    if (!tank.isJumping) {
+      pos.y = terrain.getHeightAt(pos.x, pos.z);
+    }
     pos.x = THREE.MathUtils.clamp(pos.x, -ARENA_BOUND, ARENA_BOUND);
     pos.z = THREE.MathUtils.clamp(pos.z, -ARENA_BOUND, ARENA_BOUND);
 
-    // E key — voluntary exit
-    if (input.exitVehicle) {
+    // E key — voluntary exit (not permitted during lockdown or jump)
+    if (input.exitVehicle && !locked && !tank.isJumping) {
       this.exitTank();
     }
 

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -149,6 +149,40 @@ export class Tank {
     this.kills = 0;
     this.damageDealt = 0;
 
+    // ---------------------------------------------------------------------------
+    // Ability state — written and managed by TankAbilityEffects (t043).
+    // Fields are initialised here so Tank instances are always shape-consistent.
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Energy Shield: when true, all incoming damage is absorbed (returns 0).
+     * TankAbilityEffects sets this on activation; clears after the duration.
+     * @type {boolean}
+     */
+    this.shielded = false;
+
+    /**
+     * Rocket Jump: while true, PlayerController and AIController skip terrain-
+     * follow so TankAbilityEffects can drive the Y coordinate along the arc.
+     * @type {boolean}
+     */
+    this.isJumping = false;
+
+    /**
+     * Lockdown Mode: while true, hull movement is suppressed.
+     * TankAbilityEffects clears this when the duration expires.
+     * @type {boolean}
+     */
+    this.isLockedDown = false;
+
+    /**
+     * Reactive Armor: number of hit-reduction charges remaining.
+     * Each incoming hit decrements this by 1 and deals half damage instead.
+     * TankAbilityEffects sets this to REACTIVE_ARMOR_CHARGES on activation.
+     * @type {number}
+     */
+    this.reactiveArmorCharges = 0;
+
     // Use class-defined colors as defaults; explicit overrides take priority.
     // _applyClassDef() has already stored this.colorBody / this.colorTurret.
     const palette = {
@@ -480,13 +514,32 @@ export class Tank {
   }
 
   /**
-   * Apply incoming damage, reduced by this tank's armor fraction.
+   * Apply incoming damage, respecting active ability protections and armor.
    *
-   * @param {number} amount — raw incoming damage (before armor reduction)
-   * @returns {number} — actual HP removed (post-armor, clamped to remaining HP)
+   * Processing order (applied in sequence):
+   *   1. Energy Shield  — absorbs ALL damage; returns 0 immediately.
+   *   2. Reactive Armor — halves the remaining damage per charge consumed.
+   *   3. Class Armor    — reduces by armor fraction (0–0.35).
+   *
+   * Returns the actual HP removed after all reductions.
+   *
+   * @param {number} amount — raw incoming damage (before all reductions)
+   * @returns {number} actual damage applied to health (0 if shielded)
    */
   takeDamage(amount) {
-    const reduced = amount * (1 - this.armor);
+    // 1. Energy Shield: absorb everything.
+    if (this.shielded) return 0;
+
+    let dmg = amount;
+
+    // 2. Reactive Armor: 50 % reduction for each charge.
+    if (this.reactiveArmorCharges > 0) {
+      dmg = dmg * 0.5;
+      this.reactiveArmorCharges--;
+    }
+
+    // 3. Class Armor: structural damage reduction.
+    const reduced = dmg * (1 - this.armor);
     const actual  = Math.min(reduced, this.health);
     this.health   = Math.max(0, this.health - reduced);
     return actual;
@@ -524,6 +577,15 @@ export class Tank {
     this.fireCooldown = 0;
     this.kills = 0;
     this.damageDealt = 0;
+
+    // Clear ability state so each round starts clean.
+    // TankAbilityEffects.reset() cancels any in-flight timed effects before
+    // Tank.reset() runs, so it is safe to zero these flags here.
+    this.shielded             = false;
+    this.isJumping            = false;
+    this.isLockedDown         = false;
+    this.reactiveArmorCharges = 0;
+
     // Reset turret to face forward (local rotation.y = 0).
     // Class stats (speed, armor, damage, etc.) and league-scaled maxHealth are
     // intentionally NOT reset here — they persist across rounds per VISION.md.

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -514,15 +514,23 @@ export class AIController {
     // Normalize to [-π, π]
     while (diff > Math.PI) diff -= Math.PI * 2;
     while (diff < -Math.PI) diff += Math.PI * 2;
-    tank.mesh.rotation.y += Math.sign(diff) * Math.min(Math.abs(diff), turnSpeed * dt);
 
-    // --- Advance if outside preferred fire distance ---
-    if (dist > stopDist) {
-      tank.mesh.translateZ(-moveSpeed * dt);
+    // Lockdown Mode (t043): skip all hull movement and turning while active.
+    // The tank remains stationary but still aims and fires at doubled rate.
+    if (!tank.isLockedDown) {
+      tank.mesh.rotation.y += Math.sign(diff) * Math.min(Math.abs(diff), turnSpeed * dt);
+
+      // --- Advance if outside preferred fire distance ---
+      if (dist > stopDist) {
+        tank.mesh.translateZ(-moveSpeed * dt);
+      }
     }
 
     // --- Keep on terrain ---
-    pos.y = this.terrain.getHeightAt(pos.x, pos.z);
+    // Skip terrain-follow while jumping — TankAbilityEffects drives Y (t043).
+    if (!tank.isJumping) {
+      pos.y = this.terrain.getHeightAt(pos.x, pos.z);
+    }
 
     // --- Clamp to arena ---
     pos.x = THREE.MathUtils.clamp(pos.x, -ARENA_BOUND, ARENA_BOUND);

--- a/src/systems/TankAbilityEffects.js
+++ b/src/systems/TankAbilityEffects.js
@@ -1,0 +1,492 @@
+/**
+ * TankAbilityEffects.js — Gameplay effects for the six tank abilities (t043).
+ *
+ * AbilitySystem (t042) manages cooldowns and emits ability IDs when the player
+ * presses Q.  This module converts those IDs into actual game-state changes:
+ * damage bursts, timed invincibility, parabolic jumps, fire-rate boosts, etc.
+ *
+ * Architecture
+ * ────────────
+ *  Game.js creates ONE TankAbilityEffects instance and calls:
+ *    effects.execute(abilityId, playerTank, allLivingTanks)   — on Q press
+ *    effects.update(dt, allLivingTanks)                       — every game frame
+ *    effects.reset()                                           — on round reset
+ *
+ * Tank-level flags written by this system (initialised on Tank, see Tank.js):
+ *   tank.shielded             {boolean} — takeDamage() absorbs all hits
+ *   tank.isJumping            {boolean} — PlayerController/AIController skip
+ *                                         terrain-follow while this is set
+ *   tank.isLockedDown         {boolean} — movement suppressed for lockdown duration
+ *   tank._jumpBaseY           {number}  — ground Y at jump origin (internal)
+ *   tank._preLockdownFireRate {number}  — saved fireRate (internal, restored on end)
+ *   tank.reactiveArmorCharges {number}  — hits remaining at half damage
+ *
+ * Ability specs (VISION.md §"Abilities"):
+ *   infernoBurst  — 360° flame ring, ≤40 dmg to all enemies within 15 units
+ *   energyShield  — absorb ALL incoming damage for 5 s
+ *   rocketJump    — parabolic arc 12 units tall over 2 s; AoE 60 dmg / 12-unit splash on land
+ *   lockdownMode  — stationary 8 s, fireRate doubled while active
+ *   barrage       — 5 shells 0.2 s apart, bypasses normal fire cooldown
+ *   reactiveArmor — next 3 hits deal 50 % reduced damage
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Ability tuning constants
+// ---------------------------------------------------------------------------
+
+const INFERNO_BURST_RADIUS  = 15;   // world units, enemy tanks caught in ring
+const INFERNO_BURST_DAMAGE  = 40;   // max damage (falls off linearly toward edge)
+
+const ENERGY_SHIELD_DURATION = 5;   // seconds
+
+const ROCKET_JUMP_HEIGHT     = 12;  // peak altitude above launch point (world units)
+const ROCKET_JUMP_DURATION   = 2.0; // total flight time (seconds)
+const ROCKET_JUMP_SPLASH     = 12;  // AoE radius on landing (world units)
+const ROCKET_JUMP_DAMAGE     = 60;  // max landing damage (falls off toward edge)
+
+const LOCKDOWN_DURATION        = 8;   // seconds locked in place
+const LOCKDOWN_FIRE_RATE_MULT  = 2;   // fire rate multiplier (higher = faster cadence)
+
+const BARRAGE_SHOTS    = 5;
+const BARRAGE_INTERVAL = 0.2;   // seconds between consecutive barrage shells
+
+export const REACTIVE_ARMOR_CHARGES   = 3;    // hit-reduction charges granted
+export const REACTIVE_ARMOR_REDUCTION = 0.50; // 50 % of incoming damage is absorbed
+
+// ---------------------------------------------------------------------------
+// TankAbilityEffects
+// ---------------------------------------------------------------------------
+
+export class TankAbilityEffects {
+  /**
+   * @param {object} opts
+   * @param {import('../entities/Terrain.js').Terrain}             opts.terrain
+   * @param {import('./ParticleSystem.js').ParticleSystem}         opts.particles
+   * @param {import('./ProjectileSystem.js').ProjectileSystem}     opts.projectileSystem
+   */
+  constructor({ terrain, particles, projectileSystem }) {
+    this.terrain          = terrain;
+    this.particles        = particles;
+    this.projectileSystem = projectileSystem;
+
+    /**
+     * Timed effects in flight: energyShield, lockdownMode, rocketJump.
+     * @type {Array<{type: string, tank: object, timeLeft: number, maxTime?: number}>}
+     */
+    this._activeEffects = [];
+
+    /**
+     * Queued barrage shots waiting to fire.
+     * @type {Array<{tank: object, shotsLeft: number, timer: number}>}
+     */
+    this._barrageQueues = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Execute the named ability for the given tank.
+   * Called by Game.js immediately after AbilitySystem.tryActivateTankAbility()
+   * returns a non-null ID.
+   *
+   * @param {string}   abilityId  — ability identifier from TankDefs.ability
+   * @param {object}   tank       — the activating player Tank instance
+   * @param {object[]} allTanks   — all LIVING Tank instances (both teams)
+   * @returns {boolean} true if the effect was successfully started
+   */
+  execute(abilityId, tank, allTanks) {
+    switch (abilityId) {
+      case 'infernoBurst':  return this._infernoBurst(tank, allTanks);
+      case 'energyShield':  return this._energyShield(tank);
+      case 'rocketJump':    return this._rocketJump(tank);
+      case 'lockdownMode':  return this._lockdownMode(tank);
+      case 'barrage':       return this._barrage(tank);
+      case 'reactiveArmor': return this._reactiveArmor(tank);
+      default:
+        console.warn(`[TankAbilityEffects] Unknown ability: "${abilityId}"`);
+        return false;
+    }
+  }
+
+  /**
+   * Per-frame update: advance timed effects and flush barrage queues.
+   *
+   * @param {number}   dt       — seconds since last frame
+   * @param {object[]} allTanks — all living tanks (for AoE resolution)
+   */
+  update(dt, allTanks) {
+    // Advance timed effects (iterate backward so splice is safe)
+    for (let i = this._activeEffects.length - 1; i >= 0; i--) {
+      const effect = this._activeEffects[i];
+      effect.timeLeft -= dt;
+
+      if (effect.type === 'rocketJump') {
+        this._tickRocketJump(effect, dt);
+      }
+
+      if (effect.timeLeft <= 0) {
+        this._endEffect(effect, allTanks);
+        this._activeEffects.splice(i, 1);
+      }
+    }
+
+    // Flush barrage shot queues
+    for (let i = this._barrageQueues.length - 1; i >= 0; i--) {
+      const q = this._barrageQueues[i];
+      q.timer -= dt;
+      if (q.timer <= 0 && q.shotsLeft > 0) {
+        this._fireBarrageShot(q.tank);
+        q.shotsLeft--;
+        q.timer = BARRAGE_INTERVAL;
+      }
+      if (q.shotsLeft <= 0) {
+        this._barrageQueues.splice(i, 1);
+      }
+    }
+  }
+
+  /**
+   * Cancel all active effects and clear queues.
+   * Call at round reset; Tank.reset() clears the flag fields independently.
+   */
+  reset() {
+    for (const effect of this._activeEffects) {
+      this._cancelEffect(effect);
+    }
+    this._activeEffects.length = 0;
+    this._barrageQueues.length = 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ability implementations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Inferno Burst (Flame Tank)
+   *
+   * 360° flame ring radiating outward from the tank hull.  Damage falls off
+   * linearly: full INFERNO_BURST_DAMAGE at the tank's position, half at the
+   * edge of INFERNO_BURST_RADIUS.  Friendly fire disabled.
+   * @private
+   */
+  _infernoBurst(tank, allTanks) {
+    const pos = tank.mesh.position.clone();
+
+    // Ring-of-fire VFX: 16 bursts evenly spaced around the hull
+    const STEPS = 16;
+    for (let step = 0; step < STEPS; step++) {
+      const angle = (step / STEPS) * Math.PI * 2;
+      const offset = new THREE.Vector3(
+        Math.cos(angle) * 3, 0.5, Math.sin(angle) * 3
+      );
+      this.particles.emitExplosion(pos.clone().add(offset), {
+        count:    6,
+        speed:    5,
+        lifetime: 0.8,
+      });
+    }
+
+    // Central burst
+    this.particles.emitExplosion(pos, { count: 20, speed: 8, lifetime: 1.0 });
+
+    // Damage all enemies in radius (linear falloff)
+    let hitCount = 0;
+    for (const target of allTanks) {
+      if (target === tank || target.teamId === tank.teamId) continue;
+      const dist = target.mesh.position.distanceTo(pos);
+      if (dist <= INFERNO_BURST_RADIUS) {
+        const falloff = 1 - dist / INFERNO_BURST_RADIUS;
+        const dmg = Math.round(INFERNO_BURST_DAMAGE * (0.5 + 0.5 * falloff));
+        target.takeDamage(dmg);
+        hitCount++;
+      }
+    }
+
+    console.info(`[TankAbilityEffects] infernoBurst — ${hitCount} targets hit.`);
+    return true;
+  }
+
+  /**
+   * Energy Shield (Shield Tank)
+   *
+   * Sets tank.shielded = true.  Tank.takeDamage() returns 0 while this flag is
+   * set.  Clears automatically after ENERGY_SHIELD_DURATION seconds.
+   * Does NOT stack: a second activation while the shield is already up fails.
+   * @private
+   */
+  _energyShield(tank) {
+    if (tank.shielded) return false;
+
+    tank.shielded = true;
+
+    // Blue-tinted activation burst (white particles simulate glow)
+    this.particles.emitExplosion(tank.mesh.position.clone(), {
+      count: 20, speed: 3, lifetime: 0.5,
+    });
+
+    this._activeEffects.push({
+      type: 'energyShield',
+      tank,
+      timeLeft: ENERGY_SHIELD_DURATION,
+    });
+
+    console.info(`[TankAbilityEffects] energyShield active (${ENERGY_SHIELD_DURATION}s).`);
+    return true;
+  }
+
+  /**
+   * Rocket Jump (Jump Tank)
+   *
+   * Tank follows a parabolic arc peaking at ROCKET_JUMP_HEIGHT above ground.
+   * Sets tank.isJumping = true so PlayerController/_driveTankTowardTarget skip
+   * terrain-follow — TankAbilityEffects drives the Y position directly.
+   * On landing, AoE damage is applied to all enemies within ROCKET_JUMP_SPLASH.
+   * Cannot activate while already jumping or during lockdown.
+   * @private
+   */
+  _rocketJump(tank) {
+    if (tank.isJumping || tank.isLockedDown) return false;
+
+    tank.isJumping = true;
+    tank._jumpBaseY = this.terrain.getHeightAt(
+      tank.mesh.position.x,
+      tank.mesh.position.z
+    );
+
+    this._activeEffects.push({
+      type:     'rocketJump',
+      tank,
+      timeLeft: ROCKET_JUMP_DURATION,
+      maxTime:  ROCKET_JUMP_DURATION,
+    });
+
+    // Launch thrust burst
+    this.particles.emitExplosion(tank.mesh.position.clone(), {
+      count: 15, speed: 6, lifetime: 0.5,
+    });
+
+    console.info('[TankAbilityEffects] rocketJump launched.');
+    return true;
+  }
+
+  /**
+   * Tick rocket-jump physics for one frame.
+   * h(t) = 4 * PEAK * t * (1 - t)  where t ∈ [0, 1] = lifecycle fraction.
+   * @private
+   */
+  _tickRocketJump(effect, _dt) {
+    const { tank, timeLeft, maxTime } = effect;
+    const t = 1 - timeLeft / maxTime; // 0 = launch, 1 = just before land
+
+    tank.mesh.position.y =
+      tank._jumpBaseY + 4 * ROCKET_JUMP_HEIGHT * t * (1 - t);
+
+    // Thrust dust during ascent phase
+    if (t < 0.5) {
+      this.particles.emitDust(tank.mesh.position.clone());
+    }
+  }
+
+  /**
+   * Lockdown Mode (Siege Tank)
+   *
+   * Prevents all hull movement for LOCKDOWN_DURATION seconds while doubling
+   * the fire rate (halving seconds-per-shot).  Sets tank.isLockedDown so
+   * PlayerController and AIController skip movement updates.
+   * Does NOT stack.
+   * @private
+   */
+  _lockdownMode(tank) {
+    if (tank.isLockedDown) return false;
+
+    tank.isLockedDown = true;
+    tank._preLockdownFireRate = tank.fireRate;
+    tank.fireRate = tank.fireRate / LOCKDOWN_FIRE_RATE_MULT; // shorter cooldown = faster fire
+
+    this.particles.emitExplosion(tank.mesh.position.clone(), {
+      count: 12, speed: 4, lifetime: 0.5,
+    });
+
+    this._activeEffects.push({
+      type: 'lockdownMode',
+      tank,
+      timeLeft: LOCKDOWN_DURATION,
+    });
+
+    console.info(`[TankAbilityEffects] lockdownMode active (${LOCKDOWN_DURATION}s, 2× fire rate).`);
+    return true;
+  }
+
+  /**
+   * Barrage (Artillery)
+   *
+   * Fires BARRAGE_SHOTS shells in rapid succession at BARRAGE_INTERVAL second
+   * intervals.  The first shell fires immediately; the rest are queued.
+   * Bypasses the normal fire cooldown and does not consume the player's ammo.
+   * @private
+   */
+  _barrage(tank) {
+    this._fireBarrageShot(tank);
+
+    this._barrageQueues.push({
+      tank,
+      shotsLeft: BARRAGE_SHOTS - 1,
+      timer:     BARRAGE_INTERVAL,
+    });
+
+    console.info('[TankAbilityEffects] barrage — 5-shot sequence started.');
+    return true;
+  }
+
+  /**
+   * Fire one barrage shell, bypassing the normal fire cooldown.
+   * Restores fireCooldown after so normal cadence is unaffected between shots.
+   * @private
+   */
+  _fireBarrageShot(tank) {
+    const savedCooldown = tank.fireCooldown;
+    const savedAmmo     = tank.ammo;
+
+    tank.fireCooldown = 0;
+    if (tank.isPlayer) tank.ammo = Math.max(1, tank.ammo); // ensure canFire() passes
+
+    const proj = tank.fire();
+    if (proj) {
+      this.projectileSystem.add(proj);
+      this.particles.emitMuzzleFlash(
+        proj.mesh.position.clone(),
+        proj.velocity.clone().normalize()
+      );
+    }
+
+    // Restore state so barrage shots don't interfere with normal firing rhythm
+    tank.fireCooldown = savedCooldown;
+    if (tank.isPlayer) tank.ammo = savedAmmo;
+  }
+
+  /**
+   * Reactive Armor (Heavy)
+   *
+   * Grants REACTIVE_ARMOR_CHARGES hit-reduction charges.  For each incoming
+   * hit while charges > 0, Tank.takeDamage() applies 50 % damage instead of
+   * full damage and decrements the counter.  Refreshes on repeat activation.
+   * @private
+   */
+  _reactiveArmor(tank) {
+    tank.reactiveArmorCharges = REACTIVE_ARMOR_CHARGES;
+
+    this.particles.emitExplosion(tank.mesh.position.clone(), {
+      count: 10, speed: 3, lifetime: 0.4,
+    });
+
+    console.info(
+      `[TankAbilityEffects] reactiveArmor — ${REACTIVE_ARMOR_CHARGES} charges.`
+    );
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Effect lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Called when a timed effect expires (timeLeft reaches 0).
+   * @private
+   */
+  _endEffect(effect, allTanks) {
+    switch (effect.type) {
+      case 'energyShield':
+        effect.tank.shielded = false;
+        console.info('[TankAbilityEffects] energyShield expired.');
+        break;
+
+      case 'rocketJump':
+        this._landRocketJump(effect.tank, allTanks);
+        break;
+
+      case 'lockdownMode':
+        this._endLockdown(effect.tank);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Called on round reset to cancel any mid-flight effect without triggering
+   * its normal completion logic (e.g. no AoE damage from a cancelled jump).
+   * @private
+   */
+  _cancelEffect(effect) {
+    switch (effect.type) {
+      case 'energyShield':
+        effect.tank.shielded = false;
+        break;
+
+      case 'rocketJump':
+        effect.tank.isJumping = false;
+        // Snap tank back to ground level so it doesn't float between rounds
+        effect.tank.mesh.position.y = this.terrain.getHeightAt(
+          effect.tank.mesh.position.x,
+          effect.tank.mesh.position.z
+        );
+        break;
+
+      case 'lockdownMode':
+        this._endLockdown(effect.tank);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Apply rocket-jump landing: snap to terrain + AoE damage.
+   * @private
+   */
+  _landRocketJump(tank, allTanks) {
+    const landPos = tank.mesh.position.clone();
+    landPos.y = this.terrain.getHeightAt(landPos.x, landPos.z);
+    tank.mesh.position.y = landPos.y;
+    tank.isJumping = false;
+
+    // Large landing explosion
+    this.particles.emitExplosion(landPos, {
+      count: 40, speed: 12, lifetime: 1.0,
+    });
+
+    // AoE damage to enemies in splash radius (linear falloff)
+    let hitCount = 0;
+    for (const target of allTanks) {
+      if (target === tank || target.teamId === tank.teamId) continue;
+      const dist = target.mesh.position.distanceTo(landPos);
+      if (dist <= ROCKET_JUMP_SPLASH) {
+        const falloff = 1 - dist / ROCKET_JUMP_SPLASH;
+        const dmg = Math.round(ROCKET_JUMP_DAMAGE * (0.4 + 0.6 * falloff));
+        target.takeDamage(dmg);
+        hitCount++;
+      }
+    }
+
+    console.info(`[TankAbilityEffects] rocketJump landed — ${hitCount} targets hit.`);
+  }
+
+  /**
+   * Restore fireRate when Lockdown Mode expires or is cancelled.
+   * @private
+   */
+  _endLockdown(tank) {
+    tank.isLockedDown = false;
+    if (tank._preLockdownFireRate !== undefined) {
+      tank.fireRate = tank._preLockdownFireRate;
+      delete tank._preLockdownFireRate;
+    }
+    console.info('[TankAbilityEffects] lockdownMode expired.');
+  }
+}

--- a/tests/TankAbilityEffects.test.js
+++ b/tests/TankAbilityEffects.test.js
@@ -1,0 +1,472 @@
+/**
+ * TankAbilityEffects.test.js — Unit tests for the six tank ability effects (t043).
+ *
+ * Run: node --test tests/TankAbilityEffects.test.js
+ *
+ * These tests verify gameplay-observable behaviour for each ability:
+ *   infernoBurst  — damages enemies in radius, ignores team-mates
+ *   energyShield  — sets shielded flag, absorbs damage, expires on timer
+ *   rocketJump    — sets isJumping, drives Y parabola, AoE on landing
+ *   lockdownMode  — sets isLockedDown, halves fireRate, restores on expiry
+ *   barrage       — fires first shot immediately, queues remaining shots
+ *   reactiveArmor — sets reactiveArmorCharges on tank
+ *
+ * Also tests:
+ *   Tank.takeDamage() — Energy Shield and Reactive Armor integration
+ *   reset()           — cancels active effects
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TankAbilityEffects,
+  REACTIVE_ARMOR_CHARGES,
+  REACTIVE_ARMOR_REDUCTION,
+} from '../src/systems/TankAbilityEffects.js';
+
+// ---------------------------------------------------------------------------
+// Minimal stubs
+// ---------------------------------------------------------------------------
+
+/** Stub terrain: flat ground at y = 0. */
+const terrain = {
+  getHeightAt: (_x, _z) => 0,
+};
+
+/** Stub ParticleSystem: records calls but does nothing visual. */
+function makeParticles() {
+  return {
+    calls: [],
+    emitExplosion(pos, opts = {}) { this.calls.push({ type: 'explosion', pos, opts }); },
+    emitMuzzleFlash(pos, dir) { this.calls.push({ type: 'flash', pos, dir }); },
+    emitDust(pos) { this.calls.push({ type: 'dust', pos }); },
+  };
+}
+
+/** Stub ProjectileSystem: records added projectiles. */
+function makeProjectileSystem() {
+  return {
+    added: [],
+    add(proj) { this.added.push(proj); },
+  };
+}
+
+/**
+ * Minimal THREE.Vector3-compatible position stub.
+ * Supports clone(), add(), distanceTo() — the only methods used by TankAbilityEffects.
+ */
+function makePos(x = 0, y = 0, z = 0) {
+  const pos = {
+    x, y, z,
+    clone() { return makePos(this.x, this.y, this.z); },
+    add(other) {
+      this.x += other.x;
+      this.y += other.y;
+      this.z += other.z;
+      return this;
+    },
+    distanceTo(other) {
+      const dx = this.x - other.x;
+      const dy = this.y - other.y;
+      const dz = this.z - other.z;
+      return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    },
+  };
+  return pos;
+}
+
+/**
+ * Minimal Tank-like stub.
+ * Sets all fields TankAbilityEffects reads or writes.
+ */
+function makeTank(teamId = 0, opts = {}) {
+  const proj = {
+    mesh: { position: makePos() },
+    velocity: {
+      clone() { return { normalize() { return makePos(); } }; },
+    },
+  };
+
+  return {
+    teamId,
+    isPlayer: opts.isPlayer ?? false,
+    health:   opts.health   ?? 100,
+    armor:    opts.armor    ?? 0,
+    fireRate: opts.fireRate ?? 0.5, // seconds between shots
+    fireCooldown: 0,
+    ammo: 30,
+    isJumping:    false,
+    isLockedDown: false,
+    shielded:     false,
+    reactiveArmorCharges: 0,
+    mesh: {
+      position: makePos(opts.x ?? 0, opts.y ?? 0, opts.z ?? 0),
+    },
+    canFire() { return this.fireCooldown <= 0 && this.ammo > 0; },
+    fire() {
+      if (!this.canFire()) return null;
+      this.fireCooldown = this.fireRate;
+      if (this.isPlayer) this.ammo--;
+      return proj;
+    },
+    takeDamage(amount) {
+      // Mirrors Tank.takeDamage() from entities/Tank.js (t043).
+      if (this.shielded) return 0;
+      let dmg = amount;
+      if (this.reactiveArmorCharges > 0) {
+        dmg = dmg * REACTIVE_ARMOR_REDUCTION;
+        this.reactiveArmorCharges--;
+      }
+      const reduced = dmg * (1 - this.armor);
+      this.health = Math.max(0, this.health - reduced);
+      return Math.min(reduced, this.health + reduced); // actual removed
+    },
+  };
+}
+
+/**
+ * Build a TankAbilityEffects instance with stubbed dependencies.
+ * @returns {{ effects: TankAbilityEffects, particles: object, projectileSystem: object }}
+ */
+function makeEffects() {
+  const particles       = makeParticles();
+  const projectileSystem = makeProjectileSystem();
+  const effects = new TankAbilityEffects({ terrain, particles, projectileSystem });
+  return { effects, particles, projectileSystem };
+}
+
+// ---------------------------------------------------------------------------
+// infernoBurst
+// ---------------------------------------------------------------------------
+
+test('infernoBurst: damages enemies in radius', () => {
+  const { effects } = makeEffects();
+  const player = makeTank(0);
+  const enemy  = makeTank(1, { health: 100 });
+  const allTanks = [player, enemy];
+
+  effects.execute('infernoBurst', player, allTanks);
+
+  assert.ok(enemy.health < 100, 'enemy should take damage');
+});
+
+test('infernoBurst: does not damage self', () => {
+  const { effects } = makeEffects();
+  const player = makeTank(0, { health: 100 });
+  const allTanks = [player];
+
+  effects.execute('infernoBurst', player, allTanks);
+  assert.equal(player.health, 100);
+});
+
+test('infernoBurst: does not damage team-mates', () => {
+  const { effects } = makeEffects();
+  const player = makeTank(0, { health: 100 });
+  const ally   = makeTank(0, { health: 100 });
+  const allTanks = [player, ally];
+
+  effects.execute('infernoBurst', player, allTanks);
+  assert.equal(ally.health, 100);
+});
+
+test('infernoBurst: enemy far outside radius takes no damage', () => {
+  const { effects } = makeEffects();
+  const player = makeTank(0);
+  // Position enemy 20 units away — outside INFERNO_BURST_RADIUS (15)
+  const farEnemy = makeTank(1, { health: 100, x: 20 });
+  const allTanks = [player, farEnemy];
+
+  effects.execute('infernoBurst', player, allTanks);
+  assert.equal(farEnemy.health, 100);
+});
+
+test('infernoBurst: emits particles', () => {
+  const { effects, particles } = makeEffects();
+  const player = makeTank(0);
+  effects.execute('infernoBurst', player, [player]);
+
+  assert.ok(particles.calls.length > 0, 'should emit particles');
+});
+
+// ---------------------------------------------------------------------------
+// energyShield
+// ---------------------------------------------------------------------------
+
+test('energyShield: sets tank.shielded = true', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('energyShield', tank, [tank]);
+  assert.equal(tank.shielded, true);
+});
+
+test('energyShield: does not stack (second call returns false)', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('energyShield', tank, [tank]);
+  const result = effects.execute('energyShield', tank, [tank]);
+  assert.equal(result, false);
+});
+
+test('energyShield: shield clears after duration', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('energyShield', tank, [tank]);
+  assert.equal(tank.shielded, true);
+
+  // Advance past the 5-second duration
+  effects.update(5.1, [tank]);
+  assert.equal(tank.shielded, false);
+});
+
+test('energyShield: absorbs all incoming damage while active', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { health: 100 });
+  effects.execute('energyShield', tank, [tank]);
+
+  const dmgApplied = tank.takeDamage(50);
+  assert.equal(dmgApplied, 0);
+  assert.equal(tank.health, 100);
+});
+
+// ---------------------------------------------------------------------------
+// rocketJump
+// ---------------------------------------------------------------------------
+
+test('rocketJump: sets isJumping = true', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('rocketJump', tank, [tank]);
+  assert.equal(tank.isJumping, true);
+});
+
+test('rocketJump: cannot activate while already jumping', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('rocketJump', tank, [tank]);
+  const second = effects.execute('rocketJump', tank, [tank]);
+  assert.equal(second, false);
+});
+
+test('rocketJump: cannot activate while locked down', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  tank.isLockedDown = true;
+  const result = effects.execute('rocketJump', tank, [tank]);
+  assert.equal(result, false);
+  assert.equal(tank.isJumping, false);
+});
+
+test('rocketJump: clears isJumping after duration', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('rocketJump', tank, [tank]);
+  // 2.1 s > ROCKET_JUMP_DURATION (2.0 s)
+  effects.update(2.1, [tank]);
+  assert.equal(tank.isJumping, false);
+});
+
+test('rocketJump: tank Y is elevated above base during flight', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('rocketJump', tank, [tank]);
+  // Advance to mid-flight (t ≈ 0.5 → peak altitude)
+  effects.update(1.0, [tank]);
+  assert.ok(
+    tank.mesh.position.y > 0,
+    `tank Y should be above ground at mid-flight (got ${tank.mesh.position.y})`
+  );
+});
+
+test('rocketJump: AoE damages enemies on landing', () => {
+  const { effects } = makeEffects();
+  const tank  = makeTank(0);
+  const enemy = makeTank(1, { health: 100 });
+  const allTanks = [tank, enemy];
+  effects.execute('rocketJump', tank, allTanks);
+  // Advance past full duration
+  effects.update(2.1, allTanks);
+  assert.ok(enemy.health < 100, 'enemy should take AoE damage on landing');
+});
+
+test('rocketJump: AoE does not damage allies', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { health: 100 });
+  const ally = makeTank(0, { health: 100 });
+  const allTanks = [tank, ally];
+  effects.execute('rocketJump', tank, allTanks);
+  effects.update(2.1, allTanks);
+  assert.equal(ally.health, 100);
+});
+
+// ---------------------------------------------------------------------------
+// lockdownMode
+// ---------------------------------------------------------------------------
+
+test('lockdownMode: sets isLockedDown = true', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('lockdownMode', tank, [tank]);
+  assert.equal(tank.isLockedDown, true);
+});
+
+test('lockdownMode: halves fireRate (doubles cadence)', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { fireRate: 0.4 });
+  effects.execute('lockdownMode', tank, [tank]);
+  assert.ok(tank.fireRate < 0.4, 'fireRate should decrease (faster firing)');
+  assert.equal(tank.fireRate, 0.2); // 0.4 / 2
+});
+
+test('lockdownMode: restores fireRate after duration', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { fireRate: 0.4 });
+  effects.execute('lockdownMode', tank, [tank]);
+  effects.update(8.1, [tank]); // past LOCKDOWN_DURATION (8s)
+  assert.equal(tank.isLockedDown, false);
+  assert.equal(tank.fireRate, 0.4);
+});
+
+test('lockdownMode: does not stack (second call returns false)', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('lockdownMode', tank, [tank]);
+  const result = effects.execute('lockdownMode', tank, [tank]);
+  assert.equal(result, false);
+});
+
+// ---------------------------------------------------------------------------
+// barrage
+// ---------------------------------------------------------------------------
+
+test('barrage: fires a shot immediately on activation', () => {
+  const { effects, projectileSystem } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('barrage', tank, [tank]);
+  assert.equal(projectileSystem.added.length, 1, 'first barrage shot fires immediately');
+});
+
+test('barrage: fires 5 total shots over time', () => {
+  const { effects, projectileSystem } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('barrage', tank, [tank]);
+  // Advance past all 4 queued intervals (4 × 0.2 = 0.8 s)
+  effects.update(0.3, [tank]);
+  effects.update(0.3, [tank]);
+  effects.update(0.3, [tank]);
+  effects.update(0.3, [tank]);
+  assert.equal(projectileSystem.added.length, 5, 'all 5 barrage shots should fire');
+});
+
+test('barrage: does not consume player ammo', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, {});
+  tank.isPlayer = true;
+  tank.ammo = 10;
+  effects.execute('barrage', tank, [tank]);
+  // Flush the queued shots
+  effects.update(1.0, [tank]);
+  assert.equal(tank.ammo, 10, 'barrage should not consume ammo');
+});
+
+test('barrage: restores normal fireCooldown after shots', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  tank.fireCooldown = 0.25; // mid-fire when barrage activates
+  effects.execute('barrage', tank, [tank]);
+  // fireCooldown should be restored to 0.25, not overwritten to 0
+  assert.ok(
+    tank.fireCooldown <= 0.25,
+    `fireCooldown should remain at most 0.25 after barrage shot (got ${tank.fireCooldown})`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// reactiveArmor
+// ---------------------------------------------------------------------------
+
+test('reactiveArmor: sets reactiveArmorCharges to REACTIVE_ARMOR_CHARGES', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('reactiveArmor', tank, [tank]);
+  assert.equal(tank.reactiveArmorCharges, REACTIVE_ARMOR_CHARGES);
+});
+
+test('reactiveArmor: halves damage on each charged hit', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { health: 100 });
+  effects.execute('reactiveArmor', tank, [tank]);
+
+  tank.takeDamage(40); // should apply 20 (50% of 40)
+  assert.equal(tank.health, 80);
+  assert.equal(tank.reactiveArmorCharges, REACTIVE_ARMOR_CHARGES - 1);
+});
+
+test('reactiveArmor: charges run out after N hits', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { health: 1000 });
+  effects.execute('reactiveArmor', tank, [tank]);
+
+  // Apply N hits; each should consume one charge
+  for (let i = 0; i < REACTIVE_ARMOR_CHARGES; i++) {
+    tank.takeDamage(10);
+  }
+  assert.equal(tank.reactiveArmorCharges, 0);
+
+  // Next hit applies full damage (no charges remaining)
+  const healthBefore = tank.health;
+  tank.takeDamage(10);
+  assert.equal(tank.health, healthBefore - 10);
+});
+
+// ---------------------------------------------------------------------------
+// reset()
+// ---------------------------------------------------------------------------
+
+test('reset: cancels energyShield mid-duration', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('energyShield', tank, [tank]);
+  assert.equal(tank.shielded, true);
+  effects.reset();
+  assert.equal(tank.shielded, false);
+});
+
+test('reset: cancels rocketJump mid-flight', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('rocketJump', tank, [tank]);
+  assert.equal(tank.isJumping, true);
+  effects.reset();
+  assert.equal(tank.isJumping, false);
+});
+
+test('reset: cancels lockdownMode mid-duration', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0, { fireRate: 0.4 });
+  effects.execute('lockdownMode', tank, [tank]);
+  assert.equal(tank.isLockedDown, true);
+  effects.reset();
+  assert.equal(tank.isLockedDown, false);
+  assert.equal(tank.fireRate, 0.4); // restored
+});
+
+test('reset: clears barrage queue', () => {
+  const { effects, projectileSystem } = makeEffects();
+  const tank = makeTank(0);
+  effects.execute('barrage', tank, [tank]);
+  effects.reset();
+  // Advance time — no more shots should fire after reset
+  const shotsBefore = projectileSystem.added.length;
+  effects.update(1.0, [tank]);
+  assert.equal(projectileSystem.added.length, shotsBefore, 'no barrage shots after reset');
+});
+
+// ---------------------------------------------------------------------------
+// execute: unknown ability ID
+// ---------------------------------------------------------------------------
+
+test('execute: unknown ability id returns false', () => {
+  const { effects } = makeEffects();
+  const tank = makeTank(0);
+  const result = effects.execute('blorginator', tank, [tank]);
+  assert.equal(result, false);
+});


### PR DESCRIPTION
## Summary

Implements all six tank ability **gameplay effects** for t043, on top of the t042 AbilitySystem cooldown framework that was already merged.

## What changed

**New file: `src/systems/TankAbilityEffects.js`**
- `execute(abilityId, tank, allTanks)` — routes to the correct ability handler
- `update(dt, allTanks)` — advances timed effects (shield duration, jump arc, lockdown timer, barrage queue)
- `reset()` — cancels all active effects on round reset

Abilities implemented:
| Ability | Class | Effect |
|---|---|---|
| `infernoBurst` | Flame Tank | 360° fire ring, ≤40 dmg to enemies ≤15 units (linear falloff) |
| `energyShield` | Shield Tank | 5 s full damage immunity (`tank.shielded` flag) |
| `rocketJump` | Jump Tank | Parabolic arc 12 units tall over 2 s; AoE 60 dmg on landing |
| `lockdownMode` | Siege Tank | 8 s stationary; fireRate halved (2× cadence) while active |
| `barrage` | Artillery | 5 shells, 0.2 s apart, no ammo cost |
| `reactiveArmor` | Heavy | 3 charges of 50 % damage reduction |

**`src/entities/Tank.js`**
- Added ability state fields: `shielded`, `isJumping`, `isLockedDown`, `reactiveArmorCharges`
- `takeDamage()` now processes: Energy Shield → Reactive Armor → class armor (in sequence)
- `reset()` clears all ability flags between rounds

**`src/core/Game.js`**
- Imports and creates `TankAbilityEffects` instance
- Replaces t042 placeholder burst with `tankAbilityEffects.execute()` on Q press
- Calls `tankAbilityEffects.update()` and `tankAbilityEffects.reset()` in game loop/reset

**`src/core/PlayerController.js`**
- Skips hull movement/turning when `tank.isLockedDown`
- Skips terrain-follow when `tank.isJumping` (TankAbilityEffects drives Y)
- Blocks voluntary tank exit during lockdown or jump

**`src/systems/AIController.js`**
- Skips hull movement and rotation when `tank.isLockedDown`; turret still tracks and fires
- Skips terrain-follow when `tank.isJumping`

**`tests/TankAbilityEffects.test.js`** — 32 new unit tests covering all six abilities, stacking prevention, effect expiry timers, AoE targeting rules, and `reset()`.

## Testing

```bash
node --test tests/TankAbilityEffects.test.js
# 32 tests, 0 failures

node --test tests/AbilitySystem.test.js
# 27 tests, 0 failures (pre-existing, unchanged)
```

Resolves #59