### PR TITLE
t049: Bridges and walls — destructible bridge, low walls/fences tanks drive through

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -23,6 +23,7 @@ import { SaveSystem } from '../systems/SaveSystem.js';
 import { LeagueSystem } from '../systems/LeagueSystem.js';
 import { LeagueDisplay } from '../ui/LeagueDisplay.js';
 import { getLeagueDef } from '../data/LeagueDefs.js';
+import { StructureSystem } from '../systems/StructureSystem.js';
 
 export class Game {
   constructor(canvas) {
@@ -125,6 +126,11 @@ export class Game {
     this.wrecks = new WreckSystem(this.scene);
     this.wrecks.spawnInitial(this.terrain);
 
+    // StructureSystem (t049) — destructible bridges and low walls/fences.
+    // Bridges absorb shells and collapse into rubble that blocks tank movement.
+    // Walls are destroyed by any shell hit or tank contact.
+    this.structures = new StructureSystem(this.scene, this.terrain);
+
     // Dust-emission timers
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
@@ -146,12 +152,13 @@ export class Game {
     };
 
     this.collision = new CollisionSystem({
-      terrain: this.terrain,
-      player: this.player,
-      enemies: this._enemiesAdapter,
-      projectiles: this.projectiles,
-      treeSystem: this.trees,
-      wrecks: this.wrecks,
+      terrain:         this.terrain,
+      player:          this.player,
+      enemies:         this._enemiesAdapter,
+      projectiles:     this.projectiles,
+      treeSystem:      this.trees,
+      wrecks:          this.wrecks,
+      structureSystem: this.structures,
     });
 
     this.collision
@@ -189,6 +196,19 @@ export class Game {
         // Particle count scales with splash radius so bigger weapons feel bigger.
         const count = Math.round(25 + splashRadius * 3);
         this.particles.emitExplosion(pos, { count, speed: 10, lifetime: 1.0 });
+      })
+      // t049 — bridge and wall feedback
+      .onBridgeHit((pos) => {
+        // Small concrete-chip burst when a shell hits but doesn't destroy a bridge
+        this.particles.emitExplosion(pos, { count: 10, speed: 5, lifetime: 0.5 });
+      })
+      .onBridgeDestroyed((pos) => {
+        // Large debris burst when the bridge collapses
+        this.particles.emitExplosion(pos, { count: 50, speed: 12, lifetime: 1.2 });
+      })
+      .onWallDestroyed((pos) => {
+        // Medium stone-fragment burst when a wall is smashed
+        this.particles.emitExplosion(pos, { count: 18, speed: 7, lifetime: 0.7 });
       });
 
     // SaveSystem: load persisted player profile from localStorage (t015).
@@ -247,6 +267,8 @@ export class Game {
         this.wrecks.reset();
         // Respawn the destructible tree set so the field is full again next round.
         this.trees.reset();
+        // Respawn bridges and walls so the field is fully intact next round (t049).
+        this.structures.reset();
         // Clear per-tank AI reaction timers so enemies don't carry over mid-fire
         // state from the previous round.
         this.aiController.reset();
@@ -638,6 +660,8 @@ export class Game {
       this.particles.reset();
       this.trees.reset();
       this.wrecks.reset();
+      // Respawn bridges and walls for the fresh match (t049).
+      this.structures.reset();
       this._playerDustTimer = 0;
       this._enemyDustTimer = 0;
       this.hud.hideGameOver();

--- a/src/entities/Bridge.js
+++ b/src/entities/Bridge.js
@@ -1,0 +1,226 @@
+/**
+ * Bridge — a destructible map structure spanning a low terrain area.
+ *
+ * Gameplay behaviour:
+ *  - Intact bridge: absorbs projectile hits, takes damage.  Tanks pass freely
+ *    through the bridge zone (the deck sits at terrain level, so terrain-following
+ *    Y-snapping still works).
+ *  - Damaged bridge (HP ≤ 50 %): visual appearance darkens.
+ *  - Destroyed bridge (HP = 0): deck collapses (tilts, darkens); railings hide.
+ *    Four rubble-circle obstacles are spawned at world positions along the span
+ *    so CollisionSystem can block tanks from passing through the rubble.
+ *
+ * Geometry (all in local space, rotated by `rotY` when added to scene):
+ *  - Deck: BoxGeometry(deckWidth × 0.6 × deckLength)  — local X = across, local Z = along
+ *  - Two railings: long thin boxes on ±X edges
+ *  - Two cross-braces: wide flat boxes at ±Z ends (supports)
+ *
+ * Collision (OBB in XZ):
+ *  - halfWidth  = deckWidth  / 2   (local X extent)
+ *  - halfSpan   = deckLength / 2   (local Z extent)
+ *  - radius     = sqrt(halfWidth² + halfSpan²)  — fast pre-check distance
+ *
+ * @module entities/Bridge
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Shared materials (module-level singletons to avoid repeated GPU allocation)
+// ---------------------------------------------------------------------------
+
+const _deckMat = new THREE.MeshStandardMaterial({
+  color: 0x8b7355,   // weathered wood
+  roughness: 0.9,
+  metalness: 0.0,
+  flatShading: true,
+});
+
+const _pillarMat = new THREE.MeshStandardMaterial({
+  color: 0x7a7870,   // aged concrete
+  roughness: 0.85,
+  metalness: 0.05,
+  flatShading: true,
+});
+
+const _damagedMat = new THREE.MeshStandardMaterial({
+  color: 0x3e2800,   // charred / collapsed wood
+  roughness: 1.0,
+  metalness: 0.0,
+  flatShading: true,
+});
+
+// ---------------------------------------------------------------------------
+// Bridge
+// ---------------------------------------------------------------------------
+
+export class Bridge {
+  /**
+   * @param {THREE.Scene} scene
+   * @param {number}      x        World X of bridge centre.
+   * @param {number}      z        World Z of bridge centre.
+   * @param {number}      groundY  Terrain height at (x, z).
+   * @param {number}      [rotY=0] Rotation around Y axis in radians.
+   *   rotY = 0        → bridge deck spans along world Z (N–S crossing).
+   *   rotY = Math.PI/2 → bridge deck spans along world X (E–W crossing).
+   * @param {number}      [deckWidth=8]   Width of the bridge deck (local X).
+   * @param {number}      [deckLength=18] Span of the bridge (local Z).
+   */
+  constructor(scene, x, z, groundY, rotY = 0, deckWidth = 8, deckLength = 18) {
+    this._scene  = scene;
+    this.x       = x;
+    this.z       = z;
+    this.groundY = groundY;
+    this.rotY    = rotY;
+
+    this.deckWidth  = deckWidth;
+    this.deckLength = deckLength;
+
+    this.maxHp = 6;
+    this.hp    = this.maxHp;
+    /** True while HP > 0 and the bridge has not yet collapsed. */
+    this.alive = true;
+
+    /** Half the deck width  (local X extent). Used for OBB hit checks. */
+    this.halfWidth = deckWidth  / 2;
+    /** Half the span length (local Z extent). Used for OBB hit checks. */
+    this.halfSpan  = deckLength / 2;
+    /**
+     * Circumradius for fast pre-check: shell must be within this distance of
+     * the bridge centre before the full OBB test runs.
+     */
+    this.radius = Math.sqrt(this.halfWidth * this.halfWidth + this.halfSpan * this.halfSpan);
+
+    /**
+     * Circular obstacle descriptors spawned when the bridge collapses.
+     * Format matches WreckSystem / CollisionSystem obstacle arrays:
+     *   { x: number, z: number, radius: number }
+     * Empty while alive; populated by _collapse().
+     * @type {Array<{x: number, z: number, radius: number}>}
+     */
+    this.rubbleObstacles = [];
+
+    /** Reference to the main deck mesh (mutated on damage/collapse). */
+    this._deckMesh = null;
+
+    this.group = new THREE.Group();
+    this._buildMesh();
+    scene.add(this.group);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mesh construction
+  // ---------------------------------------------------------------------------
+
+  _buildMesh() {
+    const W = this.deckWidth;
+    const L = this.deckLength;
+
+    // --- Main deck ---
+    const deckGeo = new THREE.BoxGeometry(W, 0.6, L);
+    this._deckMesh = new THREE.Mesh(deckGeo, _deckMat);
+    this._deckMesh.position.y = 0.3;
+    this._deckMesh.castShadow   = true;
+    this._deckMesh.receiveShadow = true;
+    this.group.add(this._deckMesh);
+
+    // --- Side railings (visual only) ---
+    const railGeo = new THREE.BoxGeometry(0.25, 1.0, L);
+    const railMatL = _pillarMat;
+    const railL = new THREE.Mesh(railGeo, railMatL);
+    railL.position.set(-(W / 2 - 0.125), 1.1, 0);
+    railL.castShadow = true;
+    this.group.add(railL);
+
+    const railR = railL.clone();
+    railR.position.x = W / 2 - 0.125;
+    this.group.add(railR);
+
+    // --- Cross-braces / end-supports ---
+    const braceGeo = new THREE.BoxGeometry(W + 1.0, 2.0, 0.6);
+    for (const sign of [-1, 1]) {
+      const brace = new THREE.Mesh(braceGeo, _pillarMat);
+      brace.position.set(0, -0.7, sign * (L / 2 - 0.5));
+      brace.castShadow = true;
+      this.group.add(brace);
+    }
+
+    this.group.position.set(this.x, this.groundY, this.z);
+    this.group.rotation.y = this.rotY;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply damage from a projectile hit.
+   * @param {number} amount
+   * @returns {boolean} `true` if this hit destroyed the bridge.
+   */
+  takeDamage(amount) {
+    if (!this.alive) return false;
+
+    this.hp = Math.max(0, this.hp - amount);
+
+    // Visually show damage at half HP
+    if (this.hp > 0 && this.hp <= this.maxHp * 0.5) {
+      this._deckMesh.material = _damagedMat;
+    }
+
+    if (this.hp <= 0) {
+      this._collapse();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Force-destroy without damage (e.g. round reset).  Removes from scene.
+   */
+  destroy() {
+    this.hp   = 0;
+    this.alive = false;
+    this._scene.remove(this.group);
+    this.rubbleObstacles = [];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Visually collapse the bridge deck and populate rubbleObstacles.
+   * Called when HP reaches 0.
+   */
+  _collapse() {
+    this.alive = false;
+
+    // Tilt and darken the deck
+    this._deckMesh.material = _damagedMat;
+    this._deckMesh.rotation.z = 0.4;
+    this._deckMesh.position.y = -0.4;
+
+    // Hide railings and supports
+    for (const child of this.group.children) {
+      if (child !== this._deckMesh) {
+        child.visible = false;
+      }
+    }
+
+    // Spawn rubble obstacles along the span in world space.
+    // Four circles spread evenly at ±2.5 and ±7.5 local Z positions.
+    const c = Math.cos(this.rotY);
+    const s = Math.sin(this.rotY);
+
+    for (const oz of [-7.5, -2.5, 2.5, 7.5]) {
+      // Transform local (0, oz) to world XZ:
+      //   world_x = x + local_x * cos(rotY) + local_z * sin(rotY)
+      //   world_z = z - local_x * sin(rotY) + local_z * cos(rotY)
+      // Since local_x = 0:
+      const wx = this.x + s * oz;
+      const wz = this.z + c * oz;
+      this.rubbleObstacles.push({ x: wx, z: wz, radius: 2.5 });
+    }
+  }
+}

--- a/src/entities/Wall.js
+++ b/src/entities/Wall.js
@@ -1,0 +1,164 @@
+/**
+ * Wall — a low destructible barrier providing infantry cover.
+ *
+ * Gameplay behaviour per VISION.md:
+ *  "Walls / fences — Low cover for infantry. Tanks drive through."
+ *
+ *  - Infantry cover: the wall is ~0.9 units tall (crouching-soldier height).
+ *  - Tank contact: when a tank's collision circle overlaps the wall's OBB,
+ *    the wall is instantly destroyed (tank drives through it).  The tank is
+ *    NOT pushed back — it passes through freely.
+ *  - Projectile hit: any shell that intersects the OBB consumes the projectile
+ *    and deals full damage.  A single tank-cannon shell (25 dmg, wall HP = 2)
+ *    destroys the wall.
+ *  - Destroyed wall: mesh removed; no residual obstacle.
+ *
+ * Geometry (all in local space, rotated by `rotY`):
+ *  - Wall body: BoxGeometry(length × height × thickness)
+ *    local X = along the wall (long axis),  local Z = through the wall (thin)
+ *  - Cap stone: slightly wider flat box on top for visual detail
+ *
+ * Collision (OBB in XZ):
+ *  - halfLength    = length / 2         (local X half-extent — long axis)
+ *  - halfThickness = WALL_THICKNESS / 2 (local Z half-extent — short axis)
+ *
+ * @module entities/Wall
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const WALL_HEIGHT    = 0.9;
+const WALL_THICKNESS = 0.5;
+
+// ---------------------------------------------------------------------------
+// Shared materials
+// ---------------------------------------------------------------------------
+
+const _wallMat = new THREE.MeshStandardMaterial({
+  color: 0xb8a88a,   // sandy stone
+  roughness: 0.95,
+  metalness: 0.0,
+  flatShading: true,
+});
+
+const _capMat = new THREE.MeshStandardMaterial({
+  color: 0xd0c09a,   // lighter cap stones
+  roughness: 0.9,
+  metalness: 0.0,
+  flatShading: true,
+});
+
+// ---------------------------------------------------------------------------
+// Wall
+// ---------------------------------------------------------------------------
+
+export class Wall {
+  /**
+   * @param {THREE.Scene} scene
+   * @param {number}      x        World X of wall segment centre.
+   * @param {number}      z        World Z of wall segment centre.
+   * @param {number}      groundY  Terrain height at (x, z).
+   * @param {number}      [rotY=0] Rotation around Y axis in radians.
+   *   rotY = 0        → wall long-axis runs along world X (E–W wall).
+   *   rotY = Math.PI/2 → wall long-axis runs along world Z (N–S wall).
+   * @param {number}      [length=4] Length of the wall segment (local X).
+   */
+  constructor(scene, x, z, groundY, rotY = 0, length = 4) {
+    this._scene  = scene;
+    this.x       = x;
+    this.z       = z;
+    this.groundY = groundY;
+    this.rotY    = rotY;
+    this.length  = length;
+
+    this.maxHp = 2;
+    this.hp    = this.maxHp;
+    /** True while the wall is standing and collidable. */
+    this.alive = true;
+
+    /** Half the long axis (local X). Used for OBB collision. */
+    this.halfLength    = length / 2;
+    /**
+     * Half the wall thickness (local Z).  Used for OBB collision.
+     * Inflated slightly beyond the visual half (0.25) so fast projectiles
+     * (50 u/s) don't tunnel through the thin wall face in a single frame.
+     */
+    this.halfThickness = 1.0;
+
+    this.group = new THREE.Group();
+    this._buildMesh();
+    scene.add(this.group);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mesh construction
+  // ---------------------------------------------------------------------------
+
+  _buildMesh() {
+    const L = this.length;
+    const H = WALL_HEIGHT;
+    const T = WALL_THICKNESS;
+
+    // --- Main wall body ---
+    const wallGeo  = new THREE.BoxGeometry(L, H, T);
+    const wallMesh = new THREE.Mesh(wallGeo, _wallMat);
+    wallMesh.position.y   = H / 2;
+    wallMesh.castShadow   = true;
+    wallMesh.receiveShadow = true;
+    this.group.add(wallMesh);
+
+    // --- Cap stones on top ---
+    const capGeo  = new THREE.BoxGeometry(L + 0.1, 0.12, T + 0.1);
+    const capMesh = new THREE.Mesh(capGeo, _capMat);
+    capMesh.position.y = H + 0.06;
+    capMesh.castShadow = true;
+    this.group.add(capMesh);
+
+    this.group.position.set(this.x, this.groundY, this.z);
+    this.group.rotation.y = this.rotY;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply damage from a projectile hit.
+   * @param {number} amount
+   * @returns {boolean} `true` if this hit destroyed the wall.
+   */
+  takeDamage(amount) {
+    if (!this.alive) return false;
+
+    this.hp = Math.max(0, this.hp - amount);
+
+    if (this.hp <= 0) {
+      this._destroyVisual();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Force-destroy without damage logic (tank contact or round reset).
+   * Removes mesh from the scene.
+   */
+  destroy() {
+    if (!this.alive) return;
+    this.hp = 0;
+    this._destroyVisual();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  _destroyVisual() {
+    this.alive = false;
+    this._scene.remove(this.group);
+  }
+}

--- a/src/systems/CollisionSystem.js
+++ b/src/systems/CollisionSystem.js
@@ -10,6 +10,14 @@
  *  4. Tank-vs-obstacle blocking: pushes tanks out of rocks and living trees.
  *  5. Tank-vs-wreck blocking: same impulse resolve applied to WreckSystem
  *     obstacles so live tanks cannot drive through demolished hulls.
+ *  6. Projectile-vs-bridge (t049): alive bridge segments absorb shells and
+ *     accumulate damage; when HP = 0 the bridge collapses into rubble.
+ *  7. Projectile-vs-wall (t049): alive wall/fence segments absorb shells;
+ *     destroyed in one hit (wall HP = 2, shell damage = 25).
+ *  8. Tank-vs-wall contact (t049): tanks drive *through* walls — wall is
+ *     destroyed on contact; tank is NOT pushed back.
+ *  9. Tank-vs-bridge-rubble blocking (t049): collapsed bridge rubble
+ *     circles block tanks (same resolve path as wrecks).
  *
  * Callbacks (set before first update):
  *  onScoreAdd(points)                    — called when an enemy tank is destroyed
@@ -29,6 +37,9 @@
  *  onKillFeed(killer, victim)            — called on every tank kill for the kill feed UI
  *    killer: display name of the entity that scored the kill ('Player', 'Enemy #2', …)
  *    victim: display name of the destroyed tank
+ *  onBridgeHit(position)                 — non-lethal shell hit on a bridge (t049)
+ *  onBridgeDestroyed(position)           — shell destroys a bridge (t049)
+ *  onWallDestroyed(position)             — shell or tank contact destroys a wall (t049)
  */
 export class CollisionSystem {
   /**
@@ -39,14 +50,17 @@ export class CollisionSystem {
    * @param {import('./ProjectileSystem.js').ProjectileSystem} opts.projectiles
    * @param {import('./TreeSystem.js').TreeSystem}             [opts.treeSystem]
    * @param {import('./WreckSystem.js').WreckSystem}           [opts.wrecks]
+   * @param {import('./StructureSystem.js').StructureSystem}   [opts.structureSystem]
    */
-  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null }) {
+  constructor({ terrain, player, enemies, projectiles, treeSystem = null, wrecks = null, structureSystem = null }) {
     this.terrain = terrain;
     this.player = player;
     this.enemies = enemies;
     this.projectiles = projectiles;
     this.treeSystem = treeSystem;
     this.wrecks = wrecks;
+    /** @type {import('./StructureSystem.js').StructureSystem|null} */
+    this.structureSystem = structureSystem;
 
     this._onScoreAdd = null;
     this._onPlayerDeath = null;
@@ -57,6 +71,10 @@ export class CollisionSystem {
     this._onTreeHit = null;
     this._onTreeDestroy = null;
     this._onKillFeed = null;
+    // t049 — bridge and wall callbacks
+    this._onBridgeHit = null;
+    this._onBridgeDestroyed = null;
+    this._onWallDestroyed = null;
 
     /**
      * Approximate half-width of a tank hull for obstacle push-back.
@@ -148,6 +166,26 @@ export class CollisionSystem {
    */
   onKillFeed(cb) {
     this._onKillFeed = cb;
+    return this;
+  }
+
+  // t049 — bridge and wall callbacks
+
+  /** @param {(position: import('three').Vector3) => void} cb */
+  onBridgeHit(cb) {
+    this._onBridgeHit = cb;
+    return this;
+  }
+
+  /** @param {(position: import('three').Vector3) => void} cb */
+  onBridgeDestroyed(cb) {
+    this._onBridgeDestroyed = cb;
+    return this;
+  }
+
+  /** @param {(position: import('three').Vector3) => void} cb */
+  onWallDestroyed(cb) {
+    this._onWallDestroyed = cb;
     return this;
   }
 
@@ -290,6 +328,12 @@ export class CollisionSystem {
     // All projectiles vs destructible trees
     if (this.treeSystem) {
       this._checkProjectileTreeCollisions();
+    }
+
+    // t049 — projectiles vs bridges and walls
+    if (this.structureSystem) {
+      this._checkProjectileBridgeCollisions();
+      this._checkProjectileWallCollisions();
     }
 
     // Explosive projectiles that reach terrain level explode on impact. (t032)
@@ -510,6 +554,24 @@ export class CollisionSystem {
         }
       }
     }
+
+    // t049 — bridge rubble blocks tanks; alive walls are destroyed on tank contact
+    if (this.structureSystem) {
+      // Collapsed bridge rubble — push tanks back (same as wrecks)
+      const rubbleObs = this.structureSystem.bridgeRubbleObstacles;
+      if (rubbleObs.length > 0) {
+        this._resolveObstacleCollision(this.player.mesh, rubbleObs);
+        for (const enemy of this.enemies.active) {
+          this._resolveObstacleCollision(enemy.mesh, rubbleObs);
+        }
+      }
+
+      // Alive walls — tanks drive through them (wall destroyed, tank not blocked)
+      this._checkTankWallContact(this.player.mesh, this.structureSystem.walls);
+      for (const enemy of this.enemies.active) {
+        this._checkTankWallContact(enemy.mesh, this.structureSystem.walls);
+      }
+    }
   }
 
   /**
@@ -537,6 +599,195 @@ export class CollisionSystem {
           pos.x += (dx / dist) * overlap;
           pos.z += (dz / dist) * overlap;
         }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // t049 — Bridge and wall collision helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Check all active projectiles against alive bridge segments.
+   *
+   * Uses a fast circumradius pre-check followed by a full OBB test in the
+   * bridge's local XZ space.  A vertical bounds check prevents shells flying
+   * far above the bridge deck from being consumed.
+   *
+   * Explosives that hit a bridge still apply splash damage to nearby tanks.
+   */
+  _checkProjectileBridgeCollisions() {
+    const bridges = this.structureSystem.bridges;
+    const projectiles = this.projectiles.active;
+
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p = projectiles[i];
+      const px = p.mesh.position.x;
+      const py = p.mesh.position.y;
+      const pz = p.mesh.position.z;
+
+      for (const bridge of bridges) {
+        if (!bridge.alive) continue;
+
+        // --- Fast circumradius pre-check ---
+        const dx = px - bridge.x;
+        const dz = pz - bridge.z;
+        if (dx * dx + dz * dz > bridge.radius * bridge.radius * 1.5) continue;
+
+        // --- Vertical bounds: only hit if near the bridge deck ---
+        const relY = py - bridge.groundY;
+        if (relY < -0.5 || relY > 3.0) continue;
+
+        // --- OBB test in bridge local space ---
+        // Transform (dx, dz) by -rotY to get local coordinates:
+        //   lx = dx * cos(rotY) - dz * sin(rotY)  (across bridge)
+        //   lz = dx * sin(rotY) + dz * cos(rotY)  (along bridge span)
+        const c  = Math.cos(bridge.rotY);
+        const s  = Math.sin(bridge.rotY);
+        const lx = dx * c - dz * s;
+        const lz = dx * s + dz * c;
+
+        if (Math.abs(lx) >= bridge.halfWidth + 0.5) continue;
+        if (Math.abs(lz) >= bridge.halfSpan  + 0.5) continue;
+
+        // --- Hit confirmed ---
+        const hitPos = p.mesh.position.clone();
+        this.projectiles.remove(i);
+
+        const destroyed = bridge.takeDamage(p.damage);
+
+        // Explosives apply splash even when hitting a bridge
+        if (p.splashRadius > 0) {
+          this._applySplashToEnemies(p, hitPos, null);
+          this._applySplashToPlayer(p, hitPos, null);
+          if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+        }
+
+        if (destroyed) {
+          if (this._onBridgeDestroyed) this._onBridgeDestroyed(hitPos);
+        } else if (!p.splashRadius) {
+          if (this._onBridgeHit) this._onBridgeHit(hitPos);
+        }
+
+        break; // projectile consumed
+      }
+    }
+  }
+
+  /**
+   * Check all active projectiles against alive wall/fence segments.
+   *
+   * Uses an OBB test with the wall's local XZ frame.  The wall thickness
+   * halfThickness is set to 1.0 (larger than the visual 0.25) to prevent
+   * fast shells from tunnelling through the thin face.
+   *
+   * Explosives that hit a wall still apply splash damage to nearby tanks.
+   */
+  _checkProjectileWallCollisions() {
+    const walls = this.structureSystem.walls;
+    const projectiles = this.projectiles.active;
+
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+      const p = projectiles[i];
+      const px = p.mesh.position.x;
+      const py = p.mesh.position.y;
+      const pz = p.mesh.position.z;
+
+      for (const wall of walls) {
+        if (!wall.alive) continue;
+
+        // --- Vertical bounds: only hit if near the wall body ---
+        const relY = py - wall.groundY;
+        if (relY < -0.3 || relY > 1.5) continue;
+
+        // --- Fast outer-radius pre-check ---
+        const dx = px - wall.x;
+        const dz = pz - wall.z;
+        const outerR = wall.halfLength + wall.halfThickness + 0.5;
+        if (dx * dx + dz * dz > outerR * outerR) continue;
+
+        // --- OBB test in wall local space ---
+        // lx = along the wall long axis   (local X)
+        // lz = through the wall thickness (local Z)
+        const c  = Math.cos(wall.rotY);
+        const s  = Math.sin(wall.rotY);
+        const lx = dx * c - dz * s;
+        const lz = dx * s + dz * c;
+
+        if (Math.abs(lx) >= wall.halfLength    + 0.3) continue;
+        if (Math.abs(lz) >= wall.halfThickness + 0.3) continue;
+
+        // --- Hit confirmed ---
+        const hitPos = p.mesh.position.clone();
+        this.projectiles.remove(i);
+
+        const destroyed = wall.takeDamage(p.damage);
+
+        // Explosives apply splash even on wall hits
+        if (p.splashRadius > 0) {
+          this._applySplashToEnemies(p, hitPos, null);
+          this._applySplashToPlayer(p, hitPos, null);
+          if (this._onExplosion) this._onExplosion(hitPos, p.splashRadius);
+        }
+
+        if (destroyed) {
+          if (this._onWallDestroyed) this._onWallDestroyed(hitPos);
+        }
+
+        break; // projectile consumed
+      }
+    }
+  }
+
+  /**
+   * Check if a tank mesh is in contact with any alive wall.
+   * Per VISION.md: "Tanks drive through" walls — contact destroys the wall
+   * instantly; the tank is NOT pushed back.
+   *
+   * Uses a circle-vs-OBB closest-point test:
+   *  1. Transform the tank centre into wall local space.
+   *  2. Clamp to wall rectangle to find the nearest point on the wall.
+   *  3. If distance from tank centre to nearest point < tankRadius → destroy wall.
+   *
+   * @param {import('three').Object3D}            tankMesh
+   * @param {import('../entities/Wall.js').Wall[]} walls
+   */
+  _checkTankWallContact(tankMesh, walls) {
+    const tp = tankMesh.position;
+    const tr = this._tankRadius;
+
+    for (const wall of walls) {
+      if (!wall.alive) continue;
+
+      const dx = tp.x - wall.x;
+      const dz = tp.z - wall.z;
+
+      // --- Fast outer-radius pre-check ---
+      const outerR = wall.halfLength + tr + 1;
+      if (dx * dx + dz * dz > outerR * outerR) continue;
+
+      // --- Transform tank centre to wall local space ---
+      const c  = Math.cos(wall.rotY);
+      const s  = Math.sin(wall.rotY);
+      const lx = dx * c - dz * s;   // along wall long axis
+      const lz = dx * s + dz * c;   // through wall thickness
+
+      // Clamp to wall OBB rectangle
+      const clampedLx = lx < -wall.halfLength    ? -wall.halfLength    :
+                        lx >  wall.halfLength     ?  wall.halfLength    : lx;
+      const clampedLz = lz < -wall.halfThickness ? -wall.halfThickness :
+                        lz >  wall.halfThickness  ?  wall.halfThickness : lz;
+
+      // Squared distance from tank centre to nearest point on wall rectangle
+      const nearDx    = lx - clampedLx;
+      const nearDz    = lz - clampedLz;
+      const nearDist2 = nearDx * nearDx + nearDz * nearDz;
+
+      if (nearDist2 < tr * tr) {
+        // Tank contact: destroy wall, emit feedback
+        const hitPos = tp.clone();
+        wall.destroy();
+        if (this._onWallDestroyed) this._onWallDestroyed(hitPos);
       }
     }
   }

--- a/src/systems/StructureSystem.js
+++ b/src/systems/StructureSystem.js
@@ -1,0 +1,153 @@
+/**
+ * StructureSystem — owns and manages all Bridge and Wall instances on the map.
+ *
+ * Responsibilities:
+ *  - Spawns predefined bridges and wall/fence segments at map start.
+ *  - Exposes obstacle arrays consumed by CollisionSystem:
+ *      • `bridgeRubbleObstacles` — circle obstacles along collapsed bridge spans.
+ *        Used to block tank movement through rubble after destruction.
+ *      • `wallObstacles`         — OBB descriptors for alive wall segments.
+ *        Used for projectile absorption and tank-contact destruction.
+ *  - `reset()` tears everything down and respawns for the next round.
+ *
+ * Map placements:
+ *  Bridges create E-W and N-S chokepoints in the mid-field combat zone.
+ *  Wall/fence segments are scattered at infantry-relevant positions, providing
+ *  low cover and breakable obstacles for tanks to smash through.
+ *
+ * @module systems/StructureSystem
+ */
+
+import { Bridge } from '../entities/Bridge.js';
+import { Wall }   from '../entities/Wall.js';
+
+// ---------------------------------------------------------------------------
+// Map definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge spawn definitions: [x, z, rotY].
+ *   rotY = 0          → deck spans along world Z (N–S bridge).
+ *   rotY = Math.PI/2  → deck spans along world X (E–W bridge).
+ */
+const BRIDGE_DEFS = [
+  //  x      z     rotY             — comment
+  [   0,   -25,  Math.PI / 2 ],    // Central E-W bridge at z=-25
+  [  35,    10,  0           ],    // Right-flank N-S bridge at x=35
+];
+
+/**
+ * Wall/fence segment definitions: [x, z, rotY, length].
+ *   rotY = 0          → wall long-axis along world X (E–W wall).
+ *   rotY = Math.PI/2  → wall long-axis along world Z (N–S wall).
+ */
+const WALL_DEFS = [
+  //  x       z     rotY             len   — purpose
+  [ -15,   -10,  Math.PI / 2,    5 ],     // Left mid-field cover, N-S
+  [ -15,    12,  Math.PI / 2,    5 ],     // Left mid-field cover, N-S
+  [  15,   -12,  Math.PI / 2,    5 ],     // Right mid-field cover, N-S
+  [  15,    10,  Math.PI / 2,    5 ],     // Right mid-field cover, N-S
+  [  -5,    20,  0,              4 ],     // Forward centre cover, E-W
+  [   5,   -22,  0,              4 ],     // Rear centre cover, E-W
+  [ -26,     0,  Math.PI / 4,    3 ],     // Left diagonal fence
+  [  26,     5, -Math.PI / 4,    3 ],     // Right diagonal fence
+  [ -40,    45,  0,              6 ],     // Team 0 south spawn perimeter
+  [  40,    45,  0,              6 ],     // Team 0 south spawn perimeter
+  [ -40,   -45,  0,              6 ],     // Team 1 north spawn perimeter
+  [  40,   -45,  0,              6 ],     // Team 1 north spawn perimeter
+];
+
+// ---------------------------------------------------------------------------
+// StructureSystem
+// ---------------------------------------------------------------------------
+
+export class StructureSystem {
+  /**
+   * @param {THREE.Scene}                              scene
+   * @param {import('../entities/Terrain.js').Terrain} terrain
+   */
+  constructor(scene, terrain) {
+    this._scene   = scene;
+    this._terrain = terrain;
+
+    /** @type {Bridge[]} All Bridge instances (alive + collapsed). */
+    this.bridges = [];
+
+    /** @type {Wall[]}   All Wall instances (alive only — destroyed walls are removed). */
+    this.walls = [];
+
+    this._spawn();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Circle obstacles from collapsed bridge rubble.
+   * Format matches WreckSystem.obstacles: { x, z, radius }.
+   * CollisionSystem uses these to push tanks back (bridges block movement
+   * once destroyed, creating permanent rubble chokepoints).
+   *
+   * @returns {Array<{x: number, z: number, radius: number}>}
+   */
+  get bridgeRubbleObstacles() {
+    const rubble = [];
+    for (const b of this.bridges) {
+      if (!b.alive) {
+        for (const r of b.rubbleObstacles) rubble.push(r);
+      }
+    }
+    return rubble;
+  }
+
+  /**
+   * OBB descriptors for all alive wall segments.
+   * Each entry includes a back-reference to the Wall instance so
+   * CollisionSystem can call wall.takeDamage() or wall.destroy().
+   *
+   * @returns {Array<{wall: Wall, x: number, z: number, rotY: number,
+   *                  halfLength: number, halfThickness: number, groundY: number}>}
+   */
+  get wallObstacles() {
+    return this.walls
+      .filter(w => w.alive)
+      .map(w => ({
+        wall:         w,
+        x:            w.x,
+        z:            w.z,
+        rotY:         w.rotY,
+        halfLength:   w.halfLength,
+        halfThickness: w.halfThickness,
+        groundY:      w.groundY,
+      }));
+  }
+
+  /**
+   * Remove all structures from the scene and respawn fresh instances.
+   * Call on round reset.
+   */
+  reset() {
+    for (const b of this.bridges) b.destroy();
+    for (const w of this.walls)   w.destroy();
+    this.bridges = [];
+    this.walls   = [];
+    this._spawn();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  _spawn() {
+    for (const [x, z, rotY] of BRIDGE_DEFS) {
+      const y = this._terrain.getHeightAt(x, z);
+      this.bridges.push(new Bridge(this._scene, x, z, y, rotY));
+    }
+
+    for (const [x, z, rotY, length] of WALL_DEFS) {
+      const y = this._terrain.getHeightAt(x, z);
+      this.walls.push(new Wall(this._scene, x, z, y, rotY, length));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements t049 (VISION.md M9 environment structures): destructible bridge chokepoints and low wall/fence cover.

### Bridge (`src/entities/Bridge.js`)
- Flat deck (8 × 18 units) with railings and cross-brace supports placed at terrain height
- HP = 6; shell hit (25 dmg) destroys in one shot — bridge is primarily a cover/splash obstacle
- At ≤50% HP: deck material darkens to show damage
- On collapse: deck tilts visually; 4 rubble circle obstacles (radius 2.5) are spawned along the span in world space, blocking tanks from crossing through the rubble

### Wall/Fence (`src/entities/Wall.js`)
- Low stone barrier (0.9 m tall, 0.5 m thick); HP = 2; length varies (3–6 units)
- Tanks **drive through** walls: circle-vs-OBB contact check destroys the wall instantly without pushing the tank back (VISION.md: "Tanks drive through")
- Any shell also destroys a wall in one hit
- No residual obstacle after destruction

### StructureSystem (`src/systems/StructureSystem.js`)
- 2 bridges: central E-W crossing (x=0, z=−25) and right-flank N-S crossing (x=35, z=10)
- 12 wall/fence segments spread across mid-field and near spawn perimeters
- `reset()` tears down and respawns all structures between rounds

### CollisionSystem extensions (`src/systems/CollisionSystem.js`)
- `_checkProjectileBridgeCollisions()`: circumradius pre-check → vertical bounds → OBB in bridge local XZ; explosives still splash
- `_checkProjectileWallCollisions()`: outer-radius pre-check → vertical bounds → OBB; halfThickness=1.0 prevents shell tunnelling
- `_checkTankWallContact()`: for each tank, closest-point-on-wall-OBB check; destroys wall on overlap
- Bridge rubble circles fed into existing `_resolveObstacleCollision()` to block tanks
- New callbacks: `onBridgeHit`, `onBridgeDestroyed`, `onWallDestroyed`

### Game.js integration
- `StructureSystem` created after `WreckSystem`, passed to `CollisionSystem` as `structureSystem`
- Particle effects wired: bridge hit (10 particles), bridge destroy (50 particles), wall destroy (18 particles)
- Added to both round reset (`onRoundReset`) and full match restart (`restart()`)

## Testing

```bash
# Module import sanity (no DOM required)
node --input-type=module -e "
import { Bridge } from './src/entities/Bridge.js';
import { Wall } from './src/entities/Wall.js';
import { StructureSystem } from './src/systems/StructureSystem.js';
const scene = { add: () => {}, remove: () => {} };
const terrain = { getHeightAt: () => 0 };
const ss = new StructureSystem(scene, terrain);
console.assert(ss.bridges.length === 2 && ss.walls.length === 12, 'spawn counts');
ss.bridges[0].takeDamage(100);
console.assert(ss.bridgeRubbleObstacles.length === 4, 'rubble after collapse');
ss.reset();
console.assert(ss.bridgeRubbleObstacles.length === 0, 'rubble cleared after reset');
console.log('OK');
"
```

All assertions pass. Vite build unaffected (pure JS, no new dependencies).

Resolves #65