### PR TITLE
t047: building/house geometry with destructible walls

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -6,6 +6,7 @@ import { CollisionSystem } from '../systems/CollisionSystem.js';
 import { ParticleSystem } from '../systems/ParticleSystem.js';
 import { TreeSystem } from '../systems/TreeSystem.js';
 import { WreckSystem } from '../systems/WreckSystem.js';
+import { BuildingSystem } from '../systems/BuildingSystem.js';
 import { HUD } from '../ui/HUD.js';
 import { KillFeed } from '../ui/KillFeed.js';
 import { MatchOverlay } from '../ui/MatchOverlay.js';
@@ -118,6 +119,9 @@ export class Game {
     this.particles = new ParticleSystem(this.scene);
     // TreeSystem spawns tree entities with HP; CollisionSystem handles shell hits
     this.trees = new TreeSystem(this.scene, this.terrain);
+    // BuildingSystem — destructible house/building geometry (t047).
+    // Spawns BUILDING_COUNT stacked-box buildings with independently destructible walls.
+    this.buildings = new BuildingSystem(this.scene, this.terrain);
     // WreckSystem — demolished tanks become cover props on the field.
     // spawnInitial places pre-placed wreck props at map start (t051); these
     // persist across round resets.  Dynamic wrecks (from kills) are added via
@@ -152,6 +156,7 @@ export class Game {
       projectiles: this.projectiles,
       treeSystem: this.trees,
       wrecks: this.wrecks,
+      buildingSystem: this.buildings,
     });
 
     this.collision
@@ -173,6 +178,14 @@ export class Game {
       })
       .onTreeDestroy((pos) => {
         // Full debris burst when tree is felled
+        this.particles.emitTreeDebris(pos);
+      })
+      .onWallHit((pos) => {
+        // Small impact burst to show a shell hit a wall
+        this.particles.emitExplosion(pos, { count: 6, speed: 3, lifetime: 0.3 });
+      })
+      .onWallDestroy((pos) => {
+        // Full debris burst when a wall is smashed or shelled down (t047)
         this.particles.emitTreeDebris(pos);
       })
       .onDamageDealt((tank, amount) => {
@@ -247,6 +260,8 @@ export class Game {
         this.wrecks.reset();
         // Respawn the destructible tree set so the field is full again next round.
         this.trees.reset();
+        // Respawn buildings with fresh walls so every round starts with cover intact.
+        this.buildings.reset();
         // Clear per-tank AI reaction timers so enemies don't carry over mid-fire
         // state from the previous round.
         this.aiController.reset();
@@ -637,6 +652,7 @@ export class Game {
       this.projectiles.reset();
       this.particles.reset();
       this.trees.reset();
+      this.buildings.reset();
       this.wrecks.reset();
       this._playerDustTimer = 0;
       this._enemyDustTimer = 0;

--- a/src/entities/Building.js
+++ b/src/entities/Building.js
@@ -1,0 +1,207 @@
+/**
+ * Building — a destructible structure entity.
+ *
+ * Each building consists of:
+ *  - A floor and roof (non-destructible, treated as permanent structure).
+ *  - Four walls (N, S, E, W), each independently destructible.
+ *
+ * Walls are built from BoxGeometry (flat-shaded, low-poly style) with a beige
+ * colour.  Each wall has 3 HP; projectile shells deal 1 damage per hit.  Tanks
+ * that drive into a wall instantly destroy it ("smash through" mechanic).
+ *
+ * Collision data:
+ *  Each wall exposes an AABB descriptor { cx, cz, hw, hd } where (cx, cz) is
+ *  the wall centre in world XZ, and hw/hd are the half-extents on X and Z.
+ *  CollisionSystem uses these for projectile interception and tank-smash checks.
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BUILD_W = 10;   // Building outer width  (X axis)
+const BUILD_D = 8;    // Building outer depth  (Z axis)
+const WALL_T  = 0.6;  // Wall thickness
+const WALL_H  = 3.5;  // Wall height
+
+/**
+ * Shots needed to destroy one wall.  Tanks bypass this (instant destruction).
+ */
+export const WALL_HP = 3;
+
+// ---------------------------------------------------------------------------
+// Shared geometry (created once per module — shared across all Building instances)
+// ---------------------------------------------------------------------------
+
+const _northSouthWallGeo = new THREE.BoxGeometry(BUILD_W, WALL_H, WALL_T);
+const _eastWestWallGeo   = new THREE.BoxGeometry(WALL_T, WALL_H, BUILD_D - 2 * WALL_T);
+const _floorGeo          = new THREE.BoxGeometry(BUILD_W, 0.3, BUILD_D);
+const _roofGeo           = new THREE.BoxGeometry(BUILD_W, 0.6, BUILD_D);
+
+// ---------------------------------------------------------------------------
+// Shared materials
+// ---------------------------------------------------------------------------
+
+const _wallMat  = new THREE.MeshStandardMaterial({ color: 0xd4b896, flatShading: true });
+const _roofMat  = new THREE.MeshStandardMaterial({ color: 0x8b4513, flatShading: true });
+const _floorMat = new THREE.MeshStandardMaterial({ color: 0xc8a87a, flatShading: true });
+
+// ---------------------------------------------------------------------------
+// Building
+// ---------------------------------------------------------------------------
+
+export class Building {
+  /**
+   * @param {THREE.Scene} scene
+   * @param {number}      x       World X position (building centre).
+   * @param {number}      z       World Z position (building centre).
+   * @param {number}      groundY Terrain height at (x, z).
+   */
+  constructor(scene, x, z, groundY) {
+    this._scene  = scene;
+    /** Building centre X — used for spatial queries. */
+    this.x       = x;
+    /** Building centre Z — used for spatial queries. */
+    this.z       = z;
+    this.width   = BUILD_W;
+    this.depth   = BUILD_D;
+
+    // ---- Non-destructible shell: floor + roof ----
+    this._group = new THREE.Group();
+    this._group.position.set(x, groundY, z);
+
+    const floor = new THREE.Mesh(_floorGeo, _floorMat);
+    floor.position.y = 0.15;
+    floor.receiveShadow = true;
+    this._group.add(floor);
+
+    const roof = new THREE.Mesh(_roofGeo, _roofMat);
+    roof.position.y = WALL_H + 0.3;
+    roof.castShadow = true;
+    this._group.add(roof);
+
+    scene.add(this._group);
+
+    // ---- Destructible walls (independent meshes, not children of _group) ----
+    /**
+     * Wall descriptors.  Each entry:
+     *   mesh  {THREE.Mesh}  — the wall's visual representation in the scene.
+     *   hp    {number}      — current hit-points.
+     *   alive {boolean}     — false once the wall has been destroyed.
+     *   cx    {number}      — wall centre X in world space.
+     *   cz    {number}      — wall centre Z in world space.
+     *   hw    {number}      — half-extent along X (AABB).
+     *   hd    {number}      — half-extent along Z (AABB).
+     *
+     * @type {Array<{mesh: THREE.Mesh, hp: number, alive: boolean,
+     *              cx: number, cz: number, hw: number, hd: number}>}
+     */
+    this.walls = [
+      // 0: North wall
+      this._makeWall(scene, groundY, {
+        geo: _northSouthWallGeo,
+        wx: x,                 wz: z - BUILD_D / 2,
+        cx: x,                 cz: z - BUILD_D / 2,
+        hw: BUILD_W / 2,       hd: WALL_T / 2,
+      }),
+      // 1: South wall
+      this._makeWall(scene, groundY, {
+        geo: _northSouthWallGeo,
+        wx: x,                 wz: z + BUILD_D / 2,
+        cx: x,                 cz: z + BUILD_D / 2,
+        hw: BUILD_W / 2,       hd: WALL_T / 2,
+      }),
+      // 2: East wall (fits between N+S walls)
+      this._makeWall(scene, groundY, {
+        geo: _eastWestWallGeo,
+        wx: x + BUILD_W / 2,   wz: z,
+        cx: x + BUILD_W / 2,   cz: z,
+        hw: WALL_T / 2,        hd: (BUILD_D - 2 * WALL_T) / 2,
+      }),
+      // 3: West wall
+      this._makeWall(scene, groundY, {
+        geo: _eastWestWallGeo,
+        wx: x - BUILD_W / 2,   wz: z,
+        cx: x - BUILD_W / 2,   cz: z,
+        hw: WALL_T / 2,        hd: (BUILD_D - 2 * WALL_T) / 2,
+      }),
+    ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build and scene-add one wall mesh; return its descriptor object.
+   *
+   * @param {THREE.Scene}  scene
+   * @param {number}       groundY
+   * @param {{ geo: THREE.BufferGeometry,
+   *           wx: number, wz: number,
+   *           cx: number, cz: number,
+   *           hw: number, hd: number }} opts
+   */
+  _makeWall(scene, groundY, { geo, wx, wz, cx, cz, hw, hd }) {
+    const mesh = new THREE.Mesh(geo, _wallMat);
+    mesh.position.set(wx, groundY + WALL_H / 2, wz);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    scene.add(mesh);
+
+    return { mesh, hp: WALL_HP, alive: true, cx, cz, hw, hd };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply damage to the wall at `wallIndex`.
+   * Returns true if this hit destroyed the wall (HP reached 0), false otherwise.
+   *
+   * @param {number} wallIndex  Index into `this.walls` (0-3).
+   * @param {number} amount     Damage to apply.
+   * @returns {boolean}
+   */
+  damageWall(wallIndex, amount) {
+    const wall = this.walls[wallIndex];
+    if (!wall.alive) return false;
+
+    wall.hp = Math.max(0, wall.hp - amount);
+    if (wall.hp === 0) {
+      wall.alive = false;
+      this._scene.remove(wall.mesh);
+      // If every wall is gone, remove the structural shell (floor + roof) too.
+      if (this.isFullyDestroyed) {
+        this._scene.remove(this._group);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * True when all four walls have been destroyed.
+   * @type {boolean}
+   */
+  get isFullyDestroyed() {
+    return this.walls.every(w => !w.alive);
+  }
+
+  /**
+   * Force-remove all meshes from the scene without running damage logic.
+   * Used by BuildingSystem.reset() between rounds.
+   */
+  destroy() {
+    for (const wall of this.walls) {
+      if (wall.alive) {
+        wall.alive = false;
+        this._scene.remove(wall.mesh);
+      }
+    }
+    this._scene.remove(this._group);
+  }
+}

--- a/src/systems/BuildingSystem.js
+++ b/src/systems/BuildingSystem.js
@@ -1,0 +1,91 @@
+/**
+ * BuildingSystem — owns all Building instances on the map.
+ *
+ * Responsibilities:
+ *  - Spawns BUILDING_COUNT buildings at pseudo-random world positions,
+ *    avoiding the tank spawn zones and the map centre so combat is not
+ *    immediately obstructed.
+ *  - Exposes `this.buildings` for CollisionSystem (projectile hit-tests and
+ *    tank-smash checks).
+ *  - `reset()` tears down the current building set and respawns a fresh one,
+ *    suitable for round reset.
+ *
+ * Building layout notes:
+ *  - MAP_RANGE (150) keeps buildings well inside the 200-unit terrain boundary.
+ *  - SPAWN_CLEAR_RADIUS (22) prevents buildings from appearing inside the
+ *    central combat spawn zone.
+ *  - The team spawn exclusion band (|z| ≈ 45-65) keeps the area immediately
+ *    behind each team's start position clear so tanks can move freely.
+ */
+
+import { Building } from '../entities/Building.js';
+
+const BUILDING_COUNT        = 7;
+/** Minimum XZ distance from world origin to prevent buildings blocking spawns. */
+const SPAWN_CLEAR_RADIUS    = 22;
+/** Spread of random placement in each axis. */
+const MAP_RANGE             = 150;
+/** Band around the team spawn rows (z ≈ ±55) that must stay clear. */
+const SPAWN_BAND_CENTRE_Z   = 55;
+const SPAWN_BAND_HALF_WIDTH = 14;
+
+export class BuildingSystem {
+  /**
+   * @param {THREE.Scene}                              scene
+   * @param {import('../entities/Terrain.js').Terrain} terrain
+   */
+  constructor(scene, terrain) {
+    this._scene   = scene;
+    this._terrain = terrain;
+
+    /** @type {import('../entities/Building.js').Building[]} */
+    this.buildings = [];
+
+    this._spawnBuildings();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  _spawnBuildings() {
+    let placed   = 0;
+    let attempts = 0;
+    // Allow up to 10× the target count in attempts to handle exclusion zones.
+    while (placed < BUILDING_COUNT && attempts < BUILDING_COUNT * 10) {
+      attempts++;
+      const x = (Math.random() - 0.5) * MAP_RANGE;
+      const z = (Math.random() - 0.5) * MAP_RANGE;
+
+      // Skip positions too close to the map centre (tank spawn zone).
+      if (Math.abs(x) < SPAWN_CLEAR_RADIUS && Math.abs(z) < SPAWN_CLEAR_RADIUS) {
+        continue;
+      }
+
+      // Skip the rows immediately around each team's spawn zone.
+      if (Math.abs(Math.abs(z) - SPAWN_BAND_CENTRE_Z) < SPAWN_BAND_HALF_WIDTH) {
+        continue;
+      }
+
+      const groundY = this._terrain.getHeightAt(x, z);
+      this.buildings.push(new Building(this._scene, x, z, groundY));
+      placed++;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Remove all buildings from the scene and respawn a fresh set.
+   * Call on round reset so walls are restored to full HP.
+   */
+  reset() {
+    for (const building of this.buildings) {
+      building.destroy();
+    }
+    this.buildings = [];
+    this._spawnBuildings();
+  }
+}

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -29,24 +29,28 @@
  *  onKillFeed(killer, victim)            — called on every tank kill for the kill feed UI
  *    killer: display name of the entity that scored the kill ('Player', 'Enemy #2', …)
  *    victim: display name of the destroyed tank
+ *  onWallHit(position)                   — called on every non-lethal shell hit on a building wall
+ *  onWallDestroy(position)               — called when a shell or tank destroys a building wall
  */
 export class CollisionSystem {
   /**
    * @param {object} opts
-   * @param {import('../entities/Terrain.js').Terrain}         opts.terrain
-   * @param {import('../entities/Tank.js').Tank}               opts.player
-   * @param {import('./EnemySystem.js').EnemySystem}           opts.enemies
-   * @param {import('./ProjectileSystem.js').ProjectileSystem} opts.projectiles
-   * @param {import('./TreeSystem.js').TreeSystem}             [opts.treeSystem]
-   * @param {import('./WreckSystem.js').WreckSystem}           [opts.wrecks]
+   * @param {import('../entities/Terrain.js').Terrain}             opts.terrain
+   * @param {import('../entities/Tank.js').Tank}                   opts.player
+   * @param {import('./EnemySystem.js').EnemySystem}               opts.enemies
+   * @param {import('./ProjectileSystem.js').ProjectileSystem}     opts.projectiles
+   * @param {import('./TreeSystem.js').TreeSystem}                 [opts.treeSystem]
+   * @param {import('./WreckSystem.js').WreckSystem}               [opts.wrecks]
+   * @param {import('./BuildingSystem.js').BuildingSystem}         [opts.buildingSystem]
    */
-  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null }) {
+  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null, buildingSystem = null }) {
     this.terrain = terrain;
     this.player = player;
     this.enemies = enemies;
     this.projectiles = projectiles;
     this.treeSystem = treeSystem;
     this.wrecks = wrecks;
+    this.buildingSystem = buildingSystem;
 
     this._onScoreAdd = null;
     this._onPlayerDeath = null;
@@ -57,6 +61,8 @@ export class CollisionSystem {
     this._onTreeHit = null;
     this._onTreeDestroy = null;
     this._onKillFeed = null;
+    this._onWallHit = null;
+    this._onWallDestroy = null;
 
     /**
      * Approximate half-width of a tank hull for obstacle push-back.
@@ -151,6 +157,18 @@ export class CollisionSystem {
     return this;
   }
 
+  /** @param {(position: import('three').Vector3) => void} cb */
+  onWallHit(cb) {
+    this._onWallHit = cb;
+    return this;
+  }
+
+  /** @param {(position: import('three').Vector3) => void} cb */
+  onWallDestroy(cb) {
+    this._onWallDestroy = cb;
+    return this;
+  }
+
   // ---------------------------------------------------------------------------
   // Per-frame entry point
   // ---------------------------------------------------------------------------
@@ -158,6 +176,10 @@ export class CollisionSystem {
   update() {
     this._checkProjectileCollisions();
     this._checkTankObstacleCollisions();
+    // Tank-smash building walls (tanks instantly destroy walls they drive into).
+    if (this.buildingSystem) {
+      this._checkTankBuildingCollisions();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -290,6 +312,11 @@ export class CollisionSystem {
     // All projectiles vs destructible trees
     if (this.treeSystem) {
       this._checkProjectileTreeCollisions();
+    }
+
+    // All projectiles vs destructible building walls
+    if (this.buildingSystem) {
+      this._checkProjectileBuildingCollisions();
     }
 
     // Explosive projectiles that reach terrain level explode on impact. (t032)
@@ -571,5 +598,138 @@ export class CollisionSystem {
         }
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Building collision helpers (t047)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Check every active projectile against every alive building wall.
+   *
+   * Uses an AABB check in XZ combined with a vertical bounds check (so shells
+   * flying at ground level below a wall base don't register).  Each wall
+   * half-extent is padded by PROJ_R to account for the shell's own width and
+   * prevent thin-wall tunnelling for slow-to-mid-speed shots.
+   *
+   * Explosive projectiles detonate on wall contact and apply splash as normal.
+   * Non-explosive shells deal 1 damage; WALL_HP = 3, so 3 hits destroy a wall.
+   */
+  _checkProjectileBuildingCollisions() {
+    const PROJ_R   = 0.35; // Shell radius buffer (world units)
+    const projectiles = this.projectiles.active;
+    const buildings   = this.buildingSystem.buildings;
+
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p  = projectiles[i];
+      const px = p.mesh.position.x;
+      const py = p.mesh.position.y;
+      const pz = p.mesh.position.z;
+
+      let consumed = false;
+
+      for (const building of buildings) {
+        if (consumed) break;
+
+        for (let wi = 0; wi < building.walls.length; wi++) {
+          const wall = building.walls[wi];
+          if (!wall.alive) continue;
+
+          // Padded AABB check in XZ plane
+          if (
+            px < wall.cx - wall.hw - PROJ_R || px > wall.cx + wall.hw + PROJ_R ||
+            pz < wall.cz - wall.hd - PROJ_R || pz > wall.cz + wall.hd + PROJ_R
+          ) continue;
+
+          // Vertical bounds: wall spans (mesh.y - WALL_H/2) to (mesh.y + WALL_H/2)
+          const wallMidY  = wall.mesh.position.y;
+          const wallMinY  = wallMidY - 1.75; // WALL_H/2 = 1.75
+          const wallMaxY  = wallMidY + 1.75;
+          if (py < wallMinY - PROJ_R || py > wallMaxY + PROJ_R) continue;
+
+          // Hit confirmed
+          const hitPos = p.mesh.position.clone();
+          this.projectiles.remove(i);
+
+          // Explosives trigger splash before damaging the wall.
+          if (p.splashRadius > 0) {
+            this._applySplashToEnemies(p, hitPos, null);
+            this._applySplashToPlayer(p, hitPos, null);
+            if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+          }
+
+          const destroyed = building.damageWall(wi, p.damage);
+          if (destroyed) {
+            if (this._onWallDestroy) this._onWallDestroy(hitPos);
+          } else if (!p.splashRadius) {
+            if (this._onWallHit) this._onWallHit(hitPos);
+          }
+
+          consumed = true;
+          break; // projectile consumed; skip remaining walls
+        }
+      }
+    }
+  }
+
+  /**
+   * Tank-smash mechanic: when a tank's circular footprint overlaps a building
+   * wall's AABB, the wall is instantly destroyed (tanks smash through walls).
+   *
+   * The tank is NOT pushed back — it continues moving through the destroyed
+   * wall gap.  This is intentional per the VISION ("Tanks smash through walls").
+   *
+   * All living tanks (player + all enemies) are checked each frame.
+   */
+  _checkTankBuildingCollisions() {
+    const buildings = this.buildingSystem.buildings;
+    const tankR     = this._tankRadius;
+
+    const tanks = [this.player, ...this.enemies.active];
+
+    for (const tank of tanks) {
+      const tx = tank.mesh.position.x;
+      const tz = tank.mesh.position.z;
+
+      for (const building of buildings) {
+        for (let wi = 0; wi < building.walls.length; wi++) {
+          const wall = building.walls[wi];
+          if (!wall.alive) continue;
+
+          if (!this._circleOverlapsAABB(tx, tz, tankR, wall.cx, wall.cz, wall.hw, wall.hd)) {
+            continue;
+          }
+
+          // Tank smash — instant destruction regardless of wall HP.
+          const wallPos = wall.mesh.position.clone();
+          building.damageWall(wi, 999); // 999 >> WALL_HP guarantees destruction
+          if (this._onWallDestroy) this._onWallDestroy(wallPos);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns true if a circle (cx, cz, r) overlaps an axis-aligned rectangle
+   * centred at (ax, az) with half-extents (hw, hd).
+   *
+   * Uses the standard "nearest point on AABB" approach which is correct for
+   * all relative positions (inside, outside, corner).
+   *
+   * @param {number} cx  Circle centre X.
+   * @param {number} cz  Circle centre Z.
+   * @param {number} r   Circle radius.
+   * @param {number} ax  AABB centre X.
+   * @param {number} az  AABB centre Z.
+   * @param {number} hw  AABB half-extent along X.
+   * @param {number} hd  AABB half-extent along Z.
+   * @returns {boolean}
+   */
+  _circleOverlapsAABB(cx, cz, r, ax, az, hw, hd) {
+    const nearX = Math.max(ax - hw, Math.min(cx, ax + hw));
+    const nearZ = Math.max(az - hd, Math.min(cz, az + hd));
+    const dx    = cx - nearX;
+    const dz    = cz - nearZ;
+    return dx * dx + dz * dz < r * r;
   }
 }


### PR DESCRIPTION
## Summary

Implements t047: building/house geometry — stacked boxes with flat-color roofs where destructible walls break into debris.

## What was done

- **`src/entities/Building.js`** (new): Building entity composed of a floor, roof (both permanent), and 4 independently destructible walls (N, S, E, W). Each wall is a `BoxGeometry` with flat-shaded `MeshStandardMaterial`. Wall HP = 3 (3 shell hits to destroy). Wall AABB collision data (`cx`, `cz`, `hw`, `hd`) exposed for `CollisionSystem`.

- **`src/systems/BuildingSystem.js`** (new): Manages 7 buildings spawned at pseudo-random map positions, avoiding the central spawn zone and team deployment bands. `reset()` respawns fresh buildings each round.

- **`src/systems/CollisionSystem.js`** (updated): AABB-based wall collision added:
  - `_checkProjectileBuildingCollisions()`: projectile center checked against padded wall AABB + vertical bounds; explosive projectiles trigger splash; 1 damage per hit; 3 hits destroy a wall.
  - `_checkTankBuildingCollisions()`: tanks that overlap a wall AABB instantly destroy it (`damageWall(wi, 999)`) and pass through — "tanks smash through walls" mechanic from VISION.md.
  - `_circleOverlapsAABB()`: circle-vs-AABB helper using nearest-point method.
  - `onWallHit` / `onWallDestroy` callbacks wired to particle system.

- **`src/core/Game.js`** (updated): Imports `BuildingSystem`, instantiates `this.buildings`, passes to `CollisionSystem`, registers `onWallHit` (small impact burst) and `onWallDestroy` (full debris burst via `emitTreeDebris`), and calls `buildings.reset()` on round-reset and match-restart.

## Verification

- `npm run build` completes without errors (41 modules, no new warnings).
- AABB overlap logic verified with manual node test (tank at (0,-3.5) overlaps north wall, tank at origin does not).

Resolves #63