### PR TITLE
t058: Visual polish — screen shake, damage flash, ghost health bar, better particles

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,14 +72,40 @@
       border-radius: 7px;
       overflow: hidden;
       border: 1px solid rgba(255,255,255,0.2);
+      position: relative; /* needed for ghost positioning (t058) */
+    }
+
+    /* Ghost health bar — lingers at the previous HP value, then fades. (t058) */
+    .health-bar-ghost {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      background: #ff9800;
+      border-radius: 7px;
+      transition: width 0.75s ease-out;
     }
 
     .health-bar-inner {
+      position: relative; /* sit on top of ghost bar (t058) */
+      z-index: 1;
       height: 100%;
       width: 100%;
       background: #4caf50;
       border-radius: 7px;
-      transition: width 0.3s, background-color 0.3s;
+      transition: width 0.18s ease-out, background-color 0.3s;
+    }
+
+    /* Full-screen damage flash overlay (t058) */
+    #damage-flash {
+      position: fixed;
+      inset: 0;
+      background: rgba(200, 0, 0, 0.45);
+      pointer-events: none;
+      z-index: 5;
+      opacity: 0;
+      transition: opacity 0.12s ease-out;
     }
 
     /* === Touch controls overlay === */
@@ -1731,11 +1757,16 @@
 <body>
   <canvas id="game-canvas"></canvas>
 
+  <!-- Full-screen damage flash (t058) — briefly tints red when player is hit -->
+  <div id="damage-flash"></div>
+
   <!-- HUD -->
   <div id="hud">
     <div class="hud-left">
       <span class="hud-label">Health</span>
       <div class="health-bar-outer">
+        <!-- Ghost bar lingers at old HP, then fades back (t058) -->
+        <div class="health-bar-ghost" id="health-ghost"></div>
         <div class="health-bar-inner" id="health-fill"></div>
       </div>
       <span class="hud-label">Ammo: <span class="hud-value" id="ammo">30</span></span>

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -192,15 +192,34 @@ export class Game {
     this.collision
       .onScoreAdd(pts => { this.score += pts; })
       .onPlayerDeath(() => this._onPlayerTankDestroyed())
-      .onHit((pos) => {
-        this.particles.emitExplosion(pos, { count: 15, speed: 6, lifetime: 0.6 });
+      .onHit((pos, owner) => {
+        if (owner === 'enemy') {
+          // Enemy shell struck the player tank (non-lethal, non-explosive). (t058)
+          // Use sharp metallic sparks instead of the heavier explosion burst.
+          this.particles.emitImpactSparks(pos);
+          // Screen shake + damage flash to signal the hit to the player. (t058)
+          this.cameraController.shake(1.4);
+          this.hud.flashDamage();
+        } else {
+          // Player shell struck an enemy, or shell hit a wreck/structure.
+          this.particles.emitExplosion(pos, { count: 15, speed: 6, lifetime: 0.6 });
+        }
         // Play impact sound for non-lethal shell hits (t056).
         this.sound.playImpact();
       })
       .onKill((pos, owner, tankData) => {
         this.particles.emitExplosion(pos, { count: 35, speed: 10 });
+        // Lingering smoke column on every tank kill. (t058)
+        this.particles.emitSmoke(pos, { count: 12, lifetime: 2.2 });
         // Play explosion sound whenever any tank is destroyed (t056).
         this.sound.playExplosion();
+        // Screen shake: heavier when the player's own tank is killed. (t058)
+        if (owner === 'enemy') {
+          this.cameraController.shake(3.5);
+        } else {
+          // Player killed an enemy tank — satisfying rumble.
+          this.cameraController.shake(0.9);
+        }
         // Leave a wreck at the tank's last position as indestructible cover
         if (tankData) {
           this.wrecks.add(tankData.position, tankData.rotationY);
@@ -236,8 +255,14 @@ export class Game {
         // Particle count scales with splash radius so bigger weapons feel bigger.
         const count = Math.round(25 + splashRadius * 3);
         this.particles.emitExplosion(pos, { count, speed: 10, lifetime: 1.0 });
+        // Lingering smoke makes bigger explosions look more impactful. (t058)
+        const smokeCount = Math.round(6 + splashRadius * 1.5);
+        this.particles.emitSmoke(pos, { count: smokeCount, lifetime: 1.8 });
         // Explosive rounds also play the explosion sound (t056).
         this.sound.playExplosion();
+        // Nearby explosions cause proportional screen shake. (t058)
+        const shakeAmp = Math.min(1.8, 0.2 + splashRadius * 0.12);
+        this.cameraController.shake(shakeAmp);
       })
       .onBuildingWallDestroyed((pos) => {
         // Medium debris burst when a wall panel is knocked down (t047/t048).
@@ -1111,8 +1136,15 @@ export class Game {
         this.particles.emitExplosion(hitPos, { count: 6, speed: 3, lifetime: 0.3 });
 
         if (soldier.health <= 0) {
+          // Player soldier killed — big shake + flash. (t058)
+          this.cameraController.shake(2.5);
+          this.hud.flashDamage();
           this._onPlayerSoldierDestroyed();
           break; // soldier removed; stop checking more projectiles this frame
+        } else {
+          // Non-lethal hit on player soldier. (t058)
+          this.cameraController.shake(0.9);
+          this.hud.flashDamage();
         }
       }
     }

--- a/src/systems/CameraController.js
+++ b/src/systems/CameraController.js
@@ -63,6 +63,15 @@ export class CameraController {
     this._currentPos = new THREE.Vector3();
     this._desiredPos = new THREE.Vector3();
     this._lookAt     = new THREE.Vector3();
+
+    /**
+     * Screen-shake: current amplitude in world units.
+     * Decays exponentially toward zero each frame.
+     * Call shake(amplitude) to trigger; larger values = more violent shake.
+     */
+    this._shakeAmp   = 0;
+    /** Decay rate constant — higher = faster decay. */
+    this._shakeDecay = 9;
   }
 
   // ---------------------------------------------------------------------------
@@ -75,6 +84,25 @@ export class CameraController {
    */
   setTarget(target) {
     this.target = target;
+  }
+
+  /**
+   * Trigger a screen-shake impulse.
+   *
+   * Multiple calls within the same frame are safe: the amplitude is clamped
+   * to the maximum of the existing and new values so that overlapping events
+   * don't stack beyond a sensible ceiling.
+   *
+   * Amplitude guide:
+   *   0.3 — distant explosion
+   *   0.8 — nearby enemy tank destroyed
+   *   1.5 — direct hit on player (non-lethal)
+   *   3.0 — player tank destroyed
+   *
+   * @param {number} amplitude  Peak displacement in world units (≥ 0).
+   */
+  shake(amplitude) {
+    this._shakeAmp = Math.max(this._shakeAmp, amplitude);
   }
 
   /**
@@ -109,6 +137,18 @@ export class CameraController {
     // Smooth follow of camera position.
     this._currentPos.lerp(this._desiredPos, 1 - Math.exp(-this.smoothing * dt));
     this.camera.position.copy(this._currentPos);
+
+    // ---- Screen shake (t058) ----
+    // Apply a random offset that decays exponentially toward zero.
+    if (this._shakeAmp > 0.005) {
+      this._shakeAmp *= Math.exp(-this._shakeDecay * dt);
+      const s = this._shakeAmp;
+      this.camera.position.x += (Math.random() - 0.5) * 2 * s;
+      this.camera.position.y += (Math.random() - 0.5) * s; // less vertical swing
+      this.camera.position.z += (Math.random() - 0.5) * 2 * s;
+    } else {
+      this._shakeAmp = 0;
+    }
 
     // Look-at point: slightly ahead of and at the height of the target.
     this._lookAt

--- a/src/systems/ParticleSystem.js
+++ b/src/systems/ParticleSystem.js
@@ -10,6 +10,8 @@
  *   emitExplosion(position, opts)   — burst of fire/smoke on tank/shell impact
  *   emitMuzzleFlash(position, dir)  — brief flash cone at barrel tip on fire
  *   emitDust(position)              — rising dirt puff behind moving tracks
+ *   emitImpactSparks(position)      — metallic white/blue sparks for non-lethal hits (t058)
+ *   emitSmoke(position, opts)       — slow-rising dark smoke plume post-explosion (t058)
  */
 
 import * as THREE from 'three';
@@ -18,7 +20,7 @@ import * as THREE from 'three';
 // Constants
 // ---------------------------------------------------------------------------
 
-const POOL_SIZE = 300;
+const POOL_SIZE = 500;
 
 // Shared geometry — all particles are scaled cubes.
 const _GEO = new THREE.BoxGeometry(0.25, 0.25, 0.25);
@@ -278,6 +280,107 @@ export class ParticleSystem {
   }
 
   /**
+   * Emit metallic impact sparks for a non-lethal shell hit. (t058)
+   *
+   * Small, fast white/blue particles that tumble outward with strong gravity,
+   * giving tank hits a crisp "ricochet spark" feel distinct from the heavier
+   * explosion burst used for kills.
+   *
+   * @param {THREE.Vector3} position  World-space hit point.
+   */
+  emitImpactSparks(position) {
+    const count = 14;
+    for (let i = 0; i < count; i++) {
+      const p = this._acquire();
+      if (!p) return;
+
+      const theta = Math.random() * Math.PI * 2;
+      const phi   = Math.random() * Math.PI * 0.55; // mostly outward-upward cone
+      const speed = 7 + Math.random() * 12;
+
+      p.velocity.set(
+        Math.sin(phi) * Math.cos(theta) * speed,
+        Math.abs(Math.cos(phi)) * speed * 0.5 + 0.5,
+        Math.sin(phi) * Math.sin(theta) * speed
+      );
+
+      p.position.copy(position);
+      p.life     = 0.12 + Math.random() * 0.16;
+      p.maxLife  = p.life;
+      p.gravity  = 14; // sparks fall fast
+
+      // White core → steel blue on fade
+      const r = Math.random();
+      if (r < 0.5) {
+        p.colorStart.setHex(0xffffff); // bright white
+        p.colorEnd.setHex(0x88aaff);   // cool blue
+      } else {
+        p.colorStart.setHex(0xffee88); // yellow-white
+        p.colorEnd.setHex(0xff8800);   // amber
+      }
+
+      p.startScale = 0.04 + Math.random() * 0.07;
+
+      p.mesh.material.color.copy(p.colorStart);
+      p.mesh.material.opacity = 1;
+      p.mesh.scale.setScalar(p.startScale);
+      p.mesh.position.copy(position);
+    }
+  }
+
+  /**
+   * Emit a slow-rising dark smoke plume after an explosion. (t058)
+   *
+   * Large, semi-transparent particles that drift upward and fade out,
+   * creating a lingering smoke column that makes kills look impactful.
+   *
+   * @param {THREE.Vector3} position  World-space explosion centre.
+   * @param {object}        [opts]
+   * @param {number}        [opts.count=10]      Particle count.
+   * @param {number}        [opts.lifetime=2.0]  Max smoke lifetime (s).
+   */
+  emitSmoke(position, opts = {}) {
+    const count    = opts.count    ?? 10;
+    const lifetime = opts.lifetime ?? 2.0;
+
+    for (let i = 0; i < count; i++) {
+      const p = this._acquire();
+      if (!p) return;
+
+      const angle = Math.random() * Math.PI * 2;
+      const radius = Math.random() * 1.5;
+
+      p.velocity.set(
+        Math.cos(angle) * radius * 0.5,
+        1.2 + Math.random() * 1.5, // rises slowly
+        Math.sin(angle) * radius * 0.5
+      );
+
+      p.position.set(
+        position.x + Math.cos(angle) * radius,
+        position.y + Math.random() * 0.5,
+        position.z + Math.sin(angle) * radius
+      );
+
+      p.life    = lifetime * (0.7 + Math.random() * 0.3);
+      p.maxLife = p.life;
+      p.gravity = -0.4; // slight upward drift (negative = rises)
+
+      // Dark charcoal smoke that fades to transparent
+      const shade = Math.floor(20 + Math.random() * 35);
+      p.colorStart.setRGB(shade / 255, shade / 255, shade / 255);
+      p.colorEnd.setRGB(shade / 255, shade / 255, shade / 255);
+
+      p.startScale = 0.8 + Math.random() * 1.2;
+
+      p.mesh.material.color.copy(p.colorStart);
+      p.mesh.material.opacity = 0.45;
+      p.mesh.scale.setScalar(p.startScale);
+      p.mesh.position.copy(p.position);
+    }
+  }
+
+  /**
    * Emit debris when a tree is destroyed by a shell.
    * Spawns two batches:
    *   - Wood splinters (dark brown) that tumble outward with gravity
@@ -383,10 +486,20 @@ export class ParticleSystem {
 
       // Interpolate colour and opacity
       p.mesh.material.color.lerpColors(p.colorStart, p.colorEnd, t);
-      p.mesh.material.opacity = 1 - t;
 
-      // Shrink toward zero
-      p.mesh.scale.setScalar(Math.max(0.001, p.startScale * (1 - t * 0.8)));
+      // Smoke particles (large scale, slow velocity) billow outward then fade;
+      // regular particles shrink toward zero.  Distinguish by startScale:
+      // smoke uses startScale > 0.5 and has near-zero gravity magnitude.
+      if (p.startScale >= 0.8 && Math.abs(p.gravity) <= 0.5) {
+        // Smoke: grow slightly as it rises, fade out over lifetime
+        const growFactor = 1 + t * 0.6;
+        p.mesh.scale.setScalar(Math.max(0.001, p.startScale * growFactor));
+        p.mesh.material.opacity = 0.45 * (1 - t);
+      } else {
+        p.mesh.material.opacity = 1 - t;
+        // Shrink toward zero
+        p.mesh.scale.setScalar(Math.max(0.001, p.startScale * (1 - t * 0.8)));
+      }
     }
   }
 

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -18,6 +18,16 @@ export class HUD {
     this.weaponSlotsEl  = document.getElementById('weapon-slots');
     this.slotGunEl      = document.getElementById('weapon-slot-gun');
     this.slotMeleeEl    = document.getElementById('weapon-slot-melee');
+
+    // Visual polish (t058): ghost health bar + damage flash
+    this.healthGhost  = document.getElementById('health-ghost');
+    this.damageFlashEl = document.getElementById('damage-flash');
+    /** Previous health percentage — used to detect HP drops for ghost bar. */
+    this._lastHealthPct = 100;
+    /** setTimeout handle for ghost bar decay delay. */
+    this._ghostTimer = null;
+    /** setTimeout handle for damage flash fade-out. */
+    this._flashTimer = null;
   }
 
   /**
@@ -48,15 +58,7 @@ export class HUD {
     this.ammoEl.textContent  = ammo ?? '∞';
 
     const pct = Math.max(0, (health / maxHealth) * 100);
-    this.healthBar.style.width = `${pct}%`;
-
-    if (pct > 50) {
-      this.healthBar.style.backgroundColor = '#4caf50';
-    } else if (pct > 25) {
-      this.healthBar.style.backgroundColor = '#ff9800';
-    } else {
-      this.healthBar.style.backgroundColor = '#f44336';
-    }
+    this._updateHealthBar(pct);
 
     // Update stats panel if elements are present and data was provided
     if (stats) {
@@ -100,6 +102,72 @@ export class HUD {
       this.slotMeleeEl.classList.toggle('weapon-slot-active', activeWeaponSlot === 'melee');
     }
   }
+
+  // -------------------------------------------------------------------------
+  // Visual polish helpers (t058)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Update the health bar fill width and color, including the ghost bar.
+   *
+   * Ghost bar (orange) lingers at the previous HP value for 500 ms then
+   * transitions back to the current value via CSS, giving visual feedback
+   * for damage received without obscuring the live HP state.
+   *
+   * @private
+   * @param {number} pct  Current HP as a percentage (0–100).
+   */
+  _updateHealthBar(pct) {
+    // Actual bar
+    this.healthBar.style.width = `${pct}%`;
+
+    if (pct > 50) {
+      this.healthBar.style.backgroundColor = '#4caf50';
+    } else if (pct > 25) {
+      this.healthBar.style.backgroundColor = '#ff9800';
+    } else {
+      this.healthBar.style.backgroundColor = '#f44336';
+    }
+
+    // Ghost bar: freeze at old value when HP drops, then decay after a delay.
+    if (pct < this._lastHealthPct && this.healthGhost) {
+      // Snap ghost to old value without CSS transition (remove transition temporarily).
+      this.healthGhost.style.transition = 'none';
+      this.healthGhost.style.width = `${this._lastHealthPct}%`;
+
+      clearTimeout(this._ghostTimer);
+      this._ghostTimer = setTimeout(() => {
+        if (!this.healthGhost) return;
+        // Re-enable transition before setting new width so the decay animates.
+        this.healthGhost.style.transition = 'width 0.75s ease-out';
+        this.healthGhost.style.width = `${pct}%`;
+      }, 450);
+    } else if (pct > this._lastHealthPct && this.healthGhost) {
+      // Healed up — snap ghost to match immediately (no ghost on heal).
+      clearTimeout(this._ghostTimer);
+      this.healthGhost.style.transition = 'none';
+      this.healthGhost.style.width = `${pct}%`;
+    }
+
+    this._lastHealthPct = pct;
+  }
+
+  /**
+   * Flash the screen red to signal that the player took damage.
+   *
+   * Safe to call multiple times in quick succession — each call resets the
+   * fade-out timer so rapid hits produce a consistent flash, not a blink.
+   */
+  flashDamage() {
+    if (!this.damageFlashEl) return;
+    this.damageFlashEl.style.opacity = '1';
+    clearTimeout(this._flashTimer);
+    this._flashTimer = setTimeout(() => {
+      if (this.damageFlashEl) this.damageFlashEl.style.opacity = '0';
+    }, 80);
+  }
+
+  // -------------------------------------------------------------------------
 
   showGameOver(score) {
     this.finalScoreEl.textContent = score;


### PR DESCRIPTION
## Summary

Implements t058 visual polish pass: four complementary improvements that make combat feel more physical and readable.

### Screen Shake (`CameraController.js`)
- New `shake(amplitude)` method with exponential decay (decay constant 9 ≈ 0.25 s half-life)
- Amplitude guide: 0.9 = enemy kill, 1.4 = player hit, 3.5 = player tank destroyed
- Clamped to max of concurrent calls — simultaneous events don't compound past a sensible ceiling
- Less vertical swing (0.5× horizontal) to avoid nausea on sustained fire

### Damage Flash (`HUD.js` + `index.html`)
- `#damage-flash` fixed overlay, `rgba(200,0,0,0.45)`, opacity-driven with 120 ms CSS fade-out
- `HUD.flashDamage()` sets opacity=1 and schedules 80 ms reset; repeated calls restart timer
- Triggers on: enemy non-lethal tank hit, non-lethal/lethal soldier hit

### Ghost Health Bar (`HUD.js` + `index.html`)
- Orange ghost div layered behind the actual HP bar inside `.health-bar-outer`
- On HP drop: ghost snaps (no transition) to previous value, then after 450 ms CSS-transitions back to current value (0.75 s ease-out)
- On heal: ghost snaps immediately to avoid misleading orange phantom
- Actual bar transitions 0.18 s (faster than before, more responsive feel)

### Better Particles (`ParticleSystem.js`)
- Pool expanded 300 → 500 to accommodate new effects without starvation
- `emitImpactSparks(pos)` — 14 white/amber metallic sparks with strong gravity (14 m/s²), lifetime 0.12–0.28 s; used for enemy-hit-player events instead of explosion burst
- `emitSmoke(pos, opts)` — slow-rising dark charcoal plume; particles *grow* as they rise (scale × 1.6 by death) and fade out; used post-kill and post-explosion
- Update loop: smoke particles detected by `startScale ≥ 0.8 && |gravity| ≤ 0.5` heuristic; separate opacity curve (0.45 × (1−t)) so they don't snap transparent early

## Files Changed

- `EDIT: src/systems/CameraController.js` — shake() + update() injection
- `EDIT: src/systems/ParticleSystem.js` — emitImpactSparks(), emitSmoke(), pool size, update heuristic
- `EDIT: src/ui/HUD.js` — flashDamage(), _updateHealthBar() with ghost logic
- `EDIT: src/core/Game.js` — onHit/onKill/onExplosion wired to shake+flash+smoke; soldier hit path updated
- `EDIT: index.html` — #damage-flash div, .health-bar-ghost div, CSS for both

## Verification

- Build: pre-existing `howler` Rollup error (SoundSystem missing npm dep) prevents production build; unrelated to this PR (same error on main). Dev server (`npm run dev`) loads correctly.
- Node `--check` syntax validation: all 4 modified JS files pass.
- Logic: shake decay, ghost timer teardown (clearTimeout on overlapping calls), flash idempotency all reviewed.

Resolves #74