### PR TITLE
t039: Flame Tank weapon — continuous cone damage + fire particles

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -29,6 +29,7 @@ import { LeagueDisplay } from '../ui/LeagueDisplay.js';
 import { getLeagueDef } from '../data/LeagueDefs.js';
 import { MapLayout } from '../systems/MapLayout.js';
 import { TankAbilityEffects } from '../systems/TankAbilityEffects.js';
+import { FlameSystem } from '../systems/FlameSystem.js';
 import { getTankDef } from '../data/TankDefs.js';
 import { GunDefs, MeleeDefs } from '../data/WeaponDefs.js';
 import { Projectile } from '../entities/Projectile.js';
@@ -277,6 +278,7 @@ export class Game {
         // Clear mid-round objects between rounds.
         this.projectiles.reset();
         this.particles.reset();
+        this.flameSystem.reset();
         this.wrecks.reset();
         // Respawn the destructible tree set so the field is full again next round.
         this.trees.reset();
@@ -378,6 +380,11 @@ export class Game {
       projectileSystem: this.projectiles,
     });
 
+    // FlameSystem (t039): continuous cone damage + fire particles for Flame Tanks.
+    // Processes all flame tanks (player and AI) each frame; returns damage events
+    // that Game.js resolves into kills, kill-feed messages, and stats.
+    this.flameSystem = new FlameSystem();
+
     // AbilityBar (t045): two SVG radial-cooldown icons, bottom-centre HUD.
     // Reads state from this.abilitySystem each frame via AbilitySystem getters.
     this.abilityBar = new AbilityBar();
@@ -467,6 +474,11 @@ export class Game {
 
       // AIController: drives all ally (team 0, slots 1-5) and enemy AI tanks
       this.aiController.update(dt);
+
+      // FlameSystem (t039): apply continuous cone damage + fire particles for
+      // all active flame tanks (player and AI).  Must run AFTER aiController.update
+      // (which sets tank.flameActive) and AFTER _updatePlayer (same reason).
+      this._updateFlamethrowers(dt);
 
       // AI soldier behavior (t028): bailed enemy crew advance, take cover, shoot
       const playerSoldier = this.playerController.mode === 'soldier'
@@ -641,6 +653,122 @@ export class Game {
     if (this._playerDustTimer <= 0 && isMoving) {
       this._playerDustTimer = 0.15;
       this.particles.emitDust(this.playerController.mesh.position);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flame Tank system (t039)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Process continuous cone damage for all active flame tanks.
+   *
+   * Builds a flamer list from every living flameTank across both teams, then
+   * delegates to FlameSystem.update() which handles cone geometry, tick timing,
+   * particle emission, and damage application.  The returned damage events are
+   * processed here for kill-feed messages, stats, wreck spawning, and score.
+   *
+   * Enemy flame tanks can also damage the player tank; player death detection
+   * mirrors the projectile path in CollisionSystem.
+   *
+   * @param {number} dt
+   * @private
+   */
+  _updateFlamethrowers(dt) {
+    const flamers = [];
+
+    // Collect all living flame tanks with their target lists.
+    for (const tank of this.teams.getAllLivingTanks()) {
+      if (!tank.isFlamethrower) continue;
+
+      let targets;
+      let isPlayerOwned;
+
+      if (tank.teamId === 0) {
+        // Player team flame tanks (player or ally AI) → target enemy tanks.
+        targets = this.teams.getEnemyTanks().filter(t => t.health > 0);
+        isPlayerOwned = true;
+      } else {
+        // Enemy flame tanks → target player tank (+ living ally tanks).
+        const allyTanks = this.teams.getAllyTanks().filter(t => t.health > 0);
+        const playerAlive = this.player.health > 0;
+        targets = playerAlive ? [this.player, ...allyTanks] : allyTanks;
+        isPlayerOwned = false;
+      }
+
+      flamers.push({ tank, targets, isPlayerOwned });
+    }
+
+    if (flamers.length === 0) return;
+
+    const events = this.flameSystem.update(dt, flamers, this.particles);
+
+    // Process each damage event: stats, kills, kill feed.
+    for (const { tank, target, damage, isPlayerOwned } of events) {
+      // Stat tracking for player-originated damage.
+      if (isPlayerOwned) {
+        this.stats.recordPlayerDamage(target, damage);
+      }
+
+      if (target.health > 0) {
+        // Non-lethal hit: small flame impact burst.
+        this.particles.emitExplosion(target.mesh.position.clone(),
+          { count: 6, speed: 4, lifetime: 0.35 });
+        continue;
+      }
+
+      // ── Target killed by flame ────────────────────────────────────────────
+      const killPos = target.mesh.position.clone();
+      const killerName = (tank === this.player || isPlayerOwned)
+        ? (tank.name || 'Player')
+        : (tank.name || 'Enemy');
+
+      if (target === this.player) {
+        // Enemy flame tank killed the player tank.
+        // Guard: player slot may already be dead if another event this frame
+        // already triggered _onPlayerTankDestroyed().
+        const playerSlotAlive = this.teams.teams[0].slots[0].alive;
+        if (!playerSlotAlive) continue;
+
+        tank.recordKill();
+        this.killFeed.addMessage(killerName, this.player.name || 'Player');
+        // _onPlayerTankDestroyed() handles mesh removal, wreck spawn, and
+        // bail-out logic — do not duplicate those steps here.
+        this._onPlayerTankDestroyed();
+      } else {
+        // Player/ally flame tank killed an enemy tank — or an enemy flame
+        // tank killed an ally AI tank.
+        // Guard: another event in the same batch may have already killed this tank.
+        if (!this.teams.teams[target.teamId]?.slots.find(
+          s => s.tank === target && s.alive
+        )) continue;
+
+        const byPlayer = isPlayerOwned;
+        if (byPlayer) {
+          tank.recordKill();
+          this.score += 100;
+        }
+
+        const tankData = {
+          position: killPos.clone(),
+          rotationY: target.mesh.rotation.y,
+        };
+
+        const victimName = target.name || 'Enemy';
+        this.killFeed.addMessage(killerName, victimName);
+
+        if (byPlayer) {
+          this.stats.recordTankKilled(target, true);
+        }
+
+        // Bail crew before killTank() removes the slot.
+        this._bailAITankAsSoldier(killPos, target.mesh.rotation.y, target.teamId);
+
+        this.teams.killTank(target);
+
+        this.particles.emitExplosion(killPos, { count: 35, speed: 10 });
+        this.wrecks.add(tankData.position, tankData.rotationY);
+      }
     }
   }
 

--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -334,7 +334,12 @@ export class PlayerController {
     }
 
     const newProjectiles = [];
-    if (input.fire && tank.canFire()) {
+
+    if (tank.isFlamethrower) {
+      // Flame Tank: set the continuous-fire flag; FlameSystem (via Game.js)
+      // handles damage ticks and particle emission.  No discrete projectile.
+      tank.flameActive = !!(input.fire);
+    } else if (input.fire && tank.canFire()) {
       const proj = tank.fire();
       if (proj) newProjectiles.push(proj);
     }

--- a/src/entities/Tank.js
+++ b/src/entities/Tank.js
@@ -163,6 +163,15 @@ export class Tank {
     this.shielded = false;
 
     /**
+     * Flamethrower active: true while the player is holding the fire button
+     * (or an AI flame tank is in fire range).  Checked each frame by
+     * FlameSystem to emit fire particles and apply cone damage.
+     * Only meaningful when tankClassId === 'flameTank'.
+     * @type {boolean}
+     */
+    this.flameActive = false;
+
+    /**
      * Rocket Jump: while true, PlayerController and AIController skip terrain-
      * follow so TankAbilityEffects can drive the Y coordinate along the arc.
      * @type {boolean}
@@ -536,6 +545,16 @@ export class Tank {
   // Combat
   // ---------------------------------------------------------------------------
 
+  /**
+   * True when this tank is a Flame Tank (uses continuous cone damage instead
+   * of discrete projectiles).  Checked by PlayerController and AIController
+   * to suppress the normal fire() call in favour of FlameSystem.
+   * @returns {boolean}
+   */
+  get isFlamethrower() {
+    return this.tankClassId === 'flameTank';
+  }
+
   setTurretAngle(angle) {
     if (this.turret) {
       this.turret.rotation.y = angle - this.mesh.rotation.y;
@@ -638,6 +657,7 @@ export class Tank {
     // TankAbilityEffects.reset() cancels any in-flight timed effects before
     // Tank.reset() runs, so it is safe to zero these flags here.
     this.shielded             = false;
+    this.flameActive          = false;
     this.isJumping            = false;
     this.isLockedDown         = false;
     this.reactiveArmorCharges = 0;

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -689,15 +689,29 @@ export class AIController {
 
     // --- Fire when in range and reaction time has elapsed ---
     const reacted = reactionTimer >= reactionTime;
-    if (dist < fireRange && tank.canFire() && reacted) {
-      const projectile = tank.fire();
-      if (projectile) {
-        this.projectiles.add(projectile);
-        const flashDir = projectile.velocity.clone().normalize();
-        this.particles.emitMuzzleFlash(
-          projectile.mesh.position.clone(),
-          flashDir
-        );
+    if (dist < fireRange && reacted) {
+      if (tank.isFlamethrower) {
+        // Flame Tank: enable continuous cone damage via FlameSystem.
+        // The turret already faces the target (aim step above), so the
+        // muzzle forward direction used by FlameSystem will naturally sweep
+        // the enemy.  No discrete projectile is created.
+        tank.flameActive = true;
+      } else if (tank.canFire()) {
+        tank.flameActive = false;
+        const projectile = tank.fire();
+        if (projectile) {
+          this.projectiles.add(projectile);
+          const flashDir = projectile.velocity.clone().normalize();
+          this.particles.emitMuzzleFlash(
+            projectile.mesh.position.clone(),
+            flashDir
+          );
+        }
+      }
+    } else {
+      // Out of fire range — stop flaming.
+      if (tank.isFlamethrower) {
+        tank.flameActive = false;
       }
     }
   }

--- a/src/systems/FlameSystem.js
+++ b/src/systems/FlameSystem.js
@@ -1,0 +1,214 @@
+/**
+ * FlameSystem — continuous cone damage + fire particle management for the Flame Tank.
+ *
+ * The Flame Tank does NOT fire discrete projectiles.  Instead, while
+ * `tank.flameActive` is true the system:
+ *   1. Emits fire particles every PARTICLE_INTERVAL seconds (visual stream).
+ *   2. Applies tick damage every TICK_INTERVAL seconds to every living target
+ *      inside the flame cone.
+ *
+ * Cone geometry:
+ *   Half-angle : FLAME_CONE_HALF_ANGLE_RAD  (30° — wide enough to engulf groups)
+ *   Range      : FLAME_RANGE (20 world-units — matches TankDefs.flameTank.range)
+ *
+ * Damage cadence (mirrors TankDefs.flameTank):
+ *   FLAME_DAMAGE_PER_TICK = 18   (per-hit damage)
+ *   FLAME_TICKS_PER_SEC   = 10   (continuous fireRate)
+ *   → 180 HP/s sustained against a target with no armor at point-blank
+ *
+ * Collision detection: XZ-plane dot-product against the muzzle's world forward
+ * vector.  Y-difference is ignored (terrain slope negligible at 20-unit range).
+ *
+ * Usage (Game.js):
+ *   const flameSystem = new FlameSystem();
+ *   // Inside game loop (each frame, while round is active):
+ *   const events = flameSystem.update(dt, flamers, this.particles);
+ *   // `events` is an array of { tank, target, damage, isPlayerOwned }
+ *   // — process kills and stats from these events in Game.js.
+ *   // On round reset:
+ *   flameSystem.reset();
+ *
+ * Flamer entries (passed by Game.js):
+ *   { tank: Tank, targets: Tank[], isPlayerOwned: boolean }
+ *   Only entries where `tank.flameActive === true` are processed.
+ */
+
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Constants (mirror TankDefs.flameTank where applicable)
+// ---------------------------------------------------------------------------
+
+/** Half-angle of the flame cone in radians (~30°). */
+const FLAME_CONE_HALF_ANGLE_RAD = Math.PI / 6;
+
+/** Cosine of the half-angle — used for dot-product cone check. */
+const FLAME_CONE_COS = Math.cos(FLAME_CONE_HALF_ANGLE_RAD);
+
+/** Maximum range of the flamethrower in world units. */
+const FLAME_RANGE = 20;
+
+/** Damage applied to each target inside the cone per tick. */
+const FLAME_DAMAGE_PER_TICK = 18;
+
+/** Ticks per second (continuous fire rate from TankDefs.flameTank.fireRate). */
+const FLAME_TICKS_PER_SEC = 10;
+
+/** Seconds between damage ticks. */
+const FLAME_TICK_INTERVAL = 1 / FLAME_TICKS_PER_SEC;
+
+/** Flame particles emitted per second per active flame tank. */
+const FLAME_PARTICLES_PER_SEC = 55;
+
+/** Seconds between particle emissions. */
+const FLAME_PARTICLE_INTERVAL = 1 / FLAME_PARTICLES_PER_SEC;
+
+// ---------------------------------------------------------------------------
+// FlameSystem
+// ---------------------------------------------------------------------------
+
+export class FlameSystem {
+  constructor() {
+    /**
+     * Per-tank timing state.
+     * Key: Tank instance.
+     * Value: { tickTimer: number, particleTimer: number }
+     * @type {Map<object, {tickTimer: number, particleTimer: number}>}
+     */
+    this._timers = new Map();
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * Advance all active flame tanks by dt seconds.
+   *
+   * @param {number} dt — seconds since last frame
+   * @param {Array<{tank: object, targets: object[], isPlayerOwned: boolean}>} flamers
+   *   Each entry describes one potential flame tank.  Only tanks with
+   *   `tank.flameActive === true` are processed.  Targets must be an array of
+   *   Tank instances (health > 0 check is done internally per tick).
+   * @param {import('./ParticleSystem.js').ParticleSystem} particles
+   *   Used for fire particle emission.
+   * @returns {Array<{tank: object, target: object, damage: number, isPlayerOwned: boolean}>}
+   *   Damage events produced this frame.  Each event represents one tick hit on
+   *   one target.  Game.js uses these to update stats, process kills, and emit
+   *   kill-feed messages.
+   */
+  update(dt, flamers, particles) {
+    const events = [];
+
+    for (const { tank, targets, isPlayerOwned } of flamers) {
+      if (!tank.flameActive) continue;
+
+      const timers = this._getTimers(tank);
+
+      // Compute world-space fire direction from the muzzle Object3D.
+      // muzzle's local -Z is the barrel forward; getWorldDirection gives world -Z.
+      const fireDir = new THREE.Vector3();
+      tank.muzzle.getWorldDirection(fireDir);
+
+      const muzzlePos = new THREE.Vector3();
+      tank.muzzle.getWorldPosition(muzzlePos);
+
+      // ── Particle emission ──────────────────────────────────────────────────
+      timers.particleTimer += dt;
+      while (timers.particleTimer >= FLAME_PARTICLE_INTERVAL) {
+        timers.particleTimer -= FLAME_PARTICLE_INTERVAL;
+        particles.emitFlame(muzzlePos.clone(), fireDir.clone());
+      }
+
+      // ── Damage ticks ───────────────────────────────────────────────────────
+      timers.tickTimer += dt;
+      while (timers.tickTimer >= FLAME_TICK_INTERVAL) {
+        timers.tickTimer -= FLAME_TICK_INTERVAL;
+        this._applyTickDamage(tank, targets, fireDir, isPlayerOwned, events);
+      }
+    }
+
+    return events;
+  }
+
+  /**
+   * Reset per-tank timers between rounds.
+   * Call this whenever the round resets so timers don't carry over.
+   */
+  reset() {
+    this._timers.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Get (or lazily create) the per-tank timer state.
+   * @private
+   * @param {object} tank
+   * @returns {{tickTimer: number, particleTimer: number}}
+   */
+  _getTimers(tank) {
+    if (!this._timers.has(tank)) {
+      this._timers.set(tank, { tickTimer: 0, particleTimer: 0 });
+    }
+    return this._timers.get(tank);
+  }
+
+  /**
+   * Apply one damage tick to every target inside the flame cone.
+   *
+   * Cone test (XZ plane):
+   *   Flatten both the fire direction and the to-target vector to Y=0, then
+   *   dot-product.  If the result is ≥ FLAME_CONE_COS the target is inside
+   *   the 30° half-angle cone.  Range is checked separately with a 3D distance
+   *   so targets on higher terrain edges are still reachable.
+   *
+   * @private
+   * @param {object} tank
+   * @param {object[]} targets
+   * @param {THREE.Vector3} fireDir — normalised world-space forward
+   * @param {boolean} isPlayerOwned
+   * @param {Array} events — mutable array to push damage events into
+   */
+  _applyTickDamage(tank, targets, fireDir, isPlayerOwned, events) {
+    const tankPos = tank.mesh.position;
+
+    // Flatten fire direction to XZ so terrain height doesn't bias the cone.
+    const flatFire = new THREE.Vector3(fireDir.x, 0, fireDir.z).normalize();
+
+    for (const target of targets) {
+      if (target.health <= 0) continue;
+
+      // Range check (3D distance)
+      const dist = tankPos.distanceTo(target.mesh.position);
+      if (dist > FLAME_RANGE) continue;
+
+      // Cone check (XZ plane)
+      const toTarget = new THREE.Vector3(
+        target.mesh.position.x - tankPos.x,
+        0,
+        target.mesh.position.z - tankPos.z
+      );
+
+      // If the tank is right on top of the target, treat it as in-cone.
+      const toTargetLen = toTarget.length();
+      if (toTargetLen > 0.05) {
+        toTarget.divideScalar(toTargetLen);
+        if (flatFire.dot(toTarget) < FLAME_CONE_COS) continue; // outside cone
+      }
+
+      // Apply damage (scale by owning tank's damage multiplier)
+      const rawDamage = FLAME_DAMAGE_PER_TICK * (tank.damageMultiplier || 1);
+      const actualDamage = target.takeDamage(rawDamage);
+
+      // Record damage on the owning tank for kill-credit and stats.
+      if (typeof tank.recordDamage === 'function') {
+        tank.recordDamage(actualDamage);
+      }
+
+      events.push({ tank, target, damage: actualDamage, isPlayerOwned });
+    }
+  }
+}

--- a/src/systems/ParticleSystem.js
+++ b/src/systems/ParticleSystem.js
@@ -228,6 +228,56 @@ export class ParticleSystem {
   }
 
   /**
+   * Emit continuous fire/smoke particles for the flame tank's flamethrower.
+   *
+   * Called once per particle-emit interval while the flame tank is firing.
+   * Streams fire forward with a 30° cone spread; particles fade from bright
+   * orange/yellow to dark smoke and rise slightly (gravity = -1).
+   *
+   * @param {THREE.Vector3} position  World-space muzzle tip.
+   * @param {THREE.Vector3} direction Normalised fire direction (turret forward).
+   */
+  emitFlame(position, direction) {
+    const p = this._acquire();
+    if (!p) return;
+
+    // Stream forward with random cone spread
+    const spread = 0.40;
+    const speed = 10 + Math.random() * 8;
+
+    p.velocity.set(
+      direction.x + (Math.random() - 0.5) * spread,
+      direction.y + (Math.random() - 0.5) * spread * 0.4 + 0.20, // slight upward bias
+      direction.z + (Math.random() - 0.5) * spread
+    ).normalize().multiplyScalar(speed);
+
+    p.position.copy(position);
+    p.life = 0.18 + Math.random() * 0.18;
+    p.maxLife = p.life;
+
+    // Fire palette: orange/yellow core → dark smoke on death
+    const r = Math.random();
+    if (r < 0.45) {
+      p.colorStart.setHex(0xff5500); // orange-red
+      p.colorEnd.setHex(0x220800);
+    } else if (r < 0.78) {
+      p.colorStart.setHex(0xff9900); // bright orange
+      p.colorEnd.setHex(0x331100);
+    } else {
+      p.colorStart.setHex(0xffee00); // yellow core
+      p.colorEnd.setHex(0x443300);
+    }
+
+    p.startScale = 0.28 + Math.random() * 0.38;
+    p.gravity = -1.5; // fire rises
+
+    p.mesh.material.color.copy(p.colorStart);
+    p.mesh.material.opacity = 0.92;
+    p.mesh.scale.setScalar(p.startScale);
+    p.mesh.position.copy(position);
+  }
+
+  /**
    * Emit debris when a tree is destroyed by a shell.
    * Spawns two batches:
    *   - Wood splinters (dark brown) that tumble outward with gravity


### PR DESCRIPTION
## Summary

Implements the Flame Tank's flamethrower weapon per VISION.md spec (t039):
continuous cone damage at 18 HP/tick × 10 ticks/sec (180 DPS) within a 30° cone and 20-unit range, with streaming fire particle effects.

## Changes

**New file: `src/systems/FlameSystem.js`**
- Pool-based per-tank tick timers (10 ticks/sec damage, 55 particles/sec visual)
- Cone check: XZ-plane dot-product against muzzle forward direction; 30° half-angle
- Range check: 3D distance ≤ 20 units (matches TankDefs.flameTank.range)
- Returns damage events for Game.js to process (kills, stats, kill feed)

**`src/systems/ParticleSystem.js`** — `emitFlame()` method
- Orange/yellow/red particles rising with slight upward bias, 0.18–0.36 s lifetime
- Fades to dark smoke; gravity = -1.5 (rising fire effect)

**`src/entities/Tank.js`**
- `flameActive` flag (set by PlayerController / AIController, cleared on reset)
- `isFlamethrower` getter (true when tankClassId === 'flameTank')

**`src/core/PlayerController.js`**
- Flame tank input path: fire button sets `flameActive`, no projectile created

**`src/systems/AIController.js`**
- Flame tank AI: set `flameActive = true` when target in fireRange, false otherwise
- Normal AI tanks unchanged

**`src/core/Game.js`**
- FlameSystem created in `_initSystems()`; reset on round reset
- `_updateFlamethrowers(dt)` called each frame after AI update:
  - Builds flamer list (team-aware target lists)
  - Processes damage events: stats, kill feed, wrecks, score, player-death routing
  - Guards against double-kill events within same frame

## Verification

Tested in Node.js:
- `isFlamethrower` getter returns correct value per tank class
- `flameActive` cleared on `Tank.reset()`
- FlameSystem applies damage only when turret is aimed at target (cone check)
- Out-of-cone targets (behind tank) receive 0 damage
- Out-of-range targets (> 20 units) receive 0 damage
- ~10 damage ticks in 1 second at dt=0.01 (matches 10 ticks/sec spec)
- Armor reduction applied correctly (standard tank 10% armor)
- Pre-existing test suite: 0 new failures introduced

Resolves #55