### PR TITLE
t050: Rivers/mud zones movement penalty (40% tank, 60% soldier)

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -104,10 +104,12 @@ export class Game {
 
     // PlayerController manages tank vs. on-foot soldier mode for the human player.
     // It exposes a `mesh` getter so CameraController always follows the active entity.
+    // mapLayout passed so river/mud zone speed penalties are applied (t050).
     this.playerController = new PlayerController({
-      tank:    this.player,
-      scene:   this.scene,
-      terrain: this.terrain,
+      tank:      this.player,
+      scene:     this.scene,
+      terrain:   this.terrain,
+      mapLayout: this.mapLayout,
     });
 
     // t029 — Register / unregister the player's soldier with TeamManager so the
@@ -345,12 +347,14 @@ export class Game {
 
     // AIController drives all 10 AI tanks (team 0 slots 1-5 as allies, team 1 all 6 as enemies).
     // Passes the league def so enemy AI uses the correct difficulty multipliers.
+    // mapLayout passed so river/mud zone speed penalties apply to AI movement (t050).
     this.aiController = new AIController(
       this.teams,
       this.projectiles,
       this.particles,
       this.terrain,
-      currentLeagueDef
+      currentLeagueDef,
+      this.mapLayout
     );
 
     // Apply HP and damage multipliers to the enemy team (team 1) based on league.

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { Soldier } from '../entities/Soldier.js';
+import { RIVER_SPEED_TANK, RIVER_SPEED_SOLDIER } from '../systems/MapLayout.js';
 
 /**
  * Distance (units) within which the on-foot soldier can re-enter the idle tank.
@@ -33,15 +34,23 @@ const ARENA_BOUND = 90;
 export class PlayerController {
   /**
    * @param {object}  opts
-   * @param {import('../entities/Tank.js').Tank}       opts.tank    — player tank entity
+   * @param {import('../entities/Tank.js').Tank}       opts.tank      — player tank entity
    * @param {THREE.Scene}                              opts.scene
    * @param {import('../entities/Terrain.js').Terrain} opts.terrain
+   * @param {import('../systems/MapLayout.js').MapLayout} [opts.mapLayout] — for river speed penalties (t050)
    */
-  constructor({ tank, scene, terrain }) {
-    this.tank    = tank;
-    this.soldier = null;     // Soldier entity when on foot, null otherwise
-    this.scene   = scene;
-    this.terrain = terrain;
+  constructor({ tank, scene, terrain, mapLayout = null }) {
+    this.tank      = tank;
+    this.soldier   = null;     // Soldier entity when on foot, null otherwise
+    this.scene     = scene;
+    this.terrain   = terrain;
+
+    /**
+     * MapLayout reference for river / mud zone speed-penalty queries (t050).
+     * Optional: if null, no penalty is applied (e.g. tests or early boot).
+     * @type {import('../systems/MapLayout.js').MapLayout|null}
+     */
+    this.mapLayout = mapLayout;
 
     /** @type {'tank' | 'soldier'} */
     this.mode = 'tank';
@@ -298,8 +307,14 @@ export class PlayerController {
 
     // Use the tank's class-defined movement stats (set by Tank._applyClassDef).
     // speed is in world-units/second; turnRate is in radians/second.
-    const moveSpeed = tank.speed;
     const turnSpeed = tank.turnRate;
+
+    // River / mud zone speed penalty (t050): tanks move at 40% speed in rivers.
+    // Check current position before movement so the penalty applies as soon as
+    // the tank enters the zone.
+    const inRiver   = this.mapLayout !== null &&
+                      this.mapLayout.isInRiver(tank.mesh.position.x, tank.mesh.position.z);
+    const moveSpeed = tank.speed * (inRiver ? RIVER_SPEED_TANK : 1.0);
 
     // Lockdown Mode (t043): suppress all hull movement while active.
     // Turret can still track the target; firing continues at doubled rate.
@@ -353,8 +368,13 @@ export class PlayerController {
 
     const moving = input.forward || input.backward;
 
-    if (input.forward)  soldier.mesh.translateZ(-soldier.moveSpeed * dt);
-    if (input.backward) soldier.mesh.translateZ(soldier.moveSpeed * 0.6 * dt);
+    // River / mud zone speed penalty (t050): soldiers move at 60% speed in rivers.
+    const inRiver     = this.mapLayout !== null &&
+                        this.mapLayout.isInRiver(soldier.mesh.position.x, soldier.mesh.position.z);
+    const riverFactor = inRiver ? RIVER_SPEED_SOLDIER : 1.0;
+
+    if (input.forward)  soldier.mesh.translateZ(-soldier.moveSpeed * riverFactor * dt);
+    if (input.backward) soldier.mesh.translateZ(soldier.moveSpeed * 0.6 * riverFactor * dt);
     if (input.left)     soldier.mesh.rotation.y += soldier.turnSpeed * dt;
     if (input.right)    soldier.mesh.rotation.y -= soldier.turnSpeed * dt;
 

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { getLeagueDef } from '../data/LeagueDefs.js';
 import { Soldier } from '../entities/Soldier.js';
+import { RIVER_SPEED_TANK, RIVER_SPEED_SOLDIER } from './MapLayout.js';
 
 /**
  * AIController — drives all AI tanks and bailed AI soldiers.
@@ -199,12 +200,20 @@ export class AIController {
    * @param {import('../entities/Terrain.js').Terrain} terrain
    * @param {object} [leagueDef] — LeagueDefs entry for the player's current league.
    *   Defaults to 'bronze' when omitted. Determines enemy AI difficulty.
+   * @param {import('./MapLayout.js').MapLayout|null} [mapLayout] — for river speed penalties (t050).
    */
-  constructor(teamManager, projectileSystem, particleSystem, terrain, leagueDef) {
+  constructor(teamManager, projectileSystem, particleSystem, terrain, leagueDef, mapLayout = null) {
     this.teams = teamManager;
     this.projectiles = projectileSystem;
     this.particles = particleSystem;
     this.terrain = terrain;
+
+    /**
+     * MapLayout reference for river / mud zone speed-penalty queries (t050).
+     * Optional: if null, no penalty is applied.
+     * @type {import('./MapLayout.js').MapLayout|null}
+     */
+    this._mapLayout = mapLayout;
 
     /**
      * Per-tank transient AI state.
@@ -636,8 +645,12 @@ export class AIController {
 
     // --- Per-class movement stats ---
     // tank.speed and tank.turnRate are set by Tank._applyClassDef from TankDefs.
-    const moveSpeed = tank.speed;
     const turnSpeed = tank.turnRate;
+
+    // River / mud zone speed penalty (t050): AI tanks move at 40% speed in rivers.
+    const inRiver   = this._mapLayout !== null &&
+                      this._mapLayout.isInRiver(pos.x, pos.z);
+    const moveSpeed = tank.speed * (inRiver ? RIVER_SPEED_TANK : 1.0);
 
     // --- Per-class fire and aggro ranges ---
     // fireRange scales with the tank's effective range stat so Artillery AI
@@ -842,7 +855,11 @@ export class AIController {
     // Move forward until within preferred fire stop distance
     const stopDist = SOLDIER_FIRE_RANGE * SOLDIER_FIRE_STOP;
     if (dist > stopDist) {
-      soldier.mesh.translateZ(-soldier.moveSpeed * dt);
+      // River / mud zone speed penalty (t050): soldiers move at 60% speed in rivers.
+      const inRiver     = this._mapLayout !== null &&
+                          this._mapLayout.isInRiver(pos.x, pos.z);
+      const riverFactor = inRiver ? RIVER_SPEED_SOLDIER : 1.0;
+      soldier.mesh.translateZ(-soldier.moveSpeed * riverFactor * dt);
       // Keep on terrain and arena-clamped
       this._clampSoldier(soldier);
     }
@@ -871,8 +888,11 @@ export class AIController {
     const angle = Math.atan2(coverPos.x - pos.x, coverPos.z - pos.z);
     this._rotateSoldierToward(soldier, angle, dt);
 
-    // Move toward cover
-    soldier.mesh.translateZ(-soldier.moveSpeed * dt);
+    // Move toward cover (with river speed penalty if applicable — t050)
+    const inRiverCover  = this._mapLayout !== null &&
+                          this._mapLayout.isInRiver(pos.x, pos.z);
+    const riverFactorC  = inRiverCover ? RIVER_SPEED_SOLDIER : 1.0;
+    soldier.mesh.translateZ(-soldier.moveSpeed * riverFactorC * dt);
     this._clampSoldier(soldier);
 
     // Suppressive fire at target while retreating (if in range)

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -648,9 +648,7 @@ export class AIController {
     const turnSpeed = tank.turnRate;
 
     // River / mud zone speed penalty (t050): AI tanks move at 40% speed in rivers.
-    const inRiver   = this._mapLayout !== null &&
-                      this._mapLayout.isInRiver(pos.x, pos.z);
-    const moveSpeed = tank.speed * (inRiver ? RIVER_SPEED_TANK : 1.0);
+    const moveSpeed = tank.speed * this._riverSpeedFactor(pos, RIVER_SPEED_TANK);
 
     // --- Per-class fire and aggro ranges ---
     // fireRange scales with the tank's effective range stat so Artillery AI
@@ -856,10 +854,7 @@ export class AIController {
     const stopDist = SOLDIER_FIRE_RANGE * SOLDIER_FIRE_STOP;
     if (dist > stopDist) {
       // River / mud zone speed penalty (t050): soldiers move at 60% speed in rivers.
-      const inRiver     = this._mapLayout !== null &&
-                          this._mapLayout.isInRiver(pos.x, pos.z);
-      const riverFactor = inRiver ? RIVER_SPEED_SOLDIER : 1.0;
-      soldier.mesh.translateZ(-soldier.moveSpeed * riverFactor * dt);
+      soldier.mesh.translateZ(-soldier.moveSpeed * this._riverSpeedFactor(pos, RIVER_SPEED_SOLDIER) * dt);
       // Keep on terrain and arena-clamped
       this._clampSoldier(soldier);
     }
@@ -889,10 +884,7 @@ export class AIController {
     this._rotateSoldierToward(soldier, angle, dt);
 
     // Move toward cover (with river speed penalty if applicable — t050)
-    const inRiverCover  = this._mapLayout !== null &&
-                          this._mapLayout.isInRiver(pos.x, pos.z);
-    const riverFactorC  = inRiverCover ? RIVER_SPEED_SOLDIER : 1.0;
-    soldier.mesh.translateZ(-soldier.moveSpeed * riverFactorC * dt);
+    soldier.mesh.translateZ(-soldier.moveSpeed * this._riverSpeedFactor(pos, RIVER_SPEED_SOLDIER) * dt);
     this._clampSoldier(soldier);
 
     // Suppressive fire at target while retreating (if in range)
@@ -965,6 +957,22 @@ export class AIController {
 
     // Restore original rotation; visual facing handled by _rotateSoldierToward
     soldier.mesh.rotation.y = prevRotY;
+  }
+
+  /**
+   * Return the speed multiplier for a world position.
+   * Returns `riverFactor` when the position is inside a river/mud zone,
+   * otherwise 1.0 (no penalty).  Safe to call when `_mapLayout` is null.
+   *
+   * @param {{x: number, z: number}} pos — world XZ position (mesh.position works)
+   * @param {number} riverFactor — penalty factor (RIVER_SPEED_TANK or RIVER_SPEED_SOLDIER)
+   * @returns {number}
+   * @private
+   */
+  _riverSpeedFactor(pos, riverFactor) {
+    return (this._mapLayout !== null && this._mapLayout.isInRiver(pos.x, pos.z))
+      ? riverFactor
+      : 1.0;
   }
 
   /**

--- a/tests/ZoneSystem.test.js
+++ b/tests/ZoneSystem.test.js
@@ -30,9 +30,17 @@ import {
 const mockScene   = { add: () => {} };
 const mockTerrain = { getHeightAt: () => 0 };
 
-/** Construct a MapLayout with mock dependencies. */
+/**
+ * Module-scope layout instance — MapLayout construction is stateless for
+ * the assertions in this file (isInRiver() depends only on the constant
+ * RIVER_DEFS, not on scene/terrain state).  Shared to avoid redundant
+ * Three.js geometry allocations across the 19 tests.
+ */
+const layout = new MapLayout(mockScene, mockTerrain);
+
+/** @deprecated Use module-scope `layout` directly; kept for clarity in old calls. */
 function makeLayout() {
-  return new MapLayout(mockScene, mockTerrain);
+  return layout;
 }
 
 // ── Speed constant tests ──────────────────────────────────────────────────────

--- a/tests/ZoneSystem.test.js
+++ b/tests/ZoneSystem.test.js
@@ -1,0 +1,155 @@
+/**
+ * ZoneSystem.test.js — Unit tests for river/mud zone detection and speed penalties.
+ *
+ * Run: node --test tests/ZoneSystem.test.js
+ *
+ * Covers:
+ *  - RIVER_SPEED_TANK and RIVER_SPEED_SOLDIER match VISION.md values
+ *  - isInRiver() returns true for points inside the north and south river bands
+ *  - isInRiver() returns false for points clearly outside any river zone
+ *  - isInRiver() returns false for center village area (z ≈ 0)
+ *  - isInRiver() boundary: just inside and just outside the band edges
+ *  - River zones are symmetric (same depth north and south)
+ *  - X coordinate has no effect on isInRiver() (rivers span full map width)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MapLayout,
+  RIVER_SPEED_TANK,
+  RIVER_SPEED_SOLDIER,
+} from '../src/systems/MapLayout.js';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Minimal Three.js scene/terrain mocks.
+ * MapLayout calls scene.add() and terrain.getHeightAt() during construction —
+ * both are no-ops for testing.
+ */
+const mockScene   = { add: () => {} };
+const mockTerrain = { getHeightAt: () => 0 };
+
+/** Construct a MapLayout with mock dependencies. */
+function makeLayout() {
+  return new MapLayout(mockScene, mockTerrain);
+}
+
+// ── Speed constant tests ──────────────────────────────────────────────────────
+
+test('RIVER_SPEED_TANK equals 0.40 as specified in VISION.md', () => {
+  assert.equal(RIVER_SPEED_TANK, 0.40);
+});
+
+test('RIVER_SPEED_SOLDIER equals 0.60 as specified in VISION.md', () => {
+  assert.equal(RIVER_SPEED_SOLDIER, 0.60);
+});
+
+test('RIVER_SPEED_TANK is less than 1.0 (penalty, not boost)', () => {
+  assert.ok(RIVER_SPEED_TANK > 0 && RIVER_SPEED_TANK < 1.0);
+});
+
+test('RIVER_SPEED_SOLDIER is less than 1.0 (penalty, not boost)', () => {
+  assert.ok(RIVER_SPEED_SOLDIER > 0 && RIVER_SPEED_SOLDIER < 1.0);
+});
+
+// ── isInRiver() — river zone detection ───────────────────────────────────────
+
+test('isInRiver() returns true at north river centre (z=-26)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, -26), true);
+});
+
+test('isInRiver() returns true at south river centre (z=+26)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 26), true);
+});
+
+test('isInRiver() returns false at map centre (z=0, village area)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 0), false);
+});
+
+test('isInRiver() returns false at team 0 spawn zone (z=+57)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 57), false);
+});
+
+test('isInRiver() returns false at team 1 spawn zone (z=-57)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, -57), false);
+});
+
+// River depth is 10 units, centred at ±26.
+// North band: z in [-31, -21]; South band: z in [+21, +31].
+
+test('isInRiver() returns true at north river edge minZ (z=-31)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, -31), true);
+});
+
+test('isInRiver() returns true at north river edge maxZ (z=-21)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, -21), true);
+});
+
+test('isInRiver() returns false just outside north river minZ (z=-31.1)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, -31.1), false);
+});
+
+test('isInRiver() returns false just outside north river maxZ (z=-20.9)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, -20.9), false);
+});
+
+test('isInRiver() returns true at south river edge minZ (z=+21)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 21), true);
+});
+
+test('isInRiver() returns true at south river edge maxZ (z=+31)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 31), true);
+});
+
+test('isInRiver() returns false just outside south river maxZ (z=+31.1)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 31.1), false);
+});
+
+test('isInRiver() returns false just outside south river minZ (z=+20.9)', () => {
+  const layout = makeLayout();
+  assert.equal(layout.isInRiver(0, 20.9), false);
+});
+
+// ── X coordinate invariance ───────────────────────────────────────────────────
+
+test('isInRiver() is not affected by X coordinate (river spans full width)', () => {
+  const layout = makeLayout();
+  // Same Z (north river centre), various X values
+  assert.equal(layout.isInRiver(-75, -26), true);
+  assert.equal(layout.isInRiver(0,   -26), true);
+  assert.equal(layout.isInRiver(75,  -26), true);
+});
+
+// ── Symmetry: both rivers are identical bands ─────────────────────────────────
+
+test('north and south river zones have equal depth', () => {
+  const layout = makeLayout();
+  // Both rivers should span 10 units centred on their z position
+  const northIn  = layout.isInRiver(0, -26);
+  const southIn  = layout.isInRiver(0, 26);
+  assert.equal(northIn, true);
+  assert.equal(southIn, true);
+
+  // Check that equal offsets from centre match on both sides
+  const offsets = [0, 2, 4, 4.9];
+  for (const off of offsets) {
+    assert.equal(
+      layout.isInRiver(0, -26 + off),
+      layout.isInRiver(0,  26 - off),
+      `Symmetry violated at offset ${off}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Implements the river/mud zone movement penalty from VISION.md §Terrain:
- **Tanks** slow to 40% speed (`RIVER_SPEED_TANK = 0.40`) when inside a river zone
- **Soldiers** slow to 60% speed (`RIVER_SPEED_SOLDIER = 0.60`) when inside a river zone

River zones (already rendered by `MapLayout`) are centred at z ≈ ±26 with 10-unit north-south depth. The penalty applies to both player-controlled and AI-controlled entities.

## Files Changed

- **EDIT: `src/core/PlayerController.js`** — accept `mapLayout` constructor opt; apply river speed factor in `_updateTankMode` (tank mode) and `_updateSoldierMode` (soldier mode) before `translateZ` calls
- **EDIT: `src/systems/AIController.js`** — accept `mapLayout` as 6th constructor arg; apply river speed factor in `_driveTankTowardTarget` (AI tank advance), `_soldierAdvance` and `_soldierSeekCover`
- **EDIT: `src/core/Game.js`** — pass `this.mapLayout` to `PlayerController` and `AIController` constructors (already present in `Game._initScene`)
- **NEW: `tests/ZoneSystem.test.js`** — 19 tests covering speed constants, `isInRiver()` boundary conditions (band edges ±0.1), X-coordinate invariance, and north/south symmetry

## Verification

```
node --test tests/ZoneSystem.test.js
# tests 19 / pass 19 / fail 0
```

Resolves #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tanks and soldiers now experience reduced movement speed when crossing rivers.
  * AI-controlled units now account for river terrain when navigating and planning movement.

* **Tests**
  * Added test coverage for river detection and movement speed penalty mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->