### PR TITLE
GH#133: fix LeagueDisplay '0 / undefined LP' — use promotionLp from LeagueDefs

### DIFF
--- a/src/systems/LeagueSystem.js
+++ b/src/systems/LeagueSystem.js
@@ -98,8 +98,8 @@ export class LeagueSystem {
 
   /** LP required to promote to the next league (Infinity at champion). @type {number} */
   get lpToNextLeague() {
-    const promotionThreshold = this.def.lpToPromote;
-    if (!isFinite(promotionThreshold)) {
+    const promotionThreshold = this.def.promotionLp;
+    if (promotionThreshold === null) {
       return Infinity;
     }
     return Math.max(0, promotionThreshold - this._lp);
@@ -119,11 +119,11 @@ export class LeagueSystem {
    * @type {number}
    */
   get tierProgress() {
-    const { lpRequired, lpToPromote } = this.def;
-    if (!isFinite(lpToPromote)) {
+    const { lpRequired, promotionLp } = this.def;
+    if (promotionLp === null) {
       return 1.0;
     }
-    const range = lpToPromote - lpRequired;
+    const range = promotionLp - lpRequired;
     if (range <= 0) {
       return 1.0;
     }

--- a/src/ui/LeagueDisplay.js
+++ b/src/ui/LeagueDisplay.js
@@ -219,14 +219,14 @@ export class LeagueDisplay {
 
     // LP label
     this._lpLabelEl.textContent =
-      def.lpToPromote === Infinity
+      def.promotionLp === null
         ? `${lp} LP — MAX`
-        : `${lp} / ${def.lpToPromote} LP`;
+        : `${lp} / ${def.promotionLp} LP`;
 
     // Bar fill
-    const span = def.lpToPromote === Infinity
+    const span = def.promotionLp === null
       ? 1
-      : def.lpToPromote - def.lpRequired;
+      : def.promotionLp - def.lpRequired;
     const pct = span > 0
       ? Math.min(100, Math.max(0, ((lp - def.lpRequired) / span) * 100))
       : 100;


### PR DESCRIPTION
## Summary

`LeagueDefs.js` defines the promotion threshold field as `promotionLp`, but both `LeagueDisplay.js` and `LeagueSystem.js` were reading the non-existent `lpToPromote` property. This produced `undefined` in:

- The LP label text (`0 / undefined LP`)
- The LP bar fill calculation (span was `NaN`, bar stayed at 0%)
- `LeagueSystem.lpToNextLeague` (always returned `Infinity` because `isFinite(undefined)` is `false`)
- `LeagueSystem.tierProgress` (always returned `1.0` for the same reason)

## Changes

- **`src/ui/LeagueDisplay.js`** — `def.lpToPromote` → `def.promotionLp`; Champion check changed from `=== Infinity` to `=== null` to match the `null` sentinel in `LeagueDefs.js`.
- **`src/systems/LeagueSystem.js`** — same field rename in `lpToNextLeague` and `tierProgress` getters; `isFinite()` guards replaced with explicit `=== null` checks.

## Verification

- Bronze league shows `0 / 500 LP` on the main menu
- Earning LP updates the display correctly (e.g. `25 / 500 LP`)
- Each league shows the correct next-league threshold (Silver: 1200, Gold: 2200, etc.)
- Champion shows `5000 LP — MAX` with no target

Resolves #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed league progression display at champion tier to correctly show maximum LP status.

* **Refactor**
  * Optimized league tier progression calculations and promotion threshold tracking for improved accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->