### PR TITLE
t048: VillageGenerator: procedural clusters of 3-8 buildings with dirt paths

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { Terrain } from '../entities/Terrain.js';
+import { VillageGenerator } from '../entities/Village.js';
 import { InputSystem } from '../systems/InputSystem.js';
 import { ProjectileSystem } from '../systems/ProjectileSystem.js';
 import { CollisionSystem } from '../systems/CollisionSystem.js';
@@ -125,6 +126,11 @@ export class Game {
     this.wrecks = new WreckSystem(this.scene);
     this.wrecks.spawnInitial(this.terrain);
 
+    // VillageGenerator — procedural village clusters with destructible buildings
+    // and dirt paths (t047/t048).  Buildings persist across round resets (the
+    // map layout stays the same; only dynamic wrecks and projectiles are cleared).
+    this.village = new VillageGenerator(this.scene, this.terrain);
+
     // Dust-emission timers
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
@@ -152,6 +158,7 @@ export class Game {
       projectiles: this.projectiles,
       treeSystem: this.trees,
       wrecks: this.wrecks,
+      villageSystem: this.village,
     });
 
     this.collision
@@ -189,6 +196,10 @@ export class Game {
         // Particle count scales with splash radius so bigger weapons feel bigger.
         const count = Math.round(25 + splashRadius * 3);
         this.particles.emitExplosion(pos, { count, speed: 10, lifetime: 1.0 });
+      })
+      .onBuildingWallDestroyed((pos) => {
+        // Medium debris burst when a wall panel is knocked down (t047/t048).
+        this.particles.emitExplosion(pos, { count: 20, speed: 7, lifetime: 0.8 });
       });
 
     // SaveSystem: load persisted player profile from localStorage (t015).

--- a/src/entities/Building.js
+++ b/src/entities/Building.js
@@ -1,0 +1,249 @@
+/**
+ * Building — a destructible environment structure (t047).
+ *
+ * Geometry:
+ *   4 wall panels (N/S/E/W) as separate BoxGeometry meshes, each with HP.
+ *   Flat roof box on top (indestructible — stays even as walls fall).
+ *   Thin floor/foundation plane.
+ *
+ * Destruction:
+ *   Each wall takes `WALL_HP` hits before being removed from the scene.
+ *   When all 4 walls are gone the obstacle radius is zeroed so tanks can
+ *   drive through the ruins.
+ *
+ * Collision:
+ *   Exposes `obstacle: { x, z, radius }` compatible with CollisionSystem's
+ *   existing push-back helpers.  Radius is set to zero once the building is
+ *   fully destroyed.
+ *
+ * Projectile hit:
+ *   Call `hitByProjectile(worldPos, damage)` — it finds the closest alive wall
+ *   and deducts damage, returning metadata used by CollisionSystem callbacks.
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Shared materials (module-level singletons — one material per color)
+// ---------------------------------------------------------------------------
+
+const _wallMat = new THREE.MeshStandardMaterial({
+  color: 0xe0c898,  // warm sandy beige
+  roughness: 0.9,
+  flatShading: true,
+});
+
+const _roofMat = new THREE.MeshStandardMaterial({
+  color: 0x7a3820,  // dark terracotta
+  roughness: 0.85,
+  flatShading: true,
+});
+
+const _floorMat = new THREE.MeshStandardMaterial({
+  color: 0xc8a060,  // tan earth
+  roughness: 1.0,
+  flatShading: true,
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WALL_HEIGHT    = 3.5;
+const WALL_THICKNESS = 0.4;
+const WALL_HP        = 3;    // hits required to destroy one wall
+
+// ---------------------------------------------------------------------------
+// Building
+// ---------------------------------------------------------------------------
+
+export class Building {
+  /**
+   * @param {THREE.Scene}                              scene
+   * @param {number}                                   x       World X centre.
+   * @param {number}                                   z       World Z centre.
+   * @param {number}                                   width   X dimension.
+   * @param {number}                                   depth   Z dimension.
+   * @param {import('./Terrain.js').Terrain}           terrain Used for ground height.
+   */
+  constructor(scene, x, z, width, depth, terrain) {
+    this._scene  = scene;
+    this.x       = x;
+    this.z       = z;
+    this.width   = width;
+    this.depth   = depth;
+
+    const groundY  = terrain.getHeightAt(x, z);
+    this._groundY  = groundY;
+
+    /** Bounding circle radius for tank push-back (footprint diagonal / 2). */
+    this.radius = Math.sqrt(
+      (width  / 2) * (width  / 2) +
+      (depth  / 2) * (depth  / 2)
+    );
+
+    /**
+     * Obstacle record compatible with CollisionSystem's existing push-back.
+     * Radius is zeroed when all walls are gone (tanks can pass through ruins).
+     * @type {{ x: number, z: number, radius: number }}
+     */
+    this.obstacle = { x, z, radius: this.radius };
+
+    /**
+     * Individual wall records.
+     * @type {Array<{ mesh: THREE.Mesh, hp: number, alive: boolean, side: string }>}
+     */
+    this.walls = [];
+
+    /** False once every wall is destroyed. */
+    this._alive = true;
+
+    // Build the Three.js group
+    this.group = new THREE.Group();
+    this.group.position.set(x, groundY, z);
+    scene.add(this.group);
+
+    this._buildStructure();
+  }
+
+  /** True while at least one wall is standing. */
+  get alive() { return this._alive; }
+
+  // ---------------------------------------------------------------------------
+  // Construction
+  // ---------------------------------------------------------------------------
+
+  _buildStructure() {
+    const W  = this.width;
+    const D  = this.depth;
+    const WT = WALL_THICKNESS;
+    const WH = WALL_HEIGHT;
+
+    // Foundation slab
+    const floorGeo = new THREE.BoxGeometry(W + 0.3, 0.15, D + 0.3);
+    const floorMesh = new THREE.Mesh(floorGeo, _floorMat);
+    floorMesh.position.y = 0.075;
+    floorMesh.receiveShadow = true;
+    this.group.add(floorMesh);
+
+    // North wall (local z = −depth/2): full width, inset to sit inside footprint.
+    this._addWall('north',
+      0,             WH / 2, -(D / 2 - WT / 2),
+      W,             WH,     WT);
+
+    // South wall (local z = +depth/2)
+    this._addWall('south',
+      0,             WH / 2, +(D / 2 - WT / 2),
+      W,             WH,     WT);
+
+    // East wall (local x = +width/2): depth inset by WT×2 so corners don't double up.
+    this._addWall('east',
+      +(W / 2 - WT / 2), WH / 2, 0,
+      WT,                WH,     D - 2 * WT);
+
+    // West wall
+    this._addWall('west',
+      -(W / 2 - WT / 2), WH / 2, 0,
+      WT,                WH,     D - 2 * WT);
+
+    // Roof slab (indestructible — sits atop walls)
+    const roofGeo  = new THREE.BoxGeometry(W + 0.5, 0.3, D + 0.5);
+    const roofMesh = new THREE.Mesh(roofGeo, _roofMat);
+    roofMesh.position.y = WH + 0.15;
+    roofMesh.castShadow = true;
+    this.group.add(roofMesh);
+  }
+
+  /**
+   * Create one wall panel and register it.
+   *
+   * @param {string} side  'north'|'south'|'east'|'west'
+   * @param {number} lx    Local X offset.
+   * @param {number} ly    Local Y offset (centre of wall).
+   * @param {number} lz    Local Z offset.
+   * @param {number} w     Box width  (X).
+   * @param {number} h     Box height (Y).
+   * @param {number} d     Box depth  (Z).
+   */
+  _addWall(side, lx, ly, lz, w, h, d) {
+    const geo  = new THREE.BoxGeometry(w, h, d);
+    const mesh = new THREE.Mesh(geo, _wallMat);
+    mesh.position.set(lx, ly, lz);
+    mesh.castShadow    = true;
+    mesh.receiveShadow = true;
+    this.group.add(mesh);
+    this.walls.push({ mesh, hp: WALL_HP, alive: true, side });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply projectile damage to the closest alive wall.
+   *
+   * @param {THREE.Vector3} hitWorldPos  World-space hit position.
+   * @param {number}        damage       Amount of HP to remove.
+   * @returns {{ hit: boolean, wallDestroyed: boolean, buildingDestroyed: boolean }}
+   */
+  hitByProjectile(hitWorldPos, damage) {
+    // Find the closest alive wall by world-space distance to its centre.
+    let closest     = null;
+    let closestDist = Infinity;
+    const wallWorld = new THREE.Vector3();
+
+    for (const wall of this.walls) {
+      if (!wall.alive) { continue; }
+      wall.mesh.getWorldPosition(wallWorld);
+      const dist = hitWorldPos.distanceTo(wallWorld);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closest     = wall;
+      }
+    }
+
+    if (!closest) {
+      return { hit: false, wallDestroyed: false, buildingDestroyed: false };
+    }
+
+    closest.hp = Math.max(0, closest.hp - damage);
+
+    let wallDestroyed     = false;
+    let buildingDestroyed = false;
+
+    if (closest.hp === 0) {
+      wallDestroyed  = true;
+      closest.alive  = false;
+      this.group.remove(closest.mesh);
+
+      // Dispose geometry to release GPU memory.
+      closest.mesh.geometry.dispose();
+
+      const allDown = this.walls.every(w => !w.alive);
+      if (allDown) {
+        this._alive           = false;
+        buildingDestroyed     = true;
+        this.obstacle.radius  = 0;  // tanks may now pass through the ruins
+      }
+    }
+
+    return { hit: true, wallDestroyed, buildingDestroyed };
+  }
+
+  /**
+   * Returns true if the given world XZ point is within the building AABB.
+   * Used by CollisionSystem for a fast pre-filter before calling
+   * `hitByProjectile`.
+   *
+   * @param {number} worldX
+   * @param {number} worldZ
+   * @returns {boolean}
+   */
+  containsPointXZ(worldX, worldZ) {
+    const hw = this.width  / 2 + 0.5;
+    const hd = this.depth  / 2 + 0.5;
+    const lx = worldX - this.x;
+    const lz = worldZ - this.z;
+    return lx >= -hw && lx <= hw && lz >= -hd && lz <= hd;
+  }
+}

--- a/src/entities/Village.js
+++ b/src/entities/Village.js
@@ -1,0 +1,243 @@
+/**
+ * VillageGenerator — procedural village cluster placement (t048).
+ *
+ * Generates NUM_CLUSTERS village clusters, each containing 3–8 buildings
+ * spread across a CLUSTER_SPREAD-unit radius.  Dirt-path ground planes are
+ * placed between and around each cluster to give a worn-road appearance.
+ *
+ * Placement rules:
+ *  - Clusters avoid the team spawn lanes (|z| 35–75) so fights don't start
+ *    inside a building.
+ *  - Buildings within a cluster are checked for overlap; failures are retried.
+ *  - A random 40 % of buildings are rotated 90° so the streetscape varies.
+ *
+ * Collision integration:
+ *  - `this.buildings` holds all Building instances.
+ *  - `this.activeObstacles` returns the live obstacle list compatible with
+ *    CollisionSystem's push-back helpers ({ x, z, radius }).  Obstacles whose
+ *    radius has been zeroed (fully destroyed building) are filtered out.
+ */
+
+import * as THREE from 'three';
+import { Building } from './Building.js';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const NUM_CLUSTERS    = 3;   // village clusters on the map
+const CLUSTER_SPREAD  = 14;  // max XZ offset for buildings within a cluster
+const MIN_CLUSTER_SEP = 38;  // minimum separation between cluster centres
+const WORLD_HALF      = 80;  // buildings placed within ±80 units
+
+// Building footprint presets (width × depth, in world units)
+const BUILDING_PRESETS = [
+  { width:  7, depth: 5 },  // small cottage
+  { width:  8, depth: 6 },  // standard house
+  { width: 10, depth: 7 },  // larger house
+  { width:  9, depth: 8 },  // square house
+  { width: 12, depth: 6 },  // long barracks
+];
+
+const BUILDING_GAP = 2.5;   // minimum clear space between adjacent building footprints
+
+const DIRT_COLOR   = 0x9e825a;  // worn-earth path colour
+
+// ---------------------------------------------------------------------------
+// VillageGenerator
+// ---------------------------------------------------------------------------
+
+export class VillageGenerator {
+  /**
+   * @param {THREE.Scene}                              scene
+   * @param {import('./Terrain.js').Terrain}           terrain
+   */
+  constructor(scene, terrain) {
+    this._scene   = scene;
+    this._terrain = terrain;
+
+    /** @type {Building[]} */
+    this.buildings = [];
+
+    this._generate();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Live obstacle list for CollisionSystem.
+   * Filters out any building that has been fully destroyed (radius === 0).
+   * @returns {Array<{ x: number, z: number, radius: number }>}
+   */
+  get activeObstacles() {
+    const out = [];
+    for (const b of this.buildings) {
+      if (b.obstacle.radius > 0) {
+        out.push(b.obstacle);
+      }
+    }
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private generation
+  // ---------------------------------------------------------------------------
+
+  _generate() {
+    const centers = this._clusterCenters();
+    for (const c of centers) {
+      const count = 3 + Math.floor(Math.random() * 6); // 3–8
+      this._buildCluster(c.x, c.z, count);
+      this._placePaths(c.x, c.z);
+    }
+  }
+
+  /**
+   * Pick NUM_CLUSTERS well-separated cluster centres, avoiding spawn lanes.
+   * @returns {Array<{x:number, z:number}>}
+   */
+  _clusterCenters() {
+    const centers = [];
+    let attempts  = 0;
+
+    while (centers.length < NUM_CLUSTERS && attempts < NUM_CLUSTERS * 30) {
+      attempts++;
+      const x = (Math.random() - 0.5) * WORLD_HALF * 2;
+      const z = (Math.random() - 0.5) * WORLD_HALF * 2;
+
+      // Avoid the edge buffer
+      if (Math.abs(x) > WORLD_HALF - 10 || Math.abs(z) > WORLD_HALF - 10) { continue; }
+
+      // Avoid team spawn lanes: players spawn at z = ±55 with spread ±30.
+      // Keep clusters away from |z| = 35–75 to prevent first-contact inside buildings.
+      if (Math.abs(z) > 35 && Math.abs(z) < 75) { continue; }
+
+      // Enforce minimum separation between cluster centres.
+      let tooClose = false;
+      for (const c of centers) {
+        const dx = x - c.x;
+        const dz = z - c.z;
+        if (dx * dx + dz * dz < MIN_CLUSTER_SEP * MIN_CLUSTER_SEP) {
+          tooClose = true;
+          break;
+        }
+      }
+      if (tooClose) { continue; }
+
+      centers.push({ x, z });
+    }
+
+    return centers;
+  }
+
+  /**
+   * Attempt to place `count` buildings around the cluster centre (cx, cz).
+   * Uses rejection sampling with BUILDING_GAP clearance between footprints.
+   *
+   * @param {number} cx   Cluster centre X.
+   * @param {number} cz   Cluster centre Z.
+   * @param {number} count  Target building count.
+   */
+  _buildCluster(cx, cz, count) {
+    const placed = [];   // { x, z, width, depth }
+    let attempts = 0;
+
+    while (placed.length < count && attempts < count * 25) {
+      attempts++;
+
+      const offsetX = (Math.random() - 0.5) * CLUSTER_SPREAD * 2;
+      const offsetZ = (Math.random() - 0.5) * CLUSTER_SPREAD * 2;
+      const wx      = cx + offsetX;
+      const wz      = cz + offsetZ;
+
+      // Pick a random preset and optionally rotate 90°
+      const preset  = BUILDING_PRESETS[Math.floor(Math.random() * BUILDING_PRESETS.length)];
+      const rotate  = Math.random() < 0.4;
+      const w       = rotate ? preset.depth : preset.width;
+      const d       = rotate ? preset.width : preset.depth;
+
+      // Reject if the footprint overlaps any already-placed building
+      if (this._overlapsAny(wx, wz, w, d, placed)) { continue; }
+
+      // Also reject if too close to the world boundary
+      if (Math.abs(wx) + w / 2 > WORLD_HALF || Math.abs(wz) + d / 2 > WORLD_HALF) { continue; }
+
+      placed.push({ x: wx, z: wz, width: w, depth: d });
+      this.buildings.push(new Building(this._scene, wx, wz, w, d, this._terrain));
+    }
+  }
+
+  /**
+   * Returns true if a candidate footprint (cx, cz, w, d) overlaps any entry
+   * in the `placed` array by more than BUILDING_GAP.
+   */
+  _overlapsAny(cx, cz, w, d, placed) {
+    for (const p of placed) {
+      const minDx = (w + p.width)  / 2 + BUILDING_GAP;
+      const minDz = (d + p.depth)  / 2 + BUILDING_GAP;
+      if (Math.abs(cx - p.x) < minDx && Math.abs(cz - p.z) < minDz) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Place dirt-path ground planes around a cluster centre.
+   *
+   * Generates:
+   *  - A central cross patch at the cluster heart.
+   *  - 2–3 spoke paths radiating outward in random directions.
+   *
+   * @param {number} cx   Cluster centre X.
+   * @param {number} cz   Cluster centre Z.
+   */
+  _placePaths(cx, cz) {
+    const mat = new THREE.MeshStandardMaterial({
+      color:     DIRT_COLOR,
+      roughness: 1.0,
+      flatShading: true,
+    });
+
+    // Central dirt plaza
+    const plazaSize = 6 + Math.random() * 4;
+    this._addPathPlane(cx, cz, plazaSize, plazaSize, 0, mat);
+
+    // Spoke paths
+    const spokeCount = 2 + Math.floor(Math.random() * 2);   // 2–3
+    for (let i = 0; i < spokeCount; i++) {
+      const angle  = (i / spokeCount) * Math.PI * 2 + (Math.random() - 0.5) * 0.8;
+      const len    = CLUSTER_SPREAD * 1.3 + Math.random() * 5;
+      const pathW  = 2.2 + Math.random() * 0.8;
+
+      const midX = cx + Math.cos(angle) * len / 2;
+      const midZ = cz + Math.sin(angle) * len / 2;
+
+      this._addPathPlane(midX, midZ, pathW, len, angle, mat);
+    }
+  }
+
+  /**
+   * Spawn a single flat-box path plane at world position (wx, wz).
+   *
+   * @param {number}              wx      Path centre X.
+   * @param {number}              wz      Path centre Z.
+   * @param {number}              width   Path width (local X before rotation).
+   * @param {number}              length  Path length (local Z before rotation).
+   * @param {number}              rotY    Y-axis rotation in radians.
+   * @param {THREE.Material}      mat
+   */
+  _addPathPlane(wx, wz, width, length, rotY, mat) {
+    const geo  = new THREE.BoxGeometry(width, 0.08, length);
+    const mesh = new THREE.Mesh(geo, mat);
+
+    const groundY = this._terrain.getHeightAt(wx, wz);
+    mesh.position.set(wx, groundY + 0.03, wz);
+    mesh.rotation.y   = rotY;
+    mesh.receiveShadow = true;
+
+    this._scene.add(mesh);
+  }
+}

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -10,12 +10,16 @@
  *  4. Tank-vs-obstacle blocking: pushes tanks out of rocks and living trees.
  *  5. Tank-vs-wreck blocking: same impulse resolve applied to WreckSystem
  *     obstacles so live tanks cannot drive through demolished hulls.
+ *  6. Projectile-vs-building collisions: shells damage building walls; fully
+ *     destroyed buildings stop blocking tanks (t047/t048).
+ *  7. Tank-vs-building blocking: tanks are pushed away from standing buildings
+ *     using the same impulse-resolve path as rocks/wrecks.
  *
  * Callbacks (set before first update):
  *  onScoreAdd(points)                    — called when an enemy tank is destroyed
  *  onPlayerDeath()                       — called when the player tank reaches 0 HP
  *  onHit(position, owner)                — called on every non-lethal shell impact
- *    owner: 'player' | 'enemy' | 'wreck'
+ *    owner: 'player' | 'enemy' | 'wreck' | 'building'
  *  onKill(position, owner, tankData)     — called when a shell destroys a tank
  *    owner: 'player' (player shell hit enemy) | 'enemy' (enemy shell hit player)
  *    tankData: { position: Vector3, rotationY: number } — snapshot for wreck spawning
@@ -29,6 +33,8 @@
  *  onKillFeed(killer, victim)            — called on every tank kill for the kill feed UI
  *    killer: display name of the entity that scored the kill ('Player', 'Enemy #2', …)
  *    victim: display name of the destroyed tank
+ *  onExplosion(position, splashRadius)   — called when an explosive projectile detonates
+ *  onBuildingWallDestroyed(position)     — called when a building wall is knocked down
  */
 export class CollisionSystem {
   /**
@@ -39,14 +45,16 @@ export class CollisionSystem {
    * @param {import('./ProjectileSystem.js').ProjectileSystem} opts.projectiles
    * @param {import('./TreeSystem.js').TreeSystem}             [opts.treeSystem]
    * @param {import('./WreckSystem.js').WreckSystem}           [opts.wrecks]
+   * @param {import('../entities/Village.js').VillageGenerator} [opts.villageSystem]
    */
-  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null }) {
+  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null, villageSystem = null }) {
     this.terrain = terrain;
     this.player = player;
     this.enemies = enemies;
     this.projectiles = projectiles;
     this.treeSystem = treeSystem;
     this.wrecks = wrecks;
+    this.villageSystem = villageSystem;
 
     this._onScoreAdd = null;
     this._onPlayerDeath = null;
@@ -57,6 +65,8 @@ export class CollisionSystem {
     this._onTreeHit = null;
     this._onTreeDestroy = null;
     this._onKillFeed = null;
+    this._onExplosion = null;
+    this._onBuildingWallDestroyed = null;
 
     /**
      * Approximate half-width of a tank hull for obstacle push-back.
@@ -151,6 +161,24 @@ export class CollisionSystem {
     return this;
   }
 
+  /**
+   * Called whenever an explosive projectile detonates (t032).
+   * @param {(position: import('three').Vector3, splashRadius: number) => void} cb
+   */
+  onExplosion(cb) {
+    this._onExplosion = cb;
+    return this;
+  }
+
+  /**
+   * Called whenever a building wall is knocked down (t047/t048).
+   * @param {(position: import('three').Vector3) => void} cb
+   */
+  onBuildingWallDestroyed(cb) {
+    this._onBuildingWallDestroyed = cb;
+    return this;
+  }
+
   // ---------------------------------------------------------------------------
   // Per-frame entry point
   // ---------------------------------------------------------------------------
@@ -158,6 +186,9 @@ export class CollisionSystem {
   update() {
     this._checkProjectileCollisions();
     this._checkTankObstacleCollisions();
+    if (this.villageSystem) {
+      this._checkProjectileBuildingCollisions();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -510,6 +541,17 @@ export class CollisionSystem {
         }
       }
     }
+
+    // Buildings block tanks until all their walls are destroyed (t047/t048)
+    if (this.villageSystem) {
+      const buildingObs = this.villageSystem.activeObstacles;
+      if (buildingObs.length > 0) {
+        this._resolveObstacleCollision(this.player.mesh, buildingObs);
+        for (const enemy of this.enemies.active) {
+          this._resolveObstacleCollision(enemy.mesh, buildingObs);
+        }
+      }
+    }
   }
 
   /**
@@ -569,6 +611,66 @@ export class CollisionSystem {
           pos.x += (dx / dist) * overlap;
           pos.z += (dz / dist) * overlap;
         }
+      }
+    }
+  }
+
+  /**
+   * Check all active projectiles against all standing building walls (t047/t048).
+   *
+   * Uses a two-phase check:
+   *  1. Fast XZ distance check against the building's bounding radius.
+   *  2. AABB containment check to confirm the projectile is actually inside
+   *     the building footprint.
+   *
+   * On confirmed hit: calls building.hitByProjectile() which handles per-wall
+   * HP deduction and mesh removal.  Fires `_onBuildingWallDestroyed` so the
+   * game can emit debris particles.  Non-destructive hits use `_onHit`.
+   */
+  _checkProjectileBuildingCollisions() {
+    const projectiles = this.projectiles.active;
+    const buildings   = this.villageSystem.buildings;
+
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p   = projectiles[i];
+      const px  = p.mesh.position.x;
+      const pz  = p.mesh.position.z;
+
+      for (const building of buildings) {
+        if (!building.alive && building.obstacle.radius === 0) { continue; }
+
+        // Phase 1 — bounding-circle pre-filter
+        const dx      = px - building.x;
+        const dz      = pz - building.z;
+        const distSq  = dx * dx + dz * dz;
+        const checkR  = building.radius + 1.0; // small fudge for shell size
+        if (distSq > checkR * checkR) { continue; }
+
+        // Phase 2 — AABB containment
+        if (!building.containsPointXZ(px, pz)) { continue; }
+
+        // Hit confirmed — apply damage to the closest wall.
+        const hitPos = p.mesh.position.clone();
+        const result = building.hitByProjectile(hitPos, p.damage);
+
+        if (!result.hit) { continue; }
+
+        this.projectiles.remove(i);
+
+        // Explosive detonation: splash damage + explosion particle.
+        if (p.splashRadius > 0) {
+          this._applySplashToEnemies(p, hitPos, null);
+          this._applySplashToPlayer(p, hitPos, null);
+          if (this._onExplosion) { this._onExplosion(hitPos, p.splashRadius); }
+        }
+
+        if (result.wallDestroyed) {
+          if (this._onBuildingWallDestroyed) { this._onBuildingWallDestroyed(hitPos); }
+        } else if (!p.splashRadius) {
+          if (this._onHit) { this._onHit(hitPos, 'building'); }
+        }
+
+        break; // projectile consumed; skip remaining buildings
       }
     }
   }


### PR DESCRIPTION
## Summary

Implements t047 (Building geometry) and t048 (VillageGenerator) together since t047 is t048's direct dependency.

### What was done

**`src/entities/Building.js`** (t047)
- Destructible building entity: 4 wall panels (N/S/E/W) as separate `BoxGeometry` meshes, each with `WALL_HP = 3` hit points
- Flat-shaded materials: sandy-beige walls (`0xe0c898`), terracotta roof (`0x7a3820`), tan floor
- Indestructible roof slab stays even when walls are knocked down — visual ruin effect
- Bounding-circle obstacle (`{ x, z, radius }`) compatible with CollisionSystem push-back; radius zeroed when all walls are gone so tanks can drive through ruins
- `hitByProjectile(worldPos, damage)` finds closest alive wall, deducts HP, removes mesh on destruction, returns `{ hit, wallDestroyed, buildingDestroyed }`
- `containsPointXZ(x, z)` for fast AABB pre-filter in CollisionSystem

**`src/entities/Village.js`** (t048)
- `VillageGenerator` places 3 village clusters of 3–8 buildings each
- Cluster centres avoid team spawn lanes (`|z| 35–75`) and maintain 38-unit minimum separation
- Per-cluster: rejection-sampled building placement with 2.5-unit clearance gaps; 40% of buildings randomly rotated 90°
- 5 building presets (small cottage → long barracks)
- Dirt paths: central plaza + 2–3 spoke paths per cluster using thin `BoxGeometry` planes in worn-earth colour (`0x9e825a`)
- `activeObstacles` getter returns live obstacle list (filters radius-zeroed destroyed buildings)

**`src/systems/CollisionSystem.js`**
- Added `villageSystem` constructor parameter
- Tank-vs-building blocking via `activeObstacles` in `_checkTankObstacleCollisions()`
- New `_checkProjectileBuildingCollisions()`: bounding-circle pre-filter + AABB confirm → `hitByProjectile()` → absorbs projectile, fires splash on explosives, fires `_onBuildingWallDestroyed` callback
- Added missing `onExplosion(cb)` setter and `this._onExplosion = null` init (t032 regression: Game.js called `.onExplosion()` but the method didn't exist, silently breaking `.onTreeHit`/`.onTreeDestroy` registration)
- Added `onBuildingWallDestroyed(cb)` setter

**`src/core/Game.js`**
- Imports `VillageGenerator`; constructs after `WreckSystem`
- Passes `villageSystem: this.village` to CollisionSystem
- Wires `onBuildingWallDestroyed` → `ParticleSystem.emitExplosion` (20 particles, debris burst)

## Testing

Module parse verified:
```
node --input-type=module -e "import './src/entities/Building.js'; import './src/entities/Village.js';" ✓
node --input-type=module -e "import './src/systems/CollisionSystem.js';" ✓
node --input-type=module -e "import './src/core/Game.js';" ✓
```

Resolves #64