### PR TITLE
t053: Skin system — SkinDefs data + material swap rendering

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -419,6 +419,8 @@ export class Game {
        this.playerController.soldierMeleeId = selection.melee;
        // Configure AbilitySystem slots from the chosen loadout (t042).
        this._applyLoadoutToAbilitySystem(selection);
+       // Apply the equipped cosmetic skin to the player tank (t053).
+       this.teams.player.applySkin(this.save.getEquippedSkin());
        this._startImmediately();
     });
   }
@@ -1093,6 +1095,8 @@ export class Game {
       this.tankAbilityEffects.reset();
       // Reset field entities
       this.teams.reset();
+      // Re-apply skin after reset (handles skin changes between matches) (t053).
+      this.teams.player.applySkin(this.save.getEquippedSkin());
       this.projectiles.reset();
       this.particles.reset();
       this.trees.reset();

--- a/src/core/TeamManager.js
+++ b/src/core/TeamManager.js
@@ -50,10 +50,16 @@ export class TeamManager {
   /**
    * @param {THREE.Scene} scene
    * @param {import('../entities/Terrain.js').Terrain} terrain
+   * @param {object} [opts]
+   * @param {string|null} [opts.playerSkinId=null] — skin ID from SkinDefs to apply to the
+   *   player's tank on creation; null keeps the team default colors.
    */
-  constructor(scene, terrain) {
+  constructor(scene, terrain, { playerSkinId = null } = {}) {
     this.scene = scene;
     this.terrain = terrain;
+
+    /** @type {string|null} Skin ID applied to the player tank. */
+    this._playerSkinId = playerSkinId;
 
     /**
      * @type {Array<{id: number, name: string, slots: Array<{tank: Tank, alive: boolean}>}>}
@@ -304,6 +310,11 @@ export class TeamManager {
         name: isPlayer ? 'Player' : `Ally ${i}`,
         tankClassId,
       });
+
+      // Apply the player's equipped skin cosmetic (t053).
+      if (isPlayer && this._playerSkinId) {
+        tank.applySkin(this._playerSkinId);
+      }
 
       const pos = this._spawnPosition(i, 0);
       tank.mesh.position.copy(pos);

--- a/src/data/SkinDefs.js
+++ b/src/data/SkinDefs.js
@@ -1,0 +1,188 @@
+/**
+ * SkinDefs.js — Static definitions for all cosmetic tank skins.
+ *
+ * Skins are purely cosmetic — they swap hull and turret colors with no effect
+ * on any gameplay stat. All skins are keyed by a stable ID string.
+ *
+ * Fields:
+ *   id:             Stable ID used in save file and shop.
+ *   name:           Display name shown in the skin shop.
+ *   description:    Flavor text shown in the shop card.
+ *   type:           'solid' | 'camo' | 'prestige'
+ *                     solid    — single-color hull with matched turret
+ *                     camo     — contrasting hull/turret tones (two-tone)
+ *                     prestige — premium skins for high-league players
+ *   leagueRequired: Minimum league to purchase ('bronze' | 'silver' | 'gold' |
+ *                   'platinum' | 'diamond').
+ *   price:          Shop cost in $. Range $500–$5,000 per VISION.md.
+ *   colorBody:      Hull color (hex integer).
+ *   colorTurret:    Turret color (hex integer).
+ *
+ * NOTE: The default 'none' skin is not defined here; Tank.js falls back to
+ * the class-defined colors from TankDefs when no skin is equipped.
+ */
+
+export const SkinDefs = {
+  // --------------------------------------------------------------------------
+  // Solid color skins (Bronze+)
+  // --------------------------------------------------------------------------
+
+  desert_sand: {
+    id: 'desert_sand',
+    name: 'Desert Sand',
+    description: 'Sun-bleached tan hull with dark ochre turret. Built for arid campaigns.',
+    type: 'solid',
+    leagueRequired: 'bronze',
+    price: 500,
+    colorBody: 0xC2956C,
+    colorTurret: 0x8B6914,
+  },
+
+  arctic_white: {
+    id: 'arctic_white',
+    name: 'Arctic White',
+    description: 'Frost-white hull with pale grey turret. Invisible on snow.',
+    type: 'solid',
+    leagueRequired: 'bronze',
+    price: 500,
+    colorBody: 0xE8E8E8,
+    colorTurret: 0xB0B0B0,
+  },
+
+  midnight_black: {
+    id: 'midnight_black',
+    name: 'Midnight Black',
+    description: 'Matte black hull with dark charcoal turret. Low-profile and menacing.',
+    type: 'solid',
+    leagueRequired: 'bronze',
+    price: 750,
+    colorBody: 0x1A1A1A,
+    colorTurret: 0x2D2D2D,
+  },
+
+  steel_blue: {
+    id: 'steel_blue',
+    name: 'Steel Blue',
+    description: 'Industrial steel-blue hull with navy turret. Solid and dependable.',
+    type: 'solid',
+    leagueRequired: 'bronze',
+    price: 750,
+    colorBody: 0x4A6FA5,
+    colorTurret: 0x2B4C7E,
+  },
+
+  // --------------------------------------------------------------------------
+  // Camo patterns (Silver+) — two-tone hull/turret contrast
+  // --------------------------------------------------------------------------
+
+  woodland_camo: {
+    id: 'woodland_camo',
+    name: 'Woodland Camo',
+    description: 'Classic green-and-brown two-tone. Blends with forested terrain.',
+    type: 'camo',
+    leagueRequired: 'silver',
+    price: 1500,
+    colorBody: 0x4B5320,
+    colorTurret: 0x6B4226,
+  },
+
+  urban_camo: {
+    id: 'urban_camo',
+    name: 'Urban Camo',
+    description: 'Grey-and-slate two-tone for city fights. Looks the part in ruins.',
+    type: 'camo',
+    leagueRequired: 'silver',
+    price: 1500,
+    colorBody: 0x6E6E6E,
+    colorTurret: 0x3F3F3F,
+  },
+
+  desert_camo: {
+    id: 'desert_camo',
+    name: 'Desert Camo',
+    description: 'Sand and terracotta two-tone. Scorched-earth veteran aesthetic.',
+    type: 'camo',
+    leagueRequired: 'silver',
+    price: 2000,
+    colorBody: 0xC2A87A,
+    colorTurret: 0x8B4513,
+  },
+
+  jungle_camo: {
+    id: 'jungle_camo',
+    name: 'Jungle Camo',
+    description: 'Deep green hull with dark olive turret. Disappears in dense foliage.',
+    type: 'camo',
+    leagueRequired: 'gold',
+    price: 2500,
+    colorBody: 0x2D5A27,
+    colorTurret: 0x556B2F,
+  },
+
+  // --------------------------------------------------------------------------
+  // Prestige skins (Gold+ / Platinum+ / Diamond+)
+  // --------------------------------------------------------------------------
+
+  crimson_blaze: {
+    id: 'crimson_blaze',
+    name: 'Crimson Blaze',
+    description: 'Fiery red hull with deep crimson turret. War-paint for proven veterans.',
+    type: 'prestige',
+    leagueRequired: 'gold',
+    price: 3000,
+    colorBody: 0xCC2200,
+    colorTurret: 0x8B0000,
+  },
+
+  royal_gold: {
+    id: 'royal_gold',
+    name: 'Royal Gold',
+    description: 'Burnished gold hull with dark brass turret. Reserved for the elite.',
+    type: 'prestige',
+    leagueRequired: 'platinum',
+    price: 4000,
+    colorBody: 0xDAA520,
+    colorTurret: 0xB8860B,
+  },
+
+  void_black: {
+    id: 'void_black',
+    name: 'Void Black',
+    description: 'Deep-space black hull with iridescent dark-purple turret. Diamond prestige only.',
+    type: 'prestige',
+    leagueRequired: 'diamond',
+    price: 5000,
+    colorBody: 0x0A0A0A,
+    colorTurret: 0x1A0033,
+  },
+};
+
+/**
+ * Ordered array of skin IDs for shop display (cheap → expensive).
+ */
+export const SKIN_ORDER = [
+  'desert_sand',
+  'arctic_white',
+  'midnight_black',
+  'steel_blue',
+  'woodland_camo',
+  'urban_camo',
+  'desert_camo',
+  'jungle_camo',
+  'crimson_blaze',
+  'royal_gold',
+  'void_black',
+];
+
+/**
+ * Return a skin definition by id. Throws if the id is unknown.
+ * @param {string} id
+ * @returns {object}
+ */
+export function getSkinDef(id) {
+  const def = SkinDefs[id];
+  if (!def) {
+    throw new Error(`Unknown skin id: "${id}"`);
+  }
+  return def;
+}

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { Projectile } from './Projectile.js';
 import { getTankDef } from '../data/TankDefs.js';
 import { applyTankUpgrades } from '../data/UpgradeDefs.js';
+import { SkinDefs } from '../data/SkinDefs.js';
 
 
 /**
@@ -213,6 +214,38 @@ export class Tank {
   }
 
   /**
+   * Apply a cosmetic skin to this tank by swapping hull and turret material colors.
+   *
+   * Accepts either a skin ID string (looked up in SkinDefs) or a raw skin
+   * definition object with `colorBody` and `colorTurret` fields.  Passing
+   * `null` or an empty string resets to the palette the tank was built with.
+   *
+   * @param {string|object|null} skin — skin ID, skin def object, or null to reset
+   */
+  applySkin(skin) {
+    if (!skin) {
+      // Reset to original build palette stored on the material.
+      this._hullMat.color.setHex(this._originalPalette.body);
+      this._turretMat.color.setHex(this._originalPalette.turret);
+      return;
+    }
+
+    let def;
+    if (typeof skin === 'string') {
+      def = SkinDefs[skin];
+      if (!def) {
+        console.warn(`[Tank] applySkin: unknown skin id "${skin}" — keeping current colors.`);
+        return;
+      }
+    } else {
+      def = skin;
+    }
+
+    this._hullMat.color.setHex(def.colorBody);
+    this._turretMat.color.setHex(def.colorTurret);
+  }
+
+  /**
    * Build the tank mesh using class-specific geometry parameters.
    *
    * Hull/track/turret/barrel dimensions are read from CLASS_MESH_PARAMS so that
@@ -224,6 +257,9 @@ export class Tank {
    * @returns {THREE.Group}
    */
   _buildMesh(palette, classId) {
+    // Store the build-time palette for skin-reset support.
+    this._originalPalette = { body: palette.body, turret: palette.turret };
+
     const p = CLASS_MESH_PARAMS[classId] || CLASS_MESH_PARAMS.standard;
     const group = new THREE.Group();
 
@@ -239,6 +275,8 @@ export class Tank {
       roughness: 0.7,
       metalness: 0.3,
     });
+    // Keep a reference so applySkin() can swap it later.
+    this._hullMat = hullMat;
     const hull = new THREE.Mesh(hullGeo, hullMat);
     hull.position.y = hullCenterY;
     hull.castShadow = true;
@@ -276,6 +314,8 @@ export class Tank {
       roughness: 0.6,
       metalness: 0.4,
     });
+    // Keep a reference so applySkin() can swap it later.
+    this._turretMat = turretMat;
     const turretMesh = new THREE.Mesh(turretGeo, turretMat);
     turretMesh.castShadow = true;
     turretGroup.add(turretMesh);

--- a/src/systems/SaveSystem.js
+++ b/src/systems/SaveSystem.js
@@ -1,7 +1,7 @@
 /**
  * SaveSystem — schema-versioned localStorage persistence for the player profile.
  *
- * Persisted profile fields (schema v1):
+ * Persisted profile fields (schema v2):
  *  - schemaVersion      : number
  *  - money              : number — bank balance (kept in sync with EconomySystem)
  *  - leagueId           : string — 'bronze' | 'silver' | 'gold' | 'platinum' | 'diamond' | 'champion'
@@ -13,6 +13,7 @@
  *  - equippedTankClass  : string
  *  - equippedPrimary    : string
  *  - equippedMelee      : string
+ *  - equippedSkin       : string|null — skin ID currently equipped, or null for default
  *  - upgrades           : object — { [scope: tankClass | 'infantry']: { [upgradeId]: tier } }
  *
  * Schema versioning:
@@ -29,7 +30,7 @@
  */
 
 /** Increment when the profile schema changes.  Add migration in _migrate(). */
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 /** localStorage key. */
 const STORAGE_KEY = 'gunz_profile_v1';
@@ -51,6 +52,7 @@ function createDefaultProfile() {
     equippedTankClass: 'standard',
     equippedPrimary: 'pistol',
     equippedMelee: 'combat_knife',
+    equippedSkin: null,
     upgrades: {},
   };
 }
@@ -213,6 +215,26 @@ export class SaveSystem {
   }
 
   /**
+   * Equip or unequip a cosmetic skin.
+   *
+   * @param {string|null} skinId — skin ID from SkinDefs, or null to revert to default
+   */
+  setEquippedSkin(skinId) {
+    this._assertLoaded();
+    this._profile.equippedSkin = skinId || null;
+  }
+
+  /**
+   * Return the currently equipped skin ID (or null if none).
+   *
+   * @returns {string|null}
+   */
+  getEquippedSkin() {
+    this._assertLoaded();
+    return this._profile.equippedSkin || null;
+  }
+
+  /**
    * Record a purchased upgrade tier.
    *
    * @param {string} scope     — tank class ID or 'infantry' for on-foot weapon upgrades
@@ -274,6 +296,12 @@ export class SaveSystem {
       raw.upgrades         = raw.upgrades         ?? {};
     }
 
+    // v1 → v2: add equippedSkin field (null = no skin / default colors).
+    if (fromVersion < 2) {
+      raw.schemaVersion = 2;
+      raw.equippedSkin  = raw.equippedSkin ?? null;
+    }
+
     // Future migrations go here as additional `if (fromVersion < N)` blocks.
 
     return _mergeWithDefaults(raw);
@@ -329,6 +357,7 @@ function _mergeWithDefaults(raw) {
     equippedTankClass:typeof raw.equippedTankClass === 'string' ? raw.equippedTankClass                         : d.equippedTankClass,
     equippedPrimary:  typeof raw.equippedPrimary   === 'string' ? raw.equippedPrimary                           : d.equippedPrimary,
     equippedMelee:    typeof raw.equippedMelee     === 'string' ? raw.equippedMelee                             : d.equippedMelee,
+    equippedSkin:     (typeof raw.equippedSkin     === 'string' || raw.equippedSkin === null) ? raw.equippedSkin : d.equippedSkin,
     upgrades: (typeof raw.upgrades === 'object' && raw.upgrades !== null) ? raw.upgrades : d.upgrades,
   };
 }
@@ -346,6 +375,7 @@ function _mergeWithDefaults(raw) {
  *   equippedTankClass:string,
  *   equippedPrimary:  string,
  *   equippedMelee:    string,
+ *   equippedSkin:     string|null,
  *   upgrades:         Object.<string, Object.<string, number>>
  * }} PlayerProfile
  */


### PR DESCRIPTION
## Summary

- **SkinDefs.js** (`src/data/SkinDefs.js`): 11 cosmetic tank skins in three categories — solid (4), camo (4), prestige (3). Prices \$500–\$5,000, league-gated per VISION.md. Exports `SkinDefs`, `SKIN_ORDER`, and `getSkinDef()`.
- **Tank.applySkin()**: `_buildMesh()` now stores `_hullMat` and `_turretMat` material references + `_originalPalette`. `applySkin(skinId|skinDef|null)` swaps `color` on those materials live; `null` resets to original build-time colors.
- **SaveSystem schema v2**: adds `equippedSkin: string|null` field, v1→v2 migration, `setEquippedSkin()` / `getEquippedSkin()` helpers, and updated `_mergeWithDefaults()` / typedef.
- **TeamManager**: `constructor` accepts `{ playerSkinId }` option, applies skin immediately on the player tank at build time.
- **Game.js**: calls `teams.player.applySkin(save.getEquippedSkin())` in `start()` and `restart()` callbacks so the equipped skin is applied (and re-applied after `teams.reset()` between matches).

## Verification

- No skin equipped → default team colors unchanged.
- `save.setEquippedSkin('desert_sand'); save.save(); reload` → player tank shows tan/ochre colors.
- `save.setEquippedSkin(null)` → reverts to green team colors.
- `getSkinDef('nonexistent')` throws `Unknown skin id`.
- `tank.applySkin('nonexistent')` logs a console warning and keeps current colors.

Resolves #68