### PR TITLE
t039: Flame Tank weapon — continuous cone damage + fire particles

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -333,6 +333,15 @@ export class Game {
     // round resets because Tank.reset() restores health to the (already-scaled) maxHealth.
     this.aiController.applyLeagueScalingToTeam(1, 0);
 
+    // Flame Tank (t039): when any AI Flame Tank fires, apply cone damage via
+    // CollisionSystem and emit fire particles.  Game.js owns both systems so
+    // the callback closes over them safely.
+    this.aiController.setFlameAttackCallback((tank, _target) => {
+      const { pos, dir } = tank.getFlameMuzzle();
+      this.collision.applyFlameDamage(tank, pos, dir);
+      this.particles.emitFlame(pos, dir);
+    });
+
     // AbilitySystem: cooldown-based Q-key ability framework (t042).
     // Slots are configured from the player's loadout when a match starts.
     this.abilitySystem = new AbilitySystem();
@@ -490,7 +499,7 @@ export class Game {
    * @param {number} dt
    */
   _updatePlayer(input, dt) {
-    const { newProjectiles, isMoving } = this.playerController.update(input, dt);
+    const { newProjectiles, isMoving, flameFired } = this.playerController.update(input, dt);
 
     // Emit muzzle flash once per shot (using the first projectile for position/direction).
     // Shotgun fires 8 pellets simultaneously — a single flash for the burst is correct.
@@ -503,6 +512,15 @@ export class Game {
       for (const proj of newProjectiles) {
         this.projectiles.add(proj);
       }
+    }
+
+    // ---- Flame Tank (t039): player cone damage + fire particles ----
+    // flameFired is set by PlayerController when the Flame Tank's fire() tick
+    // consumed the cooldown (tank.canFire() was true, isFlameTank is true).
+    if (flameFired) {
+      const { pos, dir } = this.player.getFlameMuzzle();
+      this.collision.applyFlameDamage(this.player, pos, dir);
+      this.particles.emitFlame(pos, dir);
     }
 
     // ---- On-foot soldier melee (t026/t034) ----

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -276,9 +276,11 @@ export class PlayerController {
    * @param {object} input — snapshot from InputSystem.getState()
    * @param {number} dt    — seconds since last frame
    * @returns {{ newProjectiles: import('../entities/Projectile.js').Projectile[],
-   *             isMoving: boolean }}
+   *             isMoving: boolean,
+   *             flameFired: boolean }}
    *   newProjectiles — projectiles to add to ProjectileSystem (empty array if none fired).
    *   isMoving       — true if the active entity moved this frame (for dust trails).
+   *   flameFired     — true when a Flame Tank successfully fired this tick (no projectile).
    */
   update(input, dt) {
     if (this.mode === 'tank') {
@@ -324,12 +326,19 @@ export class PlayerController {
     }
 
     const newProjectiles = [];
+    let flameFired = false;
+
     if (input.fire && tank.canFire()) {
       const proj = tank.fire();
-      if (proj) newProjectiles.push(proj);
+      if (proj) {
+        newProjectiles.push(proj);
+      } else if (tank.isFlameTank) {
+        // fire() set fireCooldown but returned null — flame tick confirmed.
+        flameFired = true;
+      }
     }
 
-    return { newProjectiles, isMoving: moving };
+    return { newProjectiles, isMoving: moving, flameFired };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -374,6 +374,25 @@ export class Tank {
   // Combat
   // ---------------------------------------------------------------------------
 
+  /** True when this tank uses the flamethrower weapon instead of a cannon. */
+  get isFlameTank() {
+    return this.tankClassId === 'flameTank';
+  }
+
+  /**
+   * World-space muzzle position and forward direction for the flame nozzle.
+   * Used by Game.js to position the fire cone and emit particles.
+   *
+   * @returns {{ pos: THREE.Vector3, dir: THREE.Vector3 }}
+   */
+  getFlameMuzzle() {
+    const pos = new THREE.Vector3();
+    const dir = new THREE.Vector3(0, 0, -1);
+    this.muzzle.getWorldPosition(pos);
+    this.muzzle.getWorldDirection(dir);
+    return { pos, dir };
+  }
+
   setTurretAngle(angle) {
     if (this.turret) {
       this.turret.rotation.y = angle - this.mesh.rotation.y;
@@ -389,6 +408,9 @@ export class Tank {
 
     this.fireCooldown = this.fireRate;
     if (this.isPlayer) this.ammo--;
+
+    // Flame Tank uses continuous cone damage applied by CollisionSystem — no projectile.
+    if (this.isFlameTank) return null;
 
     // Get world position and direction of muzzle
     const worldPos = new THREE.Vector3();

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -174,11 +174,32 @@ export class AIController {
 
     // Apply initial league. Falls back to bronze if leagueDef is missing/null.
     this._applyLeagueDef(leagueDef || getLeagueDef('bronze'));
+
+    /**
+     * Called when an AI Flame Tank successfully fires (canFire() was true, no
+     * projectile created).  Game.js uses this to apply cone damage and emit
+     * fire particles for both ally and enemy flame tanks.
+     *
+     * Signature: (tank: Tank, target: Tank) => void
+     * @type {((tank: import('../entities/Tank.js').Tank, target: import('../entities/Tank.js').Tank) => void)|null}
+     */
+    this._onFlameAttack = null;
   }
 
   // -------------------------------------------------------------------------
   // Public API — Tank AI
   // -------------------------------------------------------------------------
+
+  /**
+   * Register a callback for when an AI Flame Tank fires.
+   * Called by Game.js to hook in cone damage + particle emission.
+   *
+   * @param {(tank: import('../entities/Tank.js').Tank,
+   *           target: import('../entities/Tank.js').Tank) => void} cb
+   */
+  setFlameAttackCallback(cb) {
+    this._onFlameAttack = cb;
+  }
 
   /**
    * Switch the AI to a different league difficulty level.
@@ -545,6 +566,10 @@ export class AIController {
           projectile.mesh.position.clone(),
           flashDir
         );
+      } else if (tank.isFlameTank && this._onFlameAttack) {
+        // Flame Tank: fire() returned null (cooldown set, no projectile).
+        // Delegate cone damage and particle emission to Game.js via callback.
+        this._onFlameAttack(tank, target);
       }
     }
   }

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -478,6 +478,122 @@ export class CollisionSystem {
   }
 
   /**
+   * Apply continuous cone damage from a Flame Tank per fire tick (t039).
+   *
+   * Called by Game.js once per canFire() tick (~10 Hz) for:
+   *   - The player's tank when it is a Flame Tank and the fire button is held.
+   *   - Any AI tank (ally or enemy) that is a Flame Tank and in range.
+   *
+   * Geometry: targets within `flameTank.range` units of the nozzle AND within a
+   * ±30° half-angle cone centered on the nozzle forward direction take damage.
+   * Damage falls off linearly to 0 at the cone edge.
+   *
+   * Kill callbacks mirror the projectile kill chain so the kill feed, wrecks,
+   * score, and TeamManager state all stay consistent.
+   *
+   * @param {import('../entities/Tank.js').Tank} flameTank — the attacking tank
+   * @param {import('three').Vector3}            muzzlePos — world-space nozzle tip
+   * @param {import('three').Vector3}            direction  — normalised fire direction
+   */
+  applyFlameDamage(flameTank, muzzlePos, direction) {
+    const range          = flameTank.range;                 // 20 u for Flame Tank
+    const CONE_HALF      = Math.PI / 6;                     // 30° → 60° total arc
+    const cosThreshold   = Math.cos(CONE_HALF);             // ≈ 0.866
+    const isPlayerSide   = flameTank.teamId === 0;
+
+    const _toTarget = { x: 0, y: 0, z: 0 }; // scratch vector (avoids per-frame alloc)
+
+    if (isPlayerSide) {
+      // ── Flame Tank on player team (player + allies) — damages enemies ────────
+      const enemies  = this.enemies.active;
+      const toKill   = [];
+
+      for (const enemy of enemies) {
+        if (enemy.health <= 0) continue;
+
+        _toTarget.x = enemy.mesh.position.x - muzzlePos.x;
+        _toTarget.y = enemy.mesh.position.y - muzzlePos.y;
+        _toTarget.z = enemy.mesh.position.z - muzzlePos.z;
+
+        const dist = Math.sqrt(
+          _toTarget.x * _toTarget.x +
+          _toTarget.y * _toTarget.y +
+          _toTarget.z * _toTarget.z
+        );
+        if (dist > range || dist < 0.001) continue;
+
+        // Dot product of normalised to-target vs fire direction
+        const dot = (_toTarget.x / dist) * direction.x +
+                    (_toTarget.y / dist) * direction.y +
+                    (_toTarget.z / dist) * direction.z;
+        if (dot < cosThreshold) continue; // outside cone
+
+        const falloff    = 1 - dist / range;
+        const rawDmg     = flameTank.damage * flameTank.damageMultiplier * falloff;
+        const actualDmg  = enemy.takeDamage(rawDmg);
+
+        flameTank.recordDamage(actualDmg);
+        if (this._onDamageDealt) this._onDamageDealt(enemy, actualDmg);
+
+        if (enemy.health <= 0) toKill.push(enemy);
+      }
+
+      for (const killed of toKill) {
+        flameTank.recordKill();
+        const tankData = {
+          position:  killed.mesh.position.clone(),
+          rotationY: killed.mesh.rotation.y,
+        };
+        const killerName = flameTank.name || (flameTank === this.player ? 'Player' : 'Ally');
+        if (this._onKillFeed) this._onKillFeed(killerName, killed.name || 'Enemy');
+        if (this._onTankKilled) this._onTankKilled(killed, flameTank === this.player);
+        const idx = this.enemies.active.indexOf(killed);
+        if (idx !== -1) this.enemies.remove(idx);
+        if (this._onKill) this._onKill(muzzlePos.clone(), 'player', tankData);
+        if (this._onScoreAdd) this._onScoreAdd(100);
+      }
+
+    } else {
+      // ── Enemy Flame Tank — damages the player ────────────────────────────────
+      const player = this.player;
+      if (player.health <= 0) return;
+
+      _toTarget.x = player.mesh.position.x - muzzlePos.x;
+      _toTarget.y = player.mesh.position.y - muzzlePos.y;
+      _toTarget.z = player.mesh.position.z - muzzlePos.z;
+
+      const dist = Math.sqrt(
+        _toTarget.x * _toTarget.x +
+        _toTarget.y * _toTarget.y +
+        _toTarget.z * _toTarget.z
+      );
+      if (dist > range || dist < 0.001) return;
+
+      const dot = (_toTarget.x / dist) * direction.x +
+                  (_toTarget.y / dist) * direction.y +
+                  (_toTarget.z / dist) * direction.z;
+      if (dot < cosThreshold) return;
+
+      const falloff   = 1 - dist / range;
+      const rawDmg    = flameTank.damage * flameTank.damageMultiplier * falloff;
+      const actualDmg = player.takeDamage(rawDmg);
+
+      if (flameTank.recordDamage) flameTank.recordDamage(actualDmg);
+
+      if (player.health <= 0) {
+        if (flameTank.recordKill) flameTank.recordKill();
+        const tankData = {
+          position:  player.mesh.position.clone(),
+          rotationY: player.mesh.rotation.y,
+        };
+        if (this._onKillFeed) this._onKillFeed(flameTank.name || 'Enemy', player.name || 'Player');
+        if (this._onKill) this._onKill(muzzlePos.clone(), 'enemy', tankData);
+        if (this._onPlayerDeath) this._onPlayerDeath();
+      }
+    }
+  }
+
+  /**
    * After all movement, push tanks out of rocks (permanent), alive trees
    * (removed once destroyed), and wrecks (permanent until round reset).
    * Operates in the XZ plane only.

--- a/src/systems/ParticleSystem.js
+++ b/src/systems/ParticleSystem.js
@@ -298,6 +298,78 @@ export class ParticleSystem {
     }
   }
 
+  /**
+   * Emit a burst of fire particles for the Flame Tank weapon (t039).
+   *
+   * Particles travel forward within a ~30° half-angle cone from the nozzle.
+   * Called at ~10 Hz (once per fire tick) so the particle density is
+   * calibrated for that rate — not every frame.
+   *
+   * @param {THREE.Vector3} position  World-space nozzle tip.
+   * @param {THREE.Vector3} direction Normalised forward direction of the nozzle.
+   */
+  emitFlame(position, direction) {
+    const count = 10;
+    // Perpendicular axes for cone spread (arbitrary; works for any direction).
+    const up = Math.abs(direction.y) < 0.9
+      ? new THREE.Vector3(0, 1, 0)
+      : new THREE.Vector3(1, 0, 0);
+    const right = new THREE.Vector3().crossVectors(direction, up).normalize();
+    const realUp  = new THREE.Vector3().crossVectors(right, direction).normalize();
+
+    for (let i = 0; i < count; i++) {
+      const p = this._acquire();
+      if (!p) return;
+
+      // Random angle within 30° half-angle cone
+      const spreadAngle = (Math.random() * Math.PI) / 6; // 0–30°
+      const rollAngle   = Math.random() * Math.PI * 2;
+      const sinSpread   = Math.sin(spreadAngle);
+      const cosSpread   = Math.cos(spreadAngle);
+
+      const speed = 14 + Math.random() * 10; // fast, flame-like
+      p.velocity.set(
+        (direction.x * cosSpread
+          + (right.x * Math.cos(rollAngle) + realUp.x * Math.sin(rollAngle)) * sinSpread) * speed,
+        (direction.y * cosSpread
+          + (right.y * Math.cos(rollAngle) + realUp.y * Math.sin(rollAngle)) * sinSpread) * speed,
+        (direction.z * cosSpread
+          + (right.z * Math.cos(rollAngle) + realUp.z * Math.sin(rollAngle)) * sinSpread) * speed,
+      );
+
+      // Spawn slightly ahead of nozzle so particles don't clip the barrel
+      p.position.set(
+        position.x + direction.x * 0.4,
+        position.y + direction.y * 0.4,
+        position.z + direction.z * 0.4,
+      );
+
+      p.life    = 0.25 + Math.random() * 0.20; // short — flame dissipates fast
+      p.maxLife = p.life;
+      p.gravity = 1.5; // slight upward curl cancels with velocity Y; net = gentle rise
+
+      // Colour palette: bright yellow core → orange → dark red smoke
+      const r = Math.random();
+      if (r < 0.30) {
+        p.colorStart.setHex(0xffee00); // yellow-white core
+        p.colorEnd.setHex(0xff4400);
+      } else if (r < 0.70) {
+        p.colorStart.setHex(0xff8800); // orange mid
+        p.colorEnd.setHex(0x881100);
+      } else {
+        p.colorStart.setHex(0xff3300); // deep red outer
+        p.colorEnd.setHex(0x330000);
+      }
+
+      p.startScale = 0.20 + Math.random() * 0.20;
+
+      p.mesh.material.color.copy(p.colorStart);
+      p.mesh.material.opacity = 0.85 + Math.random() * 0.15;
+      p.mesh.scale.setScalar(p.startScale);
+      p.mesh.position.copy(p.position);
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Per-frame update
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the Flame Tank flamethrower weapon per VISION.md §M7 (t039). Both player and AI Flame Tanks now deal continuous cone damage and emit fire particles when firing.

## Changes

**`src/entities/Tank.js`**
- `isFlameTank` getter (`tankClassId === 'flameTank'`)
- `getFlameMuzzle()` → world-space `{pos, dir}` for nozzle position + direction
- `fire()` returns `null` for Flame Tank (still sets `fireCooldown` to maintain 10 ticks/s rate); no `Projectile` created

**`src/systems/ParticleSystem.js`**
- `emitFlame(position, direction)`: 10 particles/tick in a ±30° cone, orange/yellow core → deep red smoke, 0.25–0.45 s lifetime

**`src/systems/CollisionSystem.js`**
- `applyFlameDamage(flameTank, muzzlePos, direction)`: cone hit detection (±30° half-angle, 20 u range), linear falloff, full kill callback chain (kill feed, wrecks, score, player death)

**`src/core/PlayerController.js`**
- `_updateTankMode()` returns `flameFired: boolean` when Flame Tank successfully fired

**`src/systems/AIController.js`**
- `setFlameAttackCallback(cb)`: Game.js hook for AI flame fire events
- `_driveTankTowardTarget()`: calls callback when AI Flame Tank's `fire()` returns `null`

**`src/core/Game.js`**
- Player: destructures `flameFired`, calls `collision.applyFlameDamage()` + `particles.emitFlame()` per tick
- AI: registers flame callback at startup covering both ally and enemy Flame Tanks

## Verification

- Flame Tank stats from TankDefs: 18 dmg/tick × 10 ticks/s = 180 DPS over 20 u range in 60° cone
- Blockers resolved: t036 (distinct tank mesh, merged #102), t003 (ParticleSystem, verified 2026-04-17)
- All 6 changed modules parse without errors

Resolves #55