### PR TITLE
fix: check pre+post-move position for river penalty in tanks

### DIFF
--- a/src/core/PlayerController.js
+++ b/src/core/PlayerController.js
@@ -310,10 +310,18 @@ export class PlayerController {
     const turnSpeed = tank.turnRate;
 
     // River / mud zone speed penalty (t050): tanks move at 40% speed in rivers.
-    // Check current position before movement so the penalty applies as soon as
-    // the tank enters the zone.
-    const inRiver   = this.mapLayout !== null &&
-                      this.mapLayout.isInRiver(tank.mesh.position.x, tank.mesh.position.z);
+    // Sample both the current position and the predicted post-move position so
+    // the penalty applies on the entry frame even when a fast tank crosses the
+    // boundary in a single step (bot finding: pre-move-only check, ~1 unit drift).
+    const curX  = tank.mesh.position.x;
+    const curZ  = tank.mesh.position.z;
+    const sinRY = Math.sin(tank.mesh.rotation.y);
+    const cosRY = Math.cos(tank.mesh.rotation.y);
+    const predX = curX - sinRY * tank.speed * dt;
+    const predZ = curZ - cosRY * tank.speed * dt;
+    const inRiver = this.mapLayout !== null &&
+        (this.mapLayout.isInRiver(curX, curZ) ||
+         this.mapLayout.isInRiver(predX, predZ));
     const moveSpeed = tank.speed * (inRiver ? RIVER_SPEED_TANK : 1.0);
 
     // Lockdown Mode (t043): suppress all hull movement while active.

--- a/src/systems/AIController.js
+++ b/src/systems/AIController.js
@@ -668,7 +668,12 @@ export class AIController {
     const turnSpeed = tank.turnRate;
 
     // River / mud zone speed penalty (t050): AI tanks move at 40% speed in rivers.
-    const moveSpeed = tank.speed * this._riverSpeedFactor(pos, RIVER_SPEED_TANK);
+    // Also sample the predicted post-move position so the penalty applies on the
+    // entry frame (mirrors PlayerController fix, bot finding: pre-move-only check).
+    const sinRY  = Math.sin(tank.mesh.rotation.y);
+    const cosRY  = Math.cos(tank.mesh.rotation.y);
+    const predPos = { x: pos.x - sinRY * tank.speed * dt, z: pos.z - cosRY * tank.speed * dt };
+    const moveSpeed = tank.speed * this._riverSpeedFactor(pos, RIVER_SPEED_TANK, predPos);
 
     // --- Per-class fire and aggro ranges ---
     // fireRange scales with the tank's effective range stat so Artillery AI
@@ -997,18 +1002,21 @@ export class AIController {
 
   /**
    * Return the speed multiplier for a world position.
-   * Returns `riverFactor` when the position is inside a river/mud zone,
-   * otherwise 1.0 (no penalty).  Safe to call when `_mapLayout` is null.
+   * Returns `riverFactor` when either `pos` or `predPos` (optional predicted
+   * post-move position) is inside a river/mud zone, otherwise 1.0 (no penalty).
+   * Safe to call when `_mapLayout` is null.
    *
-   * @param {{x: number, z: number}} pos — world XZ position (mesh.position works)
+   * @param {{x: number, z: number}} pos — current world XZ position
    * @param {number} riverFactor — penalty factor (RIVER_SPEED_TANK or RIVER_SPEED_SOLDIER)
+   * @param {{x: number, z: number}|null} [predPos] — optional predicted post-move position
    * @returns {number}
    * @private
    */
-  _riverSpeedFactor(pos, riverFactor) {
-    return (this._mapLayout !== null && this._mapLayout.isInRiver(pos.x, pos.z))
-      ? riverFactor
-      : 1.0;
+  _riverSpeedFactor(pos, riverFactor, predPos = null) {
+    if (this._mapLayout === null) return 1.0;
+    const inRiver = this._mapLayout.isInRiver(pos.x, pos.z) ||
+        (predPos !== null && this._mapLayout.isInRiver(predPos.x, predPos.z));
+    return inRiver ? riverFactor : 1.0;
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit finding from PR #124: the river/mud zone speed penalty (t050) was sampled only at the pre-move position. A fast tank crossing the 10-unit river band in a single frame would not feel the penalty on the entry frame.

## Changes

**`src/core/PlayerController.js`** — `_updateTankMode`:
- Compute predicted post-move world XZ position using `tank.speed * dt` and the tank's forward direction (`sin/cos(rotation.y)`).
- Apply `RIVER_SPEED_TANK` if either the current or predicted position is inside the river zone.

**`src/systems/AIController.js`** — tank call site + `_riverSpeedFactor`:
- Same dual-position check at the AI tank movement call site.
- Extended `_riverSpeedFactor(pos, riverFactor, predPos = null)` with an optional third parameter so existing soldier call sites are unaffected.

## Verification

- `translateZ(-d)` in Three.js moves along local -Z which is world `(-sin(ry), 0, -cos(ry))`.
- Predicted position: `(curX - sin(ry) * speed * dt, curZ - cos(ry) * speed * dt)`.
- If either current or predicted position is in the river, the penalty applies for that frame.

Resolves #146

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 11,575 tokens on this as a headless worker.