### PR TITLE
t054: Skin shop tab with rotating preview model

### DIFF
--- a/index.html
+++ b/index.html
@@ -1650,6 +1650,82 @@
       border-color: rgba(255, 255, 255, 0.6);
       color: #fff;
     }
+
+    /* === Skin shop tab — rotating preview (t054) === */
+
+    .shop-skins-layout {
+      display: flex;
+      gap: 20px;
+      align-items: flex-start;
+    }
+
+    /* Left column: 3D preview + skin name */
+    .shop-skin-preview-col {
+      flex: 0 0 240px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .shop-skin-preview-mount {
+      width: 240px;
+      height: 200px;
+      background: rgba(0, 0, 0, 0.35);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      overflow: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .shop-skin-preview-name {
+      color: #fff;
+      font-size: 14px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      text-align: center;
+    }
+
+    .shop-skin-preview-desc {
+      color: rgba(255, 255, 255, 0.5);
+      font-size: 11px;
+      text-align: center;
+      line-height: 1.4;
+      padding: 0 8px;
+    }
+
+    /* Right column: scrollable skin card grid */
+    .shop-skin-grid-col {
+      flex: 1;
+      min-width: 0;
+    }
+
+    /* Selected skin card highlight */
+    .shop-skin-card-active {
+      border-color: #4caf50 !important;
+      background: rgba(76, 175, 80, 0.14) !important;
+    }
+
+    @media (max-width: 640px) {
+      .shop-skins-layout {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .shop-skin-preview-col {
+        flex: none;
+        width: 100%;
+        align-items: center;
+      }
+
+      .shop-skin-preview-mount {
+        width: 100%;
+        max-width: 320px;
+        height: 180px;
+      }
+    }
   </style>
 </head>
 <body>

--- a/src/ui/ShopMenu.js
+++ b/src/ui/ShopMenu.js
@@ -29,19 +29,8 @@ import {
   TANK_UPGRADE_ORDER,
   FOOT_UPGRADE_ORDER,
 }                                                       from '../data/UpgradeDefs.js';
-
-// ---------------------------------------------------------------------------
-// Cosmetic skin definitions (no league gate)
-// ---------------------------------------------------------------------------
-const SKIN_DEFS = [
-  { id: 'camo_green',    name: 'Camo Green',    price: 500,  description: 'Military woodland camo.' },
-  { id: 'desert_tan',    name: 'Desert Tan',    price: 750,  description: 'Sandy desert scheme.' },
-  { id: 'arctic_white',  name: 'Arctic White',  price: 1000, description: 'Snow camouflage.' },
-  { id: 'stealth_black', name: 'Stealth Black', price: 1500, description: 'All-black tactical finish.' },
-  { id: 'neon_blue',     name: 'Neon Blue',     price: 2000, description: 'Electric blue neon.' },
-  { id: 'chrome',        name: 'Chrome',        price: 3000, description: 'Mirror-polished chrome.' },
-  { id: 'gold_plated',   name: 'Gold Plated',   price: 5000, description: 'Prestige gold finish.' },
-];
+import { SkinDefs, SKIN_ORDER, getSkinDef }              from '../data/SkinDefs.js';
+import { SkinPreview }                                  from './SkinPreview.js';
 
 // ---------------------------------------------------------------------------
 // League label helper
@@ -66,6 +55,20 @@ export class ShopMenu {
 
     this._activeTab      = 'tanks';
     this._closeCallbacks = [];
+
+    /**
+     * Currently previewed skin ID in the Skins tab.
+     * Defaults to the first skin in SKIN_ORDER so the preview is never blank.
+     * @type {string|null}
+     */
+    this._selectedSkinId = SKIN_ORDER[0] ?? null;
+
+    /**
+     * Three.js rotating tank preview — created lazily when the Skins tab is
+     * opened, disposed when the shop closes.
+     * @type {SkinPreview|null}
+     */
+    this._skinPreview = null;
 
     this._el = document.getElementById('shop-menu');
     if (!this._el) {
@@ -94,6 +97,7 @@ export class ShopMenu {
 
   /** Hide the shop overlay and fire close callbacks. */
   close() {
+    this._disposeSkinPreview();
     this._el.classList.add('hidden');
     for (const fn of this._closeCallbacks) {
       fn();
@@ -110,6 +114,21 @@ export class ShopMenu {
       const tabBtn = e.target.closest('[data-tab]');
       if (tabBtn) {
         this._activeTab = tabBtn.dataset.tab;
+        this._render();
+        return;
+      }
+
+      // Skin card click (not the buy button) — update preview selection.
+      const skinCard = e.target.closest('[data-skin-select]');
+      if (skinCard && !e.target.closest('[data-buy]')) {
+        this._selectedSkinId = skinCard.dataset.skinSelect;
+        // Update preview colour immediately (no full re-render needed).
+        const def = SkinDefs[this._selectedSkinId];
+        if (def && this._skinPreview) {
+          this._skinPreview.setSkin(def.colorBody, def.colorTurret);
+        }
+        // Re-render to move the selection highlight; the preview canvas will
+        // be seamlessly re-mounted into the new DOM by _mountSkinPreview().
         this._render();
         return;
       }
@@ -162,6 +181,9 @@ export class ShopMenu {
         </div>
       </div>
     `;
+
+    // After innerHTML replacement, re-attach the SkinPreview canvas if needed.
+    this._mountSkinPreview();
   }
 
   /** @private Route to the active tab renderer. */
@@ -348,29 +370,107 @@ export class ShopMenu {
   }
 
   // ---------------------------------------------------------------------------
-  // Tab: Skins (no league gate)
+  // Tab: Skins — two-column layout: rotating 3D preview + scrollable skin list
   // ---------------------------------------------------------------------------
 
   /** @private */
   _renderSkins() {
-    const cards = SKIN_DEFS.map(def => {
+    // Ensure selectedSkinId defaults to the first skin if not yet set.
+    if (!this._selectedSkinId && SKIN_ORDER.length > 0) {
+      this._selectedSkinId = SKIN_ORDER[0];
+    }
+
+    const selectedDef = this._selectedSkinId ? SkinDefs[this._selectedSkinId] : SkinDefs[SKIN_ORDER[0]];
+
+    const cards = SKIN_ORDER.map(id => {
+      const def        = SkinDefs[id];
+      if (!def) return '';
       const owned      = this._save.hasItem('skin', def.id);
+      const locked     = !this._league.meetsLeagueRequirement(def.leagueRequired);
       const affordable = this._economy.canAfford(def.price);
+      const isSelected = def.id === this._selectedSkinId;
+
+      // Type label based on skin category.
+      const typeLabel = def.type === 'prestige' ? 'Prestige'
+                      : def.type === 'camo'     ? 'Camo'
+                      :                           'Cosmetic';
 
       return `
-        <div class="shop-card${owned ? ' owned' : ''}">
+        <div class="shop-card shop-skin-card${owned ? ' owned' : ''}${locked ? ' locked' : ''}${isSelected ? ' shop-skin-card-active' : ''}"
+             data-skin-select="${def.id}"
+             style="cursor:pointer;">
           <div class="shop-card-name">${def.name}
-            <span class="shop-type-tag">Cosmetic</span>
+            <span class="shop-type-tag">${typeLabel}</span>
           </div>
           <div class="shop-card-desc">${def.description}</div>
+          ${locked ? `<div class="shop-req-label">Requires ${leagueName(def.leagueRequired)}</div>` : ''}
           <div class="shop-card-footer">
-            ${this._buyFooter('skin', def.id, def.price, owned, false, affordable)}
+            ${this._buyFooter('skin', def.id, def.price, owned, locked, affordable)}
           </div>
         </div>
       `;
     }).join('');
 
-    return `<div class="shop-grid">${cards}</div>`;
+    return `
+      <div class="shop-skins-layout">
+        <div class="shop-skin-preview-col">
+          <div id="shop-skin-preview-mount" class="shop-skin-preview-mount"></div>
+          <div class="shop-skin-preview-name">${selectedDef ? selectedDef.name : ''}</div>
+          <div class="shop-skin-preview-desc">${selectedDef ? selectedDef.description : ''}</div>
+        </div>
+        <div class="shop-skin-grid-col">
+          <div class="shop-grid">${cards}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Skin preview lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create (or reuse) the SkinPreview instance and mount its canvas into the
+   * preview mount div that was just rendered. Called after every _render().
+   * @private
+   */
+  _mountSkinPreview() {
+    if (this._activeTab !== 'skins') {
+      // Leaving the skins tab — dispose to free GPU resources.
+      this._disposeSkinPreview();
+      return;
+    }
+
+    const mount = this._el.querySelector('#shop-skin-preview-mount');
+    if (!mount) return;
+
+    // Create the preview once; reuse across re-renders.
+    if (!this._skinPreview) {
+      this._skinPreview = new SkinPreview();
+    }
+
+    // Re-mount the canvas (it was removed when innerHTML was replaced).
+    this._skinPreview.mount(mount);
+
+    // Apply the currently selected skin colour.
+    const def = this._selectedSkinId
+      ? SkinDefs[this._selectedSkinId]
+      : SkinDefs[SKIN_ORDER[0]];
+    if (def) {
+      this._skinPreview.setSkin(def.colorBody, def.colorTurret);
+    }
+  }
+
+  /**
+   * Dispose the SkinPreview and free GPU resources.
+   * Safe to call multiple times.
+   * @private
+   */
+  _disposeSkinPreview() {
+    if (this._skinPreview) {
+      this._skinPreview.dispose();
+      this._skinPreview = null;
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -429,11 +529,13 @@ export class ShopMenu {
         this._showFlash(`${dataset.id} purchased!`, 'success');
         break;
 
-      case 'skin':
+      case 'skin': {
         this._save.addOwnedItem('skin', dataset.id);
         this._save.save();
-        this._showFlash(`${dataset.id} skin unlocked!`, 'success');
+        const skinDef = SkinDefs[dataset.id];
+        this._showFlash(`${skinDef ? skinDef.name : dataset.id} skin unlocked!`, 'success');
         break;
+      }
 
       case 'upgrade': {
         const tier     = parseInt(dataset.tier || '1', 10);

--- a/src/ui/SkinPreview.js
+++ b/src/ui/SkinPreview.js
@@ -1,0 +1,202 @@
+/**
+ * SkinPreview — self-contained Three.js mini-scene that renders a rotating
+ * tank model with a chosen skin applied. Used in the shop Skins tab.
+ *
+ * Usage:
+ *   const preview = new SkinPreview();
+ *   preview.mount(containerEl);          // attach canvas to a DOM element
+ *   preview.setSkin(0xff0000, 0xcc0000); // update hull / turret colours
+ *   preview.dispose();                   // clean up when leaving the tab
+ *
+ * The Three.js canvas is owned by this class. mount() moves it into the given
+ * container; dispose() removes it and cancels the animation loop.
+ *
+ * The preview renders at a fixed 240×200 logical pixels (device-pixel-ratio
+ * aware) so mount containers should be at least that size.
+ */
+
+import * as THREE from 'three';
+
+/** Fixed preview dimensions — chosen to fit the shop side panel comfortably. */
+const PREVIEW_W = 240;
+const PREVIEW_H = 200;
+
+export class SkinPreview {
+  constructor() {
+    this._animId = null;
+
+    // ---- Renderer ----------------------------------------------------------
+    this._renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    this._renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this._renderer.setSize(PREVIEW_W, PREVIEW_H);
+    this._renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this._renderer.toneMappingExposure = 1.0;
+
+    const canvas = this._renderer.domElement;
+    canvas.style.display      = 'block';
+    canvas.style.borderRadius = '8px';
+    canvas.style.width        = `${PREVIEW_W}px`;
+    canvas.style.height       = `${PREVIEW_H}px`;
+
+    // ---- Scene -------------------------------------------------------------
+    this._scene = new THREE.Scene();
+
+    // Soft ambient + warm key light matching the main game lighting.
+    const ambient = new THREE.AmbientLight(0x6688cc, 0.7);
+    this._scene.add(ambient);
+
+    const key = new THREE.DirectionalLight(0xffeedd, 1.6);
+    key.position.set(6, 10, 8);
+    this._scene.add(key);
+
+    const fill = new THREE.DirectionalLight(0x8899cc, 0.4);
+    fill.position.set(-5, 3, -4);
+    this._scene.add(fill);
+
+    // ---- Camera ------------------------------------------------------------
+    this._camera = new THREE.PerspectiveCamera(40, PREVIEW_W / PREVIEW_H, 0.1, 100);
+    // Slightly elevated front-quarter view so the turret and barrel are visible.
+    this._camera.position.set(7, 5, 9);
+    this._camera.lookAt(0, 1.0, 0);
+
+    // ---- Tank mesh ---------------------------------------------------------
+    /**
+     * Persistent materials — colours are updated in setSkin() without
+     * rebuilding the geometry.
+     */
+    this._hullMat   = new THREE.MeshStandardMaterial({
+      color:      0x2d5a27,
+      roughness:  0.7,
+      metalness:  0.3,
+      flatShading: true,
+    });
+    this._turretMat = new THREE.MeshStandardMaterial({
+      color:      0x3a7a33,
+      roughness:  0.6,
+      metalness:  0.4,
+      flatShading: true,
+    });
+
+    this._tankGroup = new THREE.Group();
+    this._scene.add(this._tankGroup);
+    this._buildTankMesh();
+
+    // ---- Animation loop ----------------------------------------------------
+    this._loop = this._loop.bind(this);
+    this._animId = requestAnimationFrame(this._loop);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Attach the preview canvas to a DOM container element.
+   * Safe to call multiple times (e.g. after a shop re-render): the canvas is
+   * simply moved if it already has a parent.
+   * @param {HTMLElement} container
+   */
+  mount(container) {
+    const canvas = this._renderer.domElement;
+    if (canvas.parentElement !== container) {
+      container.appendChild(canvas);
+    }
+  }
+
+  /**
+   * Update the tank colours to match a skin definition.
+   * @param {number} colorBody   Hull colour as a hex integer (e.g. 0x4a6b3f).
+   * @param {number} colorTurret Turret colour as a hex integer.
+   */
+  setSkin(colorBody, colorTurret) {
+    this._hullMat.color.setHex(colorBody);
+    this._turretMat.color.setHex(colorTurret);
+  }
+
+  /**
+   * Cancel the animation loop, dispose GPU resources, and remove the canvas
+   * from the DOM. Call this when the skins tab or shop closes.
+   */
+  dispose() {
+    if (this._animId !== null) {
+      cancelAnimationFrame(this._animId);
+      this._animId = null;
+    }
+
+    // Dispose geometries and materials to avoid GPU leaks.
+    this._scene.traverse((obj) => {
+      if (obj.isMesh) {
+        obj.geometry.dispose();
+        if (Array.isArray(obj.material)) {
+          obj.material.forEach(m => m.dispose());
+        } else {
+          obj.material.dispose();
+        }
+      }
+    });
+
+    this._renderer.dispose();
+    const canvas = this._renderer.domElement;
+    if (canvas.parentElement) {
+      canvas.parentElement.removeChild(canvas);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds the tank mesh replicating Tank.js geometry so the preview matches
+   * the in-game look exactly (flat-shaded low-poly style).
+   * @private
+   */
+  _buildTankMesh() {
+    const trackMat  = new THREE.MeshStandardMaterial({ color: 0x222222, roughness: 0.9, flatShading: true });
+    const barrelMat = new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.5, metalness: 0.6, flatShading: true });
+
+    // Hull
+    const hull = new THREE.Mesh(new THREE.BoxGeometry(3, 1.2, 4.5), this._hullMat);
+    hull.position.y = 0.8;
+    this._tankGroup.add(hull);
+
+    // Tracks
+    const trackGeo = new THREE.BoxGeometry(0.6, 0.8, 4.8);
+    const trackL = new THREE.Mesh(trackGeo, trackMat);
+    trackL.position.set(-1.6, 0.5, 0);
+    this._tankGroup.add(trackL);
+    const trackR = new THREE.Mesh(trackGeo, trackMat);
+    trackR.position.set(1.6, 0.5, 0);
+    this._tankGroup.add(trackR);
+
+    // Turret group
+    const turretGroup = new THREE.Group();
+    turretGroup.position.y = 1.5;
+
+    const turretMesh = new THREE.Mesh(new THREE.CylinderGeometry(1.1, 1.3, 0.8, 8), this._turretMat);
+    turretGroup.add(turretMesh);
+
+    // Barrel (pointing forward along -Z to match Tank.js orientation)
+    const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.15, 0.18, 3.5, 8), barrelMat);
+    barrel.rotation.x = Math.PI / 2;
+    barrel.position.set(0, 0.1, -1.9);
+    turretGroup.add(barrel);
+
+    this._tankGroup.add(turretGroup);
+
+    // Tilt slightly to show the top surface at the camera angle.
+    this._tankGroup.rotation.x = -0.08;
+  }
+
+  /**
+   * Animation loop — rotates the tank and renders a frame.
+   * @private
+   * @param {number} _ts - DOMHighResTimeStamp (unused; rotation is frame-rate-independent via fixed increment)
+   */
+  _loop(_ts) {
+    this._animId = requestAnimationFrame(this._loop);
+    // Slow continuous Y rotation — one full rotation every ~8 seconds at 60 fps.
+    this._tankGroup.rotation.y += 0.013;
+    this._renderer.render(this._scene, this._camera);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `src/ui/SkinPreview.js`: self-contained Three.js mini-renderer that builds a flat-shaded tank mesh (matching Tank.js geometry), rotates it continuously, and exposes `mount(el)` / `setSkin(colorBody, colorTurret)` / `dispose()` for clean shop lifecycle management.
- Redesign the Skins tab in `ShopMenu.js` as a two-column layout:
  - Left: fixed 240×200 rotating 3D tank preview with selected skin applied
  - Right: scrollable skin card grid with league-gate indicators
  - Clicking a skin card updates the preview colour immediately without a full re-render, then re-renders to move the selection highlight
- Import skin definitions from `src/data/SkinDefs.js` (added by t053) — all 11 skins, league-gated
- Add supporting CSS to `index.html`: `.shop-skins-layout`, `.shop-skin-preview-mount`, `.shop-skin-card-active`, responsive stack at ≤640px

## Testing

- `npm run build` succeeds (✓ 47 modules, no errors).
- Browser: open Shop → Skins tab → rotating tank visible, click different skins to see colour update live.

Resolves #69