### PR TITLE
t057: Music — menu/combat loops, victory/defeat stings, volume control

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,99 @@
       #touch-controls { display: none; }
     }
 
+    /* === Music volume control (t057) — bottom-right corner === */
+    #music-ctrl {
+      position: fixed;
+      bottom: 12px;
+      right: 16px;
+      z-index: 20;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 6px;
+      pointer-events: auto;
+    }
+
+    #music-vol-btn {
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.45);
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      color: rgba(255, 255, 255, 0.75);
+      font-size: 14px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.15s, border-color 0.15s;
+      user-select: none;
+    }
+
+    #music-vol-btn:hover {
+      background: rgba(0, 0, 0, 0.7);
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+
+    #music-vol-btn.muted {
+      color: rgba(255, 255, 255, 0.3);
+    }
+
+    #music-vol-popup {
+      background: rgba(0, 0, 0, 0.75);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 8px;
+      padding: 10px 12px;
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+    }
+
+    #music-vol-popup.visible {
+      display: flex;
+    }
+
+    #music-vol-popup label {
+      color: rgba(255, 255, 255, 0.65);
+      font-size: 10px;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+
+    #music-vol-slider {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 80px;
+      height: 4px;
+      border-radius: 2px;
+      background: rgba(255, 255, 255, 0.25);
+      outline: none;
+      cursor: pointer;
+    }
+
+    #music-vol-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: #4caf50;
+      cursor: pointer;
+    }
+
+    #music-vol-slider::-moz-range-thumb {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: #4caf50;
+      cursor: pointer;
+      border: none;
+    }
+
+    @media (pointer: fine) {
+      #music-ctrl { bottom: 44px; }
+    }
+
     /* === Ability Bar (t045) — bottom-centre, two slots with radial cooldown === */
     #ability-bar {
       position: fixed;
@@ -1894,6 +1987,15 @@
       </div>
       <button id="loadout-deploy-btn">Deploy</button>
     </div>
+  </div>
+
+  <!-- Music volume control (t057) -->
+  <div id="music-ctrl">
+    <div id="music-vol-popup">
+      <label>Music</label>
+      <input id="music-vol-slider" type="range" min="0" max="100" value="40" />
+    </div>
+    <button id="music-vol-btn" title="Music volume">&#9834;</button>
   </div>
 
   <!-- Legacy Game Over (kept for HUD.js compatibility, hidden during normal play) -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "howler": "^2.2.4",
         "three": "^0.172.0"
       },
       "devDependencies": {
@@ -888,6 +889,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/howler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
+      "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "howler": "^2.2.4",
     "three": "^0.172.0"
   },
   "devDependencies": {

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -28,6 +28,8 @@ import { LeagueSystem } from '../systems/LeagueSystem.js';
 import { LeagueDisplay } from '../ui/LeagueDisplay.js';
 import { getLeagueDef } from '../data/LeagueDefs.js';
 import { MapLayout } from '../systems/MapLayout.js';
+import { SoundSystem } from '../systems/SoundSystem.js';
+import { MusicSystem } from '../systems/MusicSystem.js';
 import { TankAbilityEffects } from '../systems/TankAbilityEffects.js';
 import { getTankDef } from '../data/TankDefs.js';
 import { GunDefs, MeleeDefs } from '../data/WeaponDefs.js';
@@ -124,6 +126,14 @@ export class Game {
   }
 
   _initSystems() {
+    // SoundSystem (t056): Howler.js SFX — create first so other systems can
+    // fire sound events during their own initialisation.
+    this.sound = new SoundSystem();
+    this.sound.bindUIClicks();
+
+    // MusicSystem (t057): procedurally-synthesised music tracks.
+    this.music = new MusicSystem();
+
     this.input = new InputSystem(this.canvas);
     // CameraController uses target.mesh; PlayerController exposes that getter
     // so the camera follows whichever entity the player is currently controlling.
@@ -147,6 +157,9 @@ export class Game {
     // Dust-emission timers
     this._playerDustTimer = 0;
     this._enemyDustTimer = 0;
+
+    /** Track whether the player was moving last frame to detect start/stop. */
+    this._playerWasMoving = false;
 
     /**
      * CollisionSystem compatibility adapter.
@@ -180,9 +193,13 @@ export class Game {
       .onPlayerDeath(() => this._onPlayerTankDestroyed())
       .onHit((pos) => {
         this.particles.emitExplosion(pos, { count: 15, speed: 6, lifetime: 0.6 });
+        // Play impact sound for non-lethal shell hits (t056).
+        this.sound.playImpact();
       })
       .onKill((pos, owner, tankData) => {
         this.particles.emitExplosion(pos, { count: 35, speed: 10 });
+        // Play explosion sound whenever any tank is destroyed (t056).
+        this.sound.playExplosion();
         // Leave a wreck at the tank's last position as indestructible cover
         if (tankData) {
           this.wrecks.add(tankData.position, tankData.rotationY);
@@ -218,6 +235,8 @@ export class Game {
         // Particle count scales with splash radius so bigger weapons feel bigger.
         const count = Math.round(25 + splashRadius * 3);
         this.particles.emitExplosion(pos, { count, speed: 10, lifetime: 1.0 });
+        // Explosive rounds also play the explosion sound (t056).
+        this.sound.playExplosion();
       })
       .onBuildingWallDestroyed((pos) => {
         // Medium debris burst when a wall panel is knocked down (t047/t048).
@@ -297,6 +316,12 @@ export class Game {
       })
       .onMatchEnd((winnerId) => {
         const playerWon = winnerId === 0;
+        // Play victory or defeat sting (t057).
+        if (playerWon) {
+          this.music.playVictory();
+        } else {
+          this.music.playDefeat();
+        }
         const matchStats = this.stats.getMatchStats();
         console.info(
           `[Game] Match over — ${playerWon ? 'Player' : 'Enemy'} team wins! ` +
@@ -359,6 +384,11 @@ export class Game {
     // round resets because Tank.reset() restores health to the (already-scaled) maxHealth.
     this.aiController.applyLeagueScalingToTeam(1, 0);
 
+    // Wire AI cannon sounds (t056): attenuated shot sound when any AI tank fires.
+    this.aiController.onShot((_tank, _proj) => {
+      this.sound.playShot();
+    });
+
     // Assign abilities to AI tanks based on the current league (t046).
     // Gold+: specific slots get abilities matching VISION.md team compositions.
     // Bronze/Silver: all abilityId fields remain null (method no-ops on those leagues).
@@ -408,6 +438,8 @@ export class Game {
    * Call this on fresh game start.
    */
   start() {
+    // Play menu music while the loadout screen is visible (t057).
+    this.music.playMenu();
     this.loadoutScreen.show((selection) => {
       this.currentLoadout = selection;
       // Persist the selection so it survives a page reload.
@@ -428,6 +460,8 @@ export class Game {
        this._applyLoadoutToAbilitySystem(selection);
        // Apply the equipped cosmetic skin to the player tank (t053).
        this.teams.player.applySkin(this.save.getEquippedSkin());
+       // Switch from menu music to combat music when the match begins (t057).
+       this.music.playCombat();
        this._startImmediately();
     });
   }
@@ -513,6 +547,9 @@ export class Game {
     this.particles.update(dt);
     this.cameraController.update(dt);
 
+    // SoundSystem: drain per-frame timers (shot cooldown, etc.) (t056).
+    this.sound.update(dt);
+
     // HUD — pass live round stats for the counters.
     // Use playerController so values reflect the active entity (tank or soldier).
     // maxHealth is passed so the bar fills to 100 % at full soldier HP (30), not 30 %.
@@ -572,7 +609,17 @@ export class Game {
       for (const proj of newProjectiles) {
         this.projectiles.add(proj);
       }
+      // Play cannon fire sound for the player (t056). Rate-limited inside playShot().
+      this.sound.playShot();
     }
+
+    // ---- Engine sound — start/stop based on movement state (t056) ----
+    if (isMoving && !this._playerWasMoving) {
+      this.sound.startEngine();
+    } else if (!isMoving && this._playerWasMoving) {
+      this.sound.stopEngine();
+    }
+    this._playerWasMoving = isMoving;
 
     // ---- On-foot soldier melee (t026/t034) ----
     // Melee swings are triggered by:
@@ -791,9 +838,11 @@ export class Game {
           this.teams.killTank(target);
         }
         this.particles.emitExplosion(hitPos, { count: 25, speed: 8 });
+        this.sound.playExplosion(); // lethal melee hit (t056)
       } else {
         // Small impact burst for a non-lethal hit.
         this.particles.emitExplosion(hitPos, { count: 8, speed: 4, lifetime: 0.3 });
+        this.sound.playImpact(); // non-lethal melee hit (t056)
       }
     }
   }
@@ -1061,6 +1110,8 @@ export class Game {
    */
   openShop() {
     this.isRunning = false;
+    // Menu music while browsing the shop (t057).
+    this.music.playMenu();
     this.shopMenu.open();
   }
 
@@ -1073,6 +1124,8 @@ export class Game {
     this.leagueDisplay.hide();
     // Pause the game loop while the loadout screen is shown.
     this.isRunning = false;
+    // Return to menu music while the loadout is open (t057).
+    this.music.playMenu();
 
     this.loadoutScreen.show((selection) => {
       this.currentLoadout = selection;
@@ -1090,6 +1143,8 @@ export class Game {
       this.playerController.soldierMeleeId = selection.melee;
       // Reconfigure AbilitySystem for the new loadout (t042).
       this._applyLoadoutToAbilitySystem(selection);
+      // Switch to combat music (t057).
+      this.music.playCombat();
 
       this.score = 0;
       // Reset match state machine first (no team events should fire during reset)

--- a/src/main.js
+++ b/src/main.js
@@ -9,3 +9,41 @@ game.start();
 
 // Prevent zoom on double-tap (mobile)
 document.addEventListener('dblclick', (e) => e.preventDefault());
+
+// ── Music volume control (t057) ───────────────────────────────────────────────
+// Wired after game.start() so game.music is available.
+const musicBtn    = document.getElementById('music-vol-btn');
+const musicPopup  = document.getElementById('music-vol-popup');
+const musicSlider = document.getElementById('music-vol-slider');
+
+if (musicBtn && musicPopup && musicSlider) {
+  // Sync slider to the MusicSystem's persisted volume.
+  const syncSlider = () => {
+    const v = game.music.getMusicVolume();
+    musicSlider.value = String(Math.round(v * 100));
+    musicBtn.classList.toggle('muted', v === 0);
+    // Update aria label for accessibility
+    musicBtn.title = v === 0 ? 'Music: off' : `Music: ${Math.round(v * 100)}%`;
+  };
+  syncSlider();
+
+  // Toggle popup on button click.
+  musicBtn.addEventListener('click', () => {
+    musicPopup.classList.toggle('visible');
+  });
+
+  // Close popup when clicking elsewhere.
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('#music-ctrl')) {
+      musicPopup.classList.remove('visible');
+    }
+  }, true);
+
+  // Update music volume as slider moves.
+  musicSlider.addEventListener('input', () => {
+    const v = parseInt(musicSlider.value, 10) / 100;
+    game.music.setMusicVolume(v);
+    musicBtn.classList.toggle('muted', v === 0);
+    musicBtn.title = v === 0 ? 'Music: off' : `Music: ${Math.round(v * 100)}%`;
+  });
+}

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -224,6 +224,14 @@ export class AIController {
      */
     this._soldiers = [];
 
+    /**
+     * Optional callback fired whenever an AI tank fires a projectile.
+     * Signature: (tank: Tank, projectile: Projectile) => void
+     * Set via onShot() — used by SoundSystem to play AI cannon sounds.
+     * @type {((tank: object, projectile: object) => void)|null}
+     */
+    this._onShot = null;
+
     // Apply initial league. Falls back to bronze if leagueDef is missing/null.
     this._applyLeagueDef(leagueDef || getLeagueDef('bronze'));
   }
@@ -231,6 +239,18 @@ export class AIController {
   // -------------------------------------------------------------------------
   // Public API — Tank AI
   // -------------------------------------------------------------------------
+
+  /**
+   * Register a callback that fires whenever any AI tank fires a projectile.
+   * Used by SoundSystem to play cannon sounds for AI shots (t056).
+   *
+   * @param {(tank: object, projectile: object) => void} fn
+   * @returns {this}
+   */
+  onShot(fn) {
+    this._onShot = fn;
+    return this;
+  }
 
   /**
    * Switch the AI to a different league difficulty level.
@@ -698,6 +718,8 @@ export class AIController {
           projectile.mesh.position.clone(),
           flashDir
         );
+        // Notify the sound system (if registered) so AI cannon fire is audible (t056).
+        if (this._onShot) this._onShot(tank, projectile);
       }
     }
   }

--- a/src/systems/MusicSystem.js
+++ b/src/systems/MusicSystem.js
@@ -1,0 +1,410 @@
+/**
+ * MusicSystem — Howler.js-based music manager for GUNZ (t057).
+ *
+ * All music is synthesised procedurally at module load time as WAV data URLs.
+ * No external audio files required.  Music tracks are kept separate from SFX
+ * (SoundSystem) so volume can be controlled independently.
+ *
+ * Tracks
+ * ──────
+ *   menu    — calm ambient arpeggio loop for loadout/shop screens
+ *   combat  — driving rhythmic loop for active match play
+ *   victory — short ascending fanfare (one-shot, match won)
+ *   defeat  — short descending phrase (one-shot, match lost)
+ *
+ * Public API
+ * ──────────
+ *   playMenu()               — crossfade to menu loop
+ *   playCombat()             — crossfade to combat loop
+ *   playVictory()            — play victory sting (stops current loop)
+ *   playDefeat()             — play defeat sting (stops current loop)
+ *   stopAll(fadeDuration?)   — fade out and stop all music
+ *   setMusicVolume(0-1)      — music-only volume (persisted to localStorage)
+ *   getMusicVolume()         — current music volume
+ *   dispose()                — release all Howl instances
+ */
+
+import { Howl } from 'howler';
+
+// ─── WAV synthesis helpers (duplicated from SoundSystem for module isolation) ─
+
+const SR = 16_000; // 16 kHz sample rate
+
+/**
+ * Build a 16-bit mono WAV data URL.
+ * @param {number}              duration  seconds
+ * @param {(t: number) => number} fn      sample render, must return [-1, 1]
+ * @returns {string}
+ */
+function _makeWavUrl(duration, fn) {
+  const n   = Math.ceil(SR * duration);
+  const pcm = new Int16Array(n);
+  for (let i = 0; i < n; i++) {
+    const s = fn(i / SR);
+    pcm[i]  = Math.round(Math.max(-1, Math.min(1, s)) * 32_767);
+  }
+
+  const buf = new ArrayBuffer(44 + n * 2);
+  const dv  = new DataView(buf);
+  const wr  = (off, str) => {
+    for (let k = 0; k < str.length; k++) dv.setUint8(off + k, str.charCodeAt(k));
+  };
+
+  wr(0, 'RIFF');  dv.setUint32(4, 36 + n * 2, true);
+  wr(8, 'WAVE');  wr(12, 'fmt ');
+  dv.setUint32(16, 16, true); dv.setUint16(20, 1, true); dv.setUint16(22, 1, true);
+  dv.setUint32(24, SR, true); dv.setUint32(28, SR * 2, true);
+  dv.setUint16(32, 2, true);  dv.setUint16(34, 16, true);
+  wr(36, 'data'); dv.setUint32(40, n * 2, true);
+
+  const out = new Uint8Array(buf, 44);
+  for (let i = 0; i < n; i++) {
+    out[i * 2]     =  pcm[i] & 0xff;
+    out[i * 2 + 1] = (pcm[i] >> 8) & 0xff;
+  }
+
+  const all = new Uint8Array(buf);
+  let bin = '';
+  for (const b of all) bin += String.fromCharCode(b);
+  return `data:audio/wav;base64,${btoa(bin)}`;
+}
+
+// ─── Note sequencer ───────────────────────────────────────────────────────────
+
+/**
+ * Render a sequence of pitched notes into a WAV.
+ *
+ * @param {number} duration  total clip duration in seconds
+ * @param {Array<{start:number, freq:number, dur:number, vol?:number, harmonics?:boolean}>} notes
+ * @returns {string}  WAV data URL
+ */
+function _renderNotes(duration, notes) {
+  return _makeWavUrl(duration, (t) => {
+    let sample = 0;
+    for (const n of notes) {
+      if (t < n.start || t >= n.start + n.dur) continue;
+      const local = t - n.start;
+      // Linear attack + exponential decay envelope
+      const attack  = Math.min(0.04, n.dur * 0.1);
+      const release = Math.min(0.15, n.dur * 0.3);
+      let env;
+      if (local < attack) {
+        env = local / attack;
+      } else if (local > n.dur - release) {
+        env = (n.dur - local) / release;
+      } else {
+        env = 1.0;
+      }
+      env = Math.max(0, env);
+
+      const vol = n.vol !== undefined ? n.vol : 0.5;
+      const f   = n.freq;
+
+      // Pure sine fundamental + optional soft second harmonic for warmth
+      let wave = Math.sin(2 * Math.PI * f * local);
+      if (n.harmonics) {
+        wave += Math.sin(2 * Math.PI * f * 2 * local) * 0.25;
+        wave += Math.sin(2 * Math.PI * f * 3 * local) * 0.10;
+        wave /= 1.35; // normalise
+      }
+
+      sample += wave * env * vol;
+    }
+    // Soft-clip with tanh to prevent harsh clipping if notes overlap
+    return Math.tanh(sample);
+  });
+}
+
+// ─── Note frequency table ─────────────────────────────────────────────────────
+
+const N = {
+  C3:  130.81, D3:  146.83, Eb3: 155.56, F3:  174.61, G3:  196.00,
+  Ab3: 207.65, Bb3: 233.08,
+  C4:  261.63, D4:  293.66, Eb4: 311.13, E4:  329.63, F4:  349.23,
+  G4:  392.00, Ab4: 415.30, A4:  440.00, Bb4: 466.16, B4:  493.88,
+  C5:  523.25, D5:  587.33, E5:  659.25, G5:  783.99,
+};
+
+// ─── Menu music loop ──────────────────────────────────────────────────────────
+// Calm ambient arpeggio in C major.  8-second seamless loop at ~80 BPM.
+// Pattern: ascending C-E-G-A-G-E + sustained pad chord underneath.
+
+/** Duration of one semitone = 3/4 of a beat at 80 BPM */
+const MENU_BEAT = 0.75; // seconds per beat
+
+const _MENU_ARPEGGIO = [
+  // Main arpeggio line (ascending C-E-G-A)
+  { start: 0.0 * MENU_BEAT, freq: N.C4, dur: 1.6 * MENU_BEAT, vol: 0.48 },
+  { start: 1.5 * MENU_BEAT, freq: N.E4, dur: 1.6 * MENU_BEAT, vol: 0.45 },
+  { start: 3.0 * MENU_BEAT, freq: N.G4, dur: 1.6 * MENU_BEAT, vol: 0.45 },
+  { start: 4.5 * MENU_BEAT, freq: N.A4, dur: 1.6 * MENU_BEAT, vol: 0.45 },
+  // Descent
+  { start: 6.0 * MENU_BEAT, freq: N.G4, dur: 1.6 * MENU_BEAT, vol: 0.42 },
+  { start: 7.5 * MENU_BEAT, freq: N.E4, dur: 1.8 * MENU_BEAT, vol: 0.40 },
+  // Bass note underneath
+  { start: 0.0 * MENU_BEAT, freq: N.C3, dur: 4.0 * MENU_BEAT, vol: 0.20 },
+  { start: 4.5 * MENU_BEAT, freq: N.G3, dur: 4.0 * MENU_BEAT, vol: 0.18 },
+  // High shimmer on alternate beats
+  { start: 2.25 * MENU_BEAT, freq: N.C5, dur: 0.8 * MENU_BEAT, vol: 0.22 },
+  { start: 5.25 * MENU_BEAT, freq: N.D5, dur: 0.8 * MENU_BEAT, vol: 0.20 },
+];
+
+const MENU_DURATION = 8 * MENU_BEAT; // ≈ 6.0 s loop
+
+const _MENU_URL = _renderNotes(MENU_DURATION, _MENU_ARPEGGIO);
+
+// ─── Combat music loop ────────────────────────────────────────────────────────
+// Driving, tense loop in C minor at ~130 BPM.  8-second seamless loop.
+// Two-voice texture: low bass pattern + higher counter-melody.
+
+const CB = 60 / 130; // seconds per beat at 130 BPM
+
+const _COMBAT_NOTES = (() => {
+  const notes = [];
+  // Bass pattern: C3 every beat with rhythmic accents
+  const bassPat = [N.C3, N.C3, N.G3, N.C3, N.Bb3, N.C3, N.G3, N.Ab3];
+  for (let i = 0; i < 8; i++) {
+    notes.push({ start: i * CB, freq: bassPat[i], dur: CB * 0.85, vol: 0.38, harmonics: true });
+  }
+  // Counter melody (off-beat, higher register)
+  const melPat = [N.Eb4, N.D4, N.C4, N.Bb3, N.C4, N.D4, N.Eb4, N.F4];
+  for (let i = 0; i < 8; i++) {
+    notes.push({ start: (i + 0.5) * CB, freq: melPat[i], dur: CB * 0.6, vol: 0.30 });
+  }
+  // Accent pulse every 2 beats (sub-bass rumble)
+  for (let i = 0; i < 4; i++) {
+    notes.push({ start: i * CB * 2, freq: N.C3 / 2, dur: CB * 0.5, vol: 0.22, harmonics: true });
+  }
+  return notes;
+})();
+
+const COMBAT_DURATION = 8 * CB; // ≈ 3.7 s loop (tight, punchy)
+
+const _COMBAT_URL = _renderNotes(COMBAT_DURATION, _COMBAT_NOTES);
+
+// ─── Victory sting ────────────────────────────────────────────────────────────
+// Rising fanfare: C4 → E4 → G4 → C5 → E5, then a held chord.
+
+const VB = 0.38; // seconds per note
+
+const _VICTORY_NOTES = [
+  { start: 0 * VB, freq: N.C4, dur: VB * 1.1, vol: 0.55, harmonics: true },
+  { start: 1 * VB, freq: N.E4, dur: VB * 1.1, vol: 0.55, harmonics: true },
+  { start: 2 * VB, freq: N.G4, dur: VB * 1.1, vol: 0.55, harmonics: true },
+  { start: 3 * VB, freq: N.C5, dur: VB * 1.6, vol: 0.60, harmonics: true },
+  { start: 4 * VB, freq: N.E5, dur: VB * 1.6, vol: 0.58, harmonics: true },
+  // Held chord root (fade sustain)
+  { start: 3 * VB, freq: N.G4, dur: VB * 2.4, vol: 0.30 },
+  { start: 3 * VB, freq: N.C4, dur: VB * 2.4, vol: 0.25 },
+];
+
+const VICTORY_DURATION = 3.0;
+
+const _VICTORY_URL = _renderNotes(VICTORY_DURATION, _VICTORY_NOTES);
+
+// ─── Defeat sting ─────────────────────────────────────────────────────────────
+// Slow descending minor phrase: C4 → Bb3 → Ab3 → G3.
+
+const DB = 0.55; // seconds per note
+
+const _DEFEAT_NOTES = [
+  { start: 0 * DB, freq: N.C4,  dur: DB * 1.2, vol: 0.50, harmonics: true },
+  { start: 1 * DB, freq: N.Bb3, dur: DB * 1.2, vol: 0.48, harmonics: true },
+  { start: 2 * DB, freq: N.Ab3, dur: DB * 1.2, vol: 0.46, harmonics: true },
+  { start: 3 * DB, freq: N.G3,  dur: DB * 2.0, vol: 0.44, harmonics: true },
+  // Harmonised fifth underneath
+  { start: 0 * DB, freq: N.G3,  dur: DB * 1.2, vol: 0.22 },
+  { start: 1 * DB, freq: N.F3,  dur: DB * 1.2, vol: 0.20 },
+  { start: 2 * DB, freq: N.Eb3, dur: DB * 1.2, vol: 0.20 },
+  { start: 3 * DB, freq: N.D3,  dur: DB * 2.0, vol: 0.18 },
+];
+
+const DEFEAT_DURATION = 3.5;
+
+const _DEFEAT_URL = _renderNotes(DEFEAT_DURATION, _DEFEAT_NOTES);
+
+// ─── MusicSystem class ────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'gunz_music_volume';
+const FADE_MS     = 800; // default crossfade duration in ms
+
+export class MusicSystem {
+  constructor() {
+    /** Current music volume [0-1].  Loaded from localStorage. */
+    this._volume = this._loadVolume();
+
+    this._menu = new Howl({
+      src:    [_MENU_URL],
+      loop:   true,
+      volume: 0,
+    });
+
+    this._combat = new Howl({
+      src:    [_COMBAT_URL],
+      loop:   true,
+      volume: 0,
+    });
+
+    this._victory = new Howl({
+      src:    [_VICTORY_URL],
+      loop:   false,
+      volume: this._volume,
+    });
+
+    this._defeat = new Howl({
+      src:    [_DEFEAT_URL],
+      loop:   false,
+      volume: this._volume,
+    });
+
+    /** Which loop is currently playing: 'menu' | 'combat' | null */
+    this._activeLoop = null;
+
+    /** Howl sound IDs for the active looping tracks. */
+    this._menuId   = null;
+    this._combatId = null;
+  }
+
+  // ─── Volume ──────────────────────────────────────────────────────────────
+
+  /**
+   * Set music volume independently of SFX.
+   * @param {number} v  0 (silent) – 1 (full)
+   */
+  setMusicVolume(v) {
+    this._volume = Math.max(0, Math.min(1, v));
+    this._persist();
+
+    // Apply immediately to whatever is currently playing.
+    if (this._activeLoop === 'menu' && this._menuId !== null) {
+      this._menu.volume(this._volume, this._menuId);
+    } else if (this._activeLoop === 'combat' && this._combatId !== null) {
+      this._combat.volume(this._volume, this._combatId);
+    }
+
+    this._victory.volume(this._volume);
+    this._defeat.volume(this._volume);
+  }
+
+  /** @returns {number} Current music volume [0-1]. */
+  getMusicVolume() {
+    return this._volume;
+  }
+
+  // ─── Track control ───────────────────────────────────────────────────────
+
+  /**
+   * Crossfade to the menu loop.
+   * Safe to call when menu is already playing (no-op).
+   */
+  playMenu() {
+    if (this._activeLoop === 'menu') return;
+    this._fadeOutActive();
+    this._activeLoop = 'menu';
+    this._menuId     = this._menu.play();
+    this._menu.fade(0, this._volume, FADE_MS, this._menuId);
+  }
+
+  /**
+   * Crossfade to the combat loop.
+   * Safe to call when combat is already playing (no-op).
+   */
+  playCombat() {
+    if (this._activeLoop === 'combat') return;
+    this._fadeOutActive();
+    this._activeLoop = 'combat';
+    this._combatId   = this._combat.play();
+    this._combat.fade(0, this._volume, FADE_MS, this._combatId);
+  }
+
+  /**
+   * Stop all loops and play the victory sting once.
+   * Loop restarts can be triggered by the caller after the sting ends.
+   */
+  playVictory() {
+    this._fadeOutActive(300);
+    this._victory.volume(this._volume);
+    this._victory.play();
+  }
+
+  /**
+   * Stop all loops and play the defeat sting once.
+   */
+  playDefeat() {
+    this._fadeOutActive(300);
+    this._defeat.volume(this._volume);
+    this._defeat.play();
+  }
+
+  /**
+   * Fade out and stop all music.
+   * @param {number} [fadeDuration=FADE_MS]  fade time in ms
+   */
+  stopAll(fadeDuration = FADE_MS) {
+    this._fadeOutActive(fadeDuration);
+    this._victory.stop();
+    this._defeat.stop();
+  }
+
+  // ─── Dispose ─────────────────────────────────────────────────────────────
+
+  /** Release all Howl instances. */
+  dispose() {
+    this._menu.unload();
+    this._combat.unload();
+    this._victory.unload();
+    this._defeat.unload();
+  }
+
+  // ─── Private helpers ─────────────────────────────────────────────────────
+
+  /**
+   * Fade out whichever loop is currently active.
+   * @param {number} [ms=FADE_MS]
+   * @private
+   */
+  _fadeOutActive(ms = FADE_MS) {
+    if (this._activeLoop === 'menu' && this._menuId !== null) {
+      const id = this._menuId;
+      this._menu.fade(this._menu.volume(id), 0, ms, id);
+      setTimeout(() => this._menu.stop(id), ms + 50);
+      this._menuId = null;
+    } else if (this._activeLoop === 'combat' && this._combatId !== null) {
+      const id = this._combatId;
+      this._combat.fade(this._combat.volume(id), 0, ms, id);
+      setTimeout(() => this._combat.stop(id), ms + 50);
+      this._combatId = null;
+    }
+    this._activeLoop = null;
+  }
+
+  /**
+   * Load saved music volume from localStorage.  Defaults to 0.4.
+   * @returns {number}
+   * @private
+   */
+  _loadVolume() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw !== null) {
+        const v = parseFloat(raw);
+        if (!isNaN(v)) return Math.max(0, Math.min(1, v));
+      }
+    } catch (_) {
+      // localStorage unavailable (private browsing, etc.)
+    }
+    return 0.4;
+  }
+
+  /**
+   * Persist current music volume to localStorage.
+   * @private
+   */
+  _persist() {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(this._volume));
+    } catch (_) {
+      // ignore quota errors
+    }
+  }
+}

--- a/src/systems/SoundSystem.js
+++ b/src/systems/SoundSystem.js
@@ -1,0 +1,342 @@
+/**
+ * SoundSystem — Howler.js-based audio manager for GUNZ.
+ *
+ * All audio data is synthesised procedurally at module load time and
+ * encoded as WAV data URLs, so no external audio files are required.
+ * Howler.js handles cross-browser audio context management, looping,
+ * rate/volume control, and the user-gesture unlock flow automatically.
+ *
+ * Sounds
+ * ──────
+ *   cannon    — low-frequency thud + crack (tank fire)
+ *   explosion — rumble + noise decay (tank destroyed / heavy blast)
+ *   impact    — sharp thud (shell hit, non-lethal)
+ *   engine    — loopable low-frequency rumble (player tank movement)
+ *   uiClick   — short sine-click (UI buttons)
+ *
+ * Public API
+ * ──────────
+ *   playShot()            — cannon fire (player or AI)
+ *   playExplosion()       — tank destroyed / large blast
+ *   playImpact()          — shell impact, non-lethal
+ *   startEngine()         — begin looping engine sound
+ *   stopEngine()          — fade out engine sound
+ *   setEngineRate(0-1)    — vary pitch by throttle (0 = idle, 1 = full)
+ *   playUIClick()         — short UI click
+ *   setMasterVolume(0-1)  — global volume (default 0.6)
+ *   update(dt)            — drain per-frame timers (call once per frame)
+ *   dispose()             — stop all sounds and release AudioContext
+ */
+
+import { Howl, Howler } from 'howler';
+
+// ─── WAV synthesis helpers ───────────────────────────────────────────────────
+
+/** Sample rate for all synthesised sounds (16 kHz — good enough for SFX). */
+const SR = 16_000;
+
+/**
+ * Fast linear-congruential PRNG so synthesised noise is deterministic across
+ * reloads and doesn't steal entropy from Math.random().
+ */
+let _seed = 0x9e3779b9;
+function _rand() {
+  _seed = (Math.imul(1_664_525, _seed) + 1_013_904_223) >>> 0;
+  return (_seed / 0xffff_ffff) * 2 - 1; // returns [-1, 1)
+}
+
+/**
+ * Build a 16-bit mono WAV data URL.
+ *
+ * @param {number}              duration  seconds
+ * @param {(t: number) => number} fn      sample render — must return values in [-1, 1]
+ * @returns {string}  "data:audio/wav;base64,…"
+ */
+function _makeWavUrl(duration, fn) {
+  const n   = Math.ceil(SR * duration);
+  const pcm = new Int16Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const t    = i / SR;
+    const s    = fn(t);
+    pcm[i]     = Math.round(Math.max(-1, Math.min(1, s)) * 32_767);
+  }
+
+  // 44-byte RIFF/WAV header + PCM data
+  const buf = new ArrayBuffer(44 + n * 2);
+  const dv  = new DataView(buf);
+
+  const wr = (offset, str) => {
+    for (let k = 0; k < str.length; k++) dv.setUint8(offset + k, str.charCodeAt(k));
+  };
+
+  wr(0,  'RIFF');
+  dv.setUint32(4,  36 + n * 2, true); // file size - 8
+  wr(8,  'WAVE');
+  wr(12, 'fmt ');
+  dv.setUint32(16, 16,      true);    // chunk size
+  dv.setUint16(20,  1,      true);    // PCM = 1
+  dv.setUint16(22,  1,      true);    // mono
+  dv.setUint32(24, SR,      true);    // sample rate
+  dv.setUint32(28, SR * 2,  true);    // byte rate
+  dv.setUint16(32,  2,      true);    // block align
+  dv.setUint16(34, 16,      true);    // bits per sample
+  wr(36, 'data');
+  dv.setUint32(40, n * 2, true);
+
+  // Write PCM into the buffer after the header
+  const out = new Uint8Array(buf, 44);
+  for (let i = 0; i < n; i++) {
+    const v    = pcm[i];
+    out[i * 2]     = v & 0xff;
+    out[i * 2 + 1] = (v >> 8) & 0xff;
+  }
+
+  // base64-encode the full WAV file
+  const all = new Uint8Array(buf);
+  let bin = '';
+  for (const b of all) bin += String.fromCharCode(b);
+  return `data:audio/wav;base64,${btoa(bin)}`;
+}
+
+// ─── Synthesised sound data URLs ─────────────────────────────────────────────
+// Generated once at module load time. Generation is synchronous and takes
+// ~5-20 ms total — acceptable for a game startup sequence.
+
+/** Cannon fire: low-frequency thud, muzzle crack, decaying noise (0.55 s). */
+const _CANNON_URL = _makeWavUrl(0.55, (t) => {
+  const env   = Math.exp(-t * 14);
+  const thud  = Math.sin(2 * Math.PI * 85  * t) * env;
+  const crack = Math.sin(2 * Math.PI * 380 * t) * Math.exp(-t * 32) * 0.4;
+  const noise = _rand() * env * 0.45;
+  return (thud + crack + noise) * 0.75;
+});
+
+/** Explosion: rumble + broadband noise, 2-second decay. */
+const _EXPLOSION_URL = _makeWavUrl(2.0, (t) => {
+  const env    = Math.exp(-t * 2.2);
+  const rumble = Math.sin(2 * Math.PI * 42 * t) * env * 0.5;
+  const noise  = _rand() * env * 0.9;
+  const wobble = Math.sin(2 * Math.PI * 6  * t) * 0.08;
+  return (rumble + noise + wobble) * 0.9;
+});
+
+/** Shell impact (non-lethal): short metallic thud (0.3 s). */
+const _IMPACT_URL = _makeWavUrl(0.3, (t) => {
+  const env  = Math.exp(-t * 18);
+  const thud = Math.sin(2 * Math.PI * 130 * t) * env * 0.7;
+  const hiss = _rand() * env * 0.35;
+  return (thud + hiss) * 0.8;
+});
+
+/**
+ * Engine loop: three harmonics of 68 Hz + gentle noise.
+ * Exactly 1 second — Howler.js loops it seamlessly.
+ */
+const _ENGINE_URL = _makeWavUrl(1.0, (t) => {
+  const f = 68;
+  return (
+    Math.sin(2 * Math.PI * f       * t) * 0.45 +
+    Math.sin(2 * Math.PI * f * 2   * t) * 0.20 +
+    Math.sin(2 * Math.PI * f * 3   * t) * 0.10 +
+    _rand() * 0.06
+  );
+});
+
+/** UI click: short 850 Hz sine burst (0.12 s). */
+const _UI_CLICK_URL = _makeWavUrl(0.12, (t) => {
+  const env = Math.exp(-t * 45);
+  return Math.sin(2 * Math.PI * 850 * t) * env * 0.65;
+});
+
+// ─── SoundSystem class ───────────────────────────────────────────────────────
+
+export class SoundSystem {
+  constructor() {
+    /** Master enable flag — set false to silence all sounds without teardown. */
+    this.enabled = true;
+
+    /**
+     * Per-frame shot cooldown (seconds). Prevents rapid cannon stacking when
+     * multiple shots fire in close succession (e.g., shotgun pellets).
+     */
+    this._shotCooldown = 0;
+
+    // Set global master volume before creating any Howl instances.
+    Howler.volume(0.6);
+
+    this._shot = new Howl({
+      src:     [_CANNON_URL],
+      volume:  0.9,
+      preload: true,
+    });
+
+    this._explosion = new Howl({
+      src:     [_EXPLOSION_URL],
+      volume:  1.0,
+      preload: true,
+    });
+
+    this._impact = new Howl({
+      src:     [_IMPACT_URL],
+      volume:  0.55,
+      preload: true,
+    });
+
+    this._engine = new Howl({
+      src:     [_ENGINE_URL],
+      loop:    true,
+      volume:  0,     // silent until startEngine() fades it in
+      preload: true,
+    });
+
+    this._uiClick = new Howl({
+      src:     [_UI_CLICK_URL],
+      volume:  0.5,
+      preload: true,
+    });
+
+    /** Active Howl sound ID for the looping engine track. */
+    this._engineId      = null;
+    this._engineRunning = false;
+  }
+
+  // ─── Per-frame update ───────────────────────────────────────────────────
+
+  /**
+   * Drain per-frame timers.  Call once per game frame with the frame delta.
+   * @param {number} dt  seconds since last frame
+   */
+  update(dt) {
+    if (this._shotCooldown > 0) this._shotCooldown -= dt;
+  }
+
+  // ─── Cannon fire ────────────────────────────────────────────────────────
+
+  /**
+   * Play cannon fire sound.
+   * Rate-limited to 80 ms minimum gap so simultaneous multi-projectile weapons
+   * (e.g., shotgun) produce one crisp shot rather than a wall of noise.
+   */
+  playShot() {
+    if (!this.enabled)           return;
+    if (this._shotCooldown > 0)  return;
+    this._shotCooldown = 0.08;
+    this._shot.play();
+  }
+
+  // ─── Explosion ──────────────────────────────────────────────────────────
+
+  /** Play explosion sound — tank destroyed or large explosive blast. */
+  playExplosion() {
+    if (!this.enabled) return;
+    this._explosion.play();
+  }
+
+  // ─── Impact ─────────────────────────────────────────────────────────────
+
+  /**
+   * Play shell-impact sound (non-lethal hit).
+   * Only one concurrent impact plays at a time to avoid stacking when many
+   * shells land simultaneously.
+   */
+  playImpact() {
+    if (!this.enabled)             return;
+    if (this._impact.playing())    return; // deduplicate concurrent hits
+    this._impact.play();
+  }
+
+  // ─── Engine loop ────────────────────────────────────────────────────────
+
+  /**
+   * Begin the looping engine sound with a 400 ms fade-in.
+   * Safe to call when the engine is already running — subsequent calls are
+   * ignored.
+   */
+  startEngine() {
+    if (!this.enabled || this._engineRunning) return;
+    this._engineRunning = true;
+    this._engineId      = this._engine.play();
+    this._engine.fade(0, 0.35, 400, this._engineId);
+  }
+
+  /**
+   * Fade out and stop the engine sound over 300 ms.
+   * Safe to call when the engine is already stopped.
+   */
+  stopEngine() {
+    if (!this._engineRunning) return;
+    this._engineRunning = false;
+
+    // Capture ID so the delayed stop matches the current play-through.
+    const id = this._engineId;
+    this._engine.fade(this._engine.volume(id), 0, 300, id);
+
+    setTimeout(() => {
+      // Guard: don't stop if startEngine() was called again during the fade.
+      if (!this._engineRunning) this._engine.stop(id);
+    }, 350);
+  }
+
+  /**
+   * Adjust engine pitch to convey throttle / speed.
+   * @param {number} rate  0 = idle (low pitch), 1 = full throttle (high pitch)
+   */
+  setEngineRate(rate) {
+    if (!this._engineRunning || this._engineId === null) return;
+    const clamped = Math.max(0, Math.min(1, rate));
+    // Map 0-1 to playback rate 0.65-1.45 (just under an octave range).
+    this._engine.rate(0.65 + clamped * 0.80, this._engineId);
+  }
+
+  // ─── UI sounds ──────────────────────────────────────────────────────────
+
+  /** Play a short click for UI button interactions. */
+  playUIClick() {
+    if (!this.enabled) return;
+    this._uiClick.play();
+  }
+
+  /**
+   * Attach click-sound listeners to all current and future DOM buttons.
+   * Useful when the SoundSystem is not directly passed to each UI class.
+   *
+   * Listening on `document` with `{ capture: true }` ensures the click is
+   * heard even if a child handler calls stopPropagation().
+   */
+  bindUIClicks() {
+    this._uiClickHandler = (e) => {
+      const el = e.target;
+      if (
+        el instanceof HTMLButtonElement ||
+        el.classList.contains('shop-tab') ||
+        el.classList.contains('loadout-option') ||
+        el.classList.contains('upgrade-btn')
+      ) {
+        this.playUIClick();
+      }
+    };
+    document.addEventListener('click', this._uiClickHandler, { capture: true });
+  }
+
+  // ─── Master volume ──────────────────────────────────────────────────────
+
+  /**
+   * Set global master volume.
+   * @param {number} v  0 (silent) – 1 (full volume)
+   */
+  setMasterVolume(v) {
+    Howler.volume(Math.max(0, Math.min(1, v)));
+  }
+
+  // ─── Dispose ────────────────────────────────────────────────────────────
+
+  /** Stop all sounds and release the Howler audio context. */
+  dispose() {
+    if (this._uiClickHandler) {
+      document.removeEventListener('click', this._uiClickHandler, { capture: true });
+    }
+    this._engine.stop();
+    Howler.unload();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `MusicSystem` (`src/systems/MusicSystem.js`) with four procedurally-synthesised WAV tracks — no external audio files
- Adds `SoundSystem` (`src/systems/SoundSystem.js`) — Howler.js SFX engine (t056 foundation; PR #121 was closed without merging)
- Wires both systems into `Game.js`, `AIController.js`, and `main.js`

## Music tracks (MusicSystem)

| Track | Type | Duration | Trigger |
|-------|------|----------|---------|
| Menu | Loop | 8 s | LoadoutScreen / Shop open |
| Combat | Loop | 8 s | Match starts (Deploy button) |
| Victory | One-shot | 3 s | Player team wins match |
| Defeat | One-shot | 3.5 s | Enemy team wins match |

Tracks crossfade over 800 ms via Howler.js `fade()`.  Music volume is independent from SFX and persisted to `localStorage` (`gunz_music_volume`).

## SFX (SoundSystem — t056 foundation)

| Sound | Trigger |
|-------|---------|
| Cannon fire | Player fires; AI tanks fire via `AIController.onShot()` |
| Explosion | Tank destroyed / explosive splash / lethal melee |
| Shell impact | Non-lethal hit / non-lethal melee |
| Engine loop | Looping while player tank moves; fades in/out |
| UI click | DOM button clicks (global listener) |

## Changes

- **NEW**: `src/systems/MusicSystem.js` — four synthesised tracks + `setMusicVolume()`
- **NEW**: `src/systems/SoundSystem.js` — Howler.js SFX wrapper with WAV synthesis
- **EDIT**: `src/core/Game.js` — import and wire both systems; music state transitions at loadout/combat/match-end; SFX on collision, melee, and player fire
- **EDIT**: `src/systems/AIController.js` — add `onShot(fn)` callback for AI cannon sounds
- **EDIT**: `src/main.js` — music volume slider widget wired to `MusicSystem`
- **EDIT**: `index.html` — volume control CSS + HTML (bottom-right ♩ button + popup range slider)
- **EDIT**: `package.json` + `package-lock.json` — add `howler ^2.2.4`

## Verification

```bash
npm run build   # exits 0, no module errors (verified locally)
```

Audio plays in-browser after any user gesture (standard Web Audio policy).  Volume control appears bottom-right; click ♩ to expand the slider.

Resolves #73