### PR TITLE
fix: replace stale lpToPromote refs with promotionLp

### DIFF
--- a/src/systems/LeagueSystem.js
+++ b/src/systems/LeagueSystem.js
@@ -11,7 +11,7 @@
  *   Lose match (1-2 close)  : -10 LP
  *   Lose match (0-2 sweep)  : -20 LP
  *
- * Promotion:  LP reaches the current league's `lpToPromote` threshold.
+ * Promotion:  LP reaches the current league's `promotionLp` threshold.
  * Demotion:   LP falls below the current league's `lpRequired` threshold
  *             (can only demote one tier at a time due to the LP floor).
  *

--- a/src/ui/MainMenu.js
+++ b/src/ui/MainMenu.js
@@ -426,14 +426,14 @@ export class MainMenu {
 
     // LP label
     this._lpLabelEl.textContent =
-      def.lpToPromote === Infinity
+      def.promotionLp === null
         ? `${lp} LP — MAX`
-        : `${lp} / ${def.lpToPromote} LP`;
+        : `${lp} / ${def.promotionLp} LP`;
 
     // Bar fill
-    const span = def.lpToPromote === Infinity
+    const span = def.promotionLp === null
       ? 1
-      : def.lpToPromote - (def.lpRequired || 0);
+      : def.promotionLp - (def.lpRequired || 0);
     const pct = span > 0
       ? Math.min(100, Math.max(0, ((lp - (def.lpRequired || 0)) / span) * 100))
       : 100;

--- a/tests/LeagueDefs.test.js
+++ b/tests/LeagueDefs.test.js
@@ -43,8 +43,8 @@ test('lpRequired is strictly increasing', () => {
   }
 });
 
-test('champion lpToPromote is Infinity', () => {
-  assert.equal(LeagueDefs.champion.lpToPromote, Infinity);
+test('champion promotionLp is null', () => {
+  assert.equal(LeagueDefs.champion.promotionLp, null);
 });
 
 test('lpRequired matches VISION.md table', () => {


### PR DESCRIPTION
## Summary

Fixes three locations that still referenced the old `lpToPromote` property name after the rename to `promotionLp` in `LeagueDefs.js` (landed in PR #134).

### Changes

- **`src/systems/LeagueSystem.js:14`** — JSDoc comment updated from `` `lpToPromote` `` to `` `promotionLp` ``
- **`src/ui/MainMenu.js:429-436`** — Four `def.lpToPromote === Infinity` references replaced with `def.promotionLp === null` (matching the actual field and sentinel value)
- **`tests/LeagueDefs.test.js:46-47`** — Test updated to assert `promotionLp === null` for the Champion tier instead of `lpToPromote === Infinity`

### Verification

The `champion promotionLp is null` test now passes (was previously failing as `champion lpToPromote is Infinity`). Pre-existing unrelated test failures (upgradeTierCap, lpGains, teamComposition, lpFloorForLeague) are unchanged from main.

Resolves #145

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 6,873 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal promotion system logic references and corresponding UI calculations to use a simplified sentinel value approach. LP display and promotion threshold handling remain functionally equivalent from the user's perspective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->